### PR TITLE
Add new stone format, Plugins, and Custom classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ simulation:
   time_step: 0.001
   max_time: 10.0
 
-components:
+nodes:
   - id: reactor1
     IdealGasReactor:
       temperature: 1000      # K

--- a/boulder/app.py
+++ b/boulder/app.py
@@ -3,7 +3,11 @@ import os
 import dash
 import dash_bootstrap_components as dbc
 
-from . import callbacks
+# Import cantera_converter early to ensure plugins are loaded at app startup
+from . import (
+    callbacks,
+    cantera_converter,  # noqa: F401
+)
 from .config import (
     get_config_from_path_with_comments,
     get_initial_config,
@@ -11,6 +15,11 @@ from .config import (
 )
 from .layout import get_layout
 from .styles import CYTOSCAPE_STYLESHEET
+
+# Create a single, shared converter instance for the app
+# This ensures that the same set of discovered plugins is used everywhere.
+CONVERTER = cantera_converter.CanteraConverter()
+
 
 # Initialize the Dash app with Bootstrap
 app = dash.Dash(

--- a/boulder/callbacks/graph_callbacks.py
+++ b/boulder/callbacks/graph_callbacks.py
@@ -77,11 +77,11 @@ def register_callbacks(app) -> None:  # type: ignore
             "type": trigger_data["type"],
             "properties": trigger_data["properties"],
         }
-        if any(comp["id"] == new_reactor["id"] for comp in config["components"]):
+        if any(node["id"] == new_reactor["id"] for node in config["nodes"]):
             return dash.no_update
 
-        new_components = [*config.get("components", []), new_reactor]
-        new_config = {**config, "components": new_components}
+        new_nodes = [*config.get("nodes", []), new_reactor]
+        new_config = {**config, "nodes": new_nodes}
         return new_config
 
     # STEP 1: Trigger MFC addition and close modal immediately

--- a/boulder/callbacks/modal_callbacks.py
+++ b/boulder/callbacks/modal_callbacks.py
@@ -50,9 +50,9 @@ def register_callbacks(app) -> None:  # type: ignore
             "Reservoir",
         ]
         options = [
-            {"label": comp["id"], "value": comp["id"]}
-            for comp in config.get("components", [])
-            if comp.get("type") in valid_types
+            {"label": node["id"], "value": node["id"]}
+            for node in config.get("nodes", [])
+            if node.get("type") in valid_types
         ]
         return options, options
 
@@ -225,7 +225,7 @@ def register_callbacks(app) -> None:  # type: ignore
         if not is_open:
             return dash.no_update
 
-        existing_ids = [comp.get("id", "") for comp in config.get("components", [])]
+        existing_ids = [node.get("id", "") for node in config.get("nodes", [])]
 
         i = 1
         while f"reactor_{i}" in existing_ids:
@@ -273,9 +273,9 @@ def register_callbacks(app) -> None:  # type: ignore
             return dash.no_update, dash.no_update, dash.no_update
 
         reactor_ids = [
-            comp.get("id")
-            for comp in config.get("components", [])
-            if comp.get("type")
+            node.get("id")
+            for node in config.get("nodes", [])
+            if node.get("type")
             in ["IdealGasReactor", "ConstVolReactor", "ConstPReactor", "Reservoir"]
         ]
 

--- a/boulder/callbacks/properties_callbacks.py
+++ b/boulder/callbacks/properties_callbacks.py
@@ -26,9 +26,9 @@ def register_callbacks(app) -> None:  # type: ignore
         if last_selected and last_selected.get("type") == "node":
             node_id = last_selected["data"]["id"]
             # Find the latest node data from config
-            for comp in config["components"]:
-                if comp["id"] == node_id:
-                    node_data = [comp]
+            for node in config["nodes"]:
+                if node["id"] == node_id:
+                    node_data = [node]
                     break
         elif last_selected and last_selected.get("type") == "edge":
             edge_id = last_selected["data"]["id"]
@@ -267,11 +267,11 @@ def register_callbacks(app) -> None:  # type: ignore
         if node_data:
             data = node_data[0]
             comp_id = data["id"]
-            new_components = []
-            for comp in config["components"]:
-                if comp["id"] == comp_id:
+            new_nodes = []
+            for node in config["nodes"]:
+                if node["id"] == comp_id:
                     # Ensure properties dict exists
-                    props = dict(comp.get("properties", {}))
+                    props = dict(node.get("properties", {}))
                     for v, i in zip(values, ids):
                         key = i["prop"]
                         # Convert to float if key is temperature or pressure
@@ -282,10 +282,10 @@ def register_callbacks(app) -> None:  # type: ignore
                                 props[key] = v
                         else:
                             props[key] = v
-                    new_components.append({**comp, "properties": props})
+                    new_nodes.append({**node, "properties": props})
                 else:
-                    new_components.append(comp)
-            return {**config, "components": new_components}
+                    new_nodes.append(node)
+            return {**config, "nodes": new_nodes}
         elif edge_data:
             data = edge_data[0]
             conn_id = data["id"]

--- a/boulder/callbacks/simulation_callbacks.py
+++ b/boulder/callbacks/simulation_callbacks.py
@@ -88,7 +88,8 @@ def register_callbacks(app) -> None:  # type: ignore
         custom_mechanism: str,
         uploaded_filename: str,
     ) -> Tuple[Any, Any, Any, str, Any, Dict[str, str], Dict[str, str], Dict[str, Any]]:
-        from ..cantera_converter import CanteraConverter, DualCanteraConverter
+        from ..app import CONVERTER
+        from ..cantera_converter import DualCanteraConverter
         from ..config import USE_DUAL_CONVERTER
         from ..utils import apply_theme_to_figure
 
@@ -128,8 +129,9 @@ def register_callbacks(app) -> None:  # type: ignore
                     config
                 )
             else:
-                single_converter = CanteraConverter(mechanism=mechanism)
-                network, results = single_converter.build_network(config)
+                # Use the shared converter instance, updating its mechanism
+                CONVERTER.mechanism = mechanism
+                network, results = CONVERTER.build_network(config)
                 code_str = ""
 
             # Build initial plots from the first available reactor (no strict need)

--- a/boulder/callbacks/simulation_callbacks.py
+++ b/boulder/callbacks/simulation_callbacks.py
@@ -88,8 +88,11 @@ def register_callbacks(app) -> None:  # type: ignore
         custom_mechanism: str,
         uploaded_filename: str,
     ) -> Tuple[Any, Any, Any, str, Any, Dict[str, str], Dict[str, str], Dict[str, Any]]:
-        from ..app import CONVERTER
-        from ..cantera_converter import DualCanteraConverter
+        from ..cantera_converter import (
+            CanteraConverter,
+            DualCanteraConverter,
+            get_plugins,
+        )
         from ..config import USE_DUAL_CONVERTER
         from ..utils import apply_theme_to_figure
 
@@ -124,14 +127,16 @@ def register_callbacks(app) -> None:  # type: ignore
 
         try:
             if USE_DUAL_CONVERTER:
-                dual_converter = DualCanteraConverter(mechanism=mechanism)
+                dual_converter = DualCanteraConverter(
+                    mechanism=mechanism, plugins=get_plugins()
+                )
                 network, results, code_str = dual_converter.build_network_and_code(
                     config
                 )
             else:
-                # Use the shared converter instance, updating its mechanism
-                CONVERTER.mechanism = mechanism
-                network, results = CONVERTER.build_network(config)
+                # Build using a fresh converter with discovered plugins
+                converter = CanteraConverter(mechanism=mechanism, plugins=get_plugins())
+                network, results = converter.build_network(config)
                 code_str = ""
 
             # Build initial plots from the first available reactor (no strict need)

--- a/boulder/cantera_converter.py
+++ b/boulder/cantera_converter.py
@@ -5,7 +5,7 @@ import math
 import os
 from dataclasses import dataclass, field
 from importlib.metadata import entry_points
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import cantera as ct  # type: ignore
 
@@ -16,9 +16,15 @@ logger = logging.getLogger(__name__)
 
 
 # Custom builder/hook types
-ReactorBuilder = Callable[["CanteraConverter", Dict[str, Any]], ct.Reactor]
-ConnectionBuilder = Callable[["CanteraConverter", Dict[str, Any]], ct.FlowDevice]
-PostBuildHook = Callable[["CanteraConverter", Dict[str, Any]], None]
+ReactorBuilder = Callable[
+    [Union["CanteraConverter", "DualCanteraConverter"], Dict[str, Any]], ct.Reactor
+]
+ConnectionBuilder = Callable[
+    [Union["CanteraConverter", "DualCanteraConverter"], Dict[str, Any]], ct.FlowDevice
+]
+PostBuildHook = Callable[
+    [Union["CanteraConverter", "DualCanteraConverter"], Dict[str, Any]], None
+]
 
 
 @dataclass

--- a/boulder/cantera_converter.py
+++ b/boulder/cantera_converter.py
@@ -182,10 +182,10 @@ class CanteraConverter:
         elif conn_type == "MassFlowController":
             # Default MassFlowController implementation
             mfc = ct.MassFlowController(source, target)
-            mfc.mass_flow_rate = props.get("mass_flow_rate", 0.1)
+            mfc.mass_flow_rate = float(props.get("mass_flow_rate", 0.1))
         elif conn_type == "Valve":
             valve = ct.Valve(source, target)
-            valve.valve_coeff = props.get("valve_coeff", 1.0)
+            valve.valve_coeff = float(props.get("valve_coeff", 1.0))
         elif conn_type == "Wall":
             # Handle walls as energy connections (e.g., torch power or losses)
             electric_power_kW = float(props.get("electric_power_kW", 0.0))
@@ -460,7 +460,7 @@ class DualCanteraConverter:
                     f"# Plugin connection {typ} -> created as '{cid}'"
                 )
             elif typ == "MassFlowController":
-                mfr = props.get("mass_flow_rate", 0.1)
+                mfr = float(props.get("mass_flow_rate", 0.1))
                 self.code_lines.append(f"{cid} = ct.MassFlowController({src}, {tgt})")
                 self.code_lines.append(f"{cid}.mass_flow_rate = {mfr}")
                 self.connections[cid] = ct.MassFlowController(
@@ -468,7 +468,7 @@ class DualCanteraConverter:
                 )
                 self.connections[cid].mass_flow_rate = mfr
             elif typ == "Valve":
-                coeff = props.get("valve_coeff", 1.0)
+                coeff = float(props.get("valve_coeff", 1.0))
                 self.code_lines.append(f"{cid} = ct.Valve({src}, {tgt})")
                 self.code_lines.append(f"{cid}.valve_coeff = {coeff}")
                 self.connections[cid] = ct.Valve(self.reactors[src], self.reactors[tgt])

--- a/boulder/cli.py
+++ b/boulder/cli.py
@@ -57,6 +57,9 @@ def main(argv: list[str] | None = None) -> None:
     if args.config:
         os.environ["BOULDER_CONFIG_PATH"] = args.config
 
+    # Import cantera_converter early to ensure plugins are loaded at app startup
+    from . import cantera_converter  # noqa: F401
+
     # Import after environment is set so app initialization can read it
     from .app import run_server
 

--- a/boulder/config.py
+++ b/boulder/config.py
@@ -79,7 +79,7 @@ def normalize_config(config: Dict[str, Any]) -> Dict[str, Any]:
     Example
     -------
 
-    🪨 STONE format::
+        🪨 STONE format::
 
         nodes:
           - id: reactor1
@@ -129,10 +129,6 @@ def normalize_config(config: Dict[str, Any]) -> Dict[str, Any]:
             if settings and isinstance(settings, dict):
                 sim.update(settings)
             normalized["simulation"] = sim
-
-    # Convert components to nodes (internal format uses nodes)
-    if "components" in normalized:
-        normalized["nodes"] = normalized.pop("components")
 
     # Normalize nodes
     if "nodes" in normalized:
@@ -280,7 +276,7 @@ def convert_to_stone_format(config: dict) -> dict:
         if settings:
             stone_config["settings"] = settings
 
-    # Convert nodes (already in STONE format)
+    # Convert nodes to STONE format
     if "nodes" in config:
         stone_config["nodes"] = []
         for node in config["nodes"]:

--- a/boulder/config.py
+++ b/boulder/config.py
@@ -64,35 +64,91 @@ def load_config_file_with_comments(config_path: str):
 def normalize_config(config: Dict[str, Any]) -> Dict[str, Any]:
     """Normalize configuration from YAML with 🪨 STONE standard to internal format.
 
-    The 🪨 STONE standard uses component types as keys:
-    - id: reactor1
-      IdealGasReactor:
-        temperature: 1000
+    The 🪨 STONE standard format:
+    - nodes: list of components (reactors, reservoirs, etc.)
+    - connections: list of connections between nodes
+    - phases: chemistry/phase configuration (e.g., gas mechanisms)
+    - settings: simulation-level settings
+    - metadata: optional configuration metadata
 
-    Converts to internal format:
-    - id: reactor1
-      type: IdealGasReactor
-      properties:
-        temperature: 1000
+    Converted to the internal format used by converters:
+    - nodes: list with { id, type, properties }
+    - connections: list with { id, type, properties, source, target }
+    - simulation: dict with mechanism selections and settings
+
+    Example
+    -------
+
+    🪨 STONE format::
+
+        nodes:
+          - id: reactor1
+            IdealGasReactor:
+                temperature: 1000
+
+    Internal format::
+
+        nodes:
+          - id: reactor1
+            type: IdealGasReactor
+            properties:
+                temperature: 1000
     """
     normalized = config.copy()
 
-    # Normalize components
+    # Require new STONE schema keys
+    if isinstance(normalized, dict):
+        if "nodes" not in normalized:
+            raise ValueError(
+                "STONE format required: top-level 'nodes' missing. "
+                "Please update your YAML configuration to use the new STONE schema with 'nodes', 'phases', and 'settings'."
+            )
+        # Merge phases/settings into simulation
+        phases = normalized.pop("phases", None)
+        settings = normalized.pop("settings", None)
+        if phases or settings:
+            sim = dict(normalized.get("simulation", {}) or {})
+            if phases and isinstance(phases, dict):
+                sim["phases"] = phases
+                # Flatten gas mechanisms for downstream consumers
+                gas = (
+                    phases.get("gas", {})
+                    if isinstance(phases.get("gas", {}), dict)
+                    else {}
+                )
+                mech = gas.get("mechanism")
+                mech_reac = gas.get("mechanism_reac")
+                mech_torch = gas.get("mechanism_torch")
+                if mech is not None:
+                    sim.setdefault("mechanism", mech)
+                if mech_reac is not None:
+                    sim.setdefault("mechanism_reac", mech_reac)
+                if mech_torch is not None:
+                    sim.setdefault("mechanism_torch", mech_torch)
+            if settings and isinstance(settings, dict):
+                sim.update(settings)
+            normalized["simulation"] = sim
+
+    # Convert components to nodes (internal format uses nodes)
     if "components" in normalized:
-        for component in normalized["components"]:
-            if "type" not in component:
+        normalized["nodes"] = normalized.pop("components")
+
+    # Normalize nodes
+    if "nodes" in normalized:
+        for node in normalized["nodes"]:
+            if "type" not in node:
                 # Find the type key (anything that's not id, metadata, etc.)
                 standard_fields = {"id", "metadata"}
-                type_keys = [k for k in component.keys() if k not in standard_fields]
+                type_keys = [k for k in node.keys() if k not in standard_fields]
 
                 if type_keys:
                     type_name = type_keys[0]  # Use the first type key found
-                    properties = component[type_name]
+                    properties = node[type_name]
 
                     # Remove the type key and add type + properties
-                    del component[type_name]
-                    component["type"] = type_name
-                    component["properties"] = (
+                    del node[type_name]
+                    node["type"] = type_name
+                    node["properties"] = (
                         properties if isinstance(properties, dict) else {}
                     )
 
@@ -200,32 +256,46 @@ def get_config_from_path_with_comments(config_path: str) -> tuple[Dict[str, Any]
 
 
 def convert_to_stone_format(config: dict) -> dict:
-    """Convert internal format back to YAML with 🪨 STONE standard for file saving."""
+    """Convert internal format back to new STONE schema for file saving."""
     stone_config = {}
 
-    # Copy metadata and simulation sections as-is
+    # Copy metadata section as-is
     if "metadata" in config:
         stone_config["metadata"] = config["metadata"]
-    if "simulation" in config:
-        stone_config["simulation"] = config["simulation"]
 
-    # Convert components
-    if "components" in config:
-        stone_config["components"] = []
-        for component in config["components"]:
-            # Build component with id first, then type
-            component_type = component.get("type", "IdealGasReactor")
-            stone_component = {
-                "id": component["id"],
-                component_type: component.get("properties", {}),
+    # Extract phases and settings from simulation section
+    simulation = config.get("simulation", {})
+    if simulation:
+        # Extract phases information
+        if "phases" in simulation:
+            stone_config["phases"] = simulation["phases"]
+
+        # Extract settings (everything except phases and mechanism info)
+        settings = {}
+        for key, value in simulation.items():
+            if key not in ["phases", "mechanism", "mechanism_reac", "mechanism_torch"]:
+                settings[key] = value
+
+        if settings:
+            stone_config["settings"] = settings
+
+    # Convert nodes (already in STONE format)
+    if "nodes" in config:
+        stone_config["nodes"] = []
+        for node in config["nodes"]:
+            # Build node with id first, then type as key containing properties
+            node_type = node.get("type", "IdealGasReactor")
+            stone_node = {
+                "id": node["id"],
+                node_type: node.get("properties", {}),
             }
-            stone_config["components"].append(stone_component)
+            stone_config["nodes"].append(stone_node)
 
-    # Convert connections
+    # Convert connections (same structure in new format)
     if "connections" in config:
         stone_config["connections"] = []
         for connection in config["connections"]:
-            # Build connection with id first, then type, then source/target
+            # Build connection with id first, then type as key, then source/target
             connection_type = connection.get("type", "MassFlowController")
             stone_connection = {
                 "id": connection["id"],
@@ -392,7 +462,7 @@ def _update_yaml_array_preserving_comments(original_array, new_array):
 def _update_yaml_item_preserving_comments(original_item, new_item):
     """Update a single YAML item while preserving its STONE format structure.
 
-    This function handles the specific case of components and connections
+    This function handles the specific case of nodes and connections
     which have a special structure in STONE format.
     """
     from ruamel.yaml.comments import CommentedMap

--- a/boulder/config.py
+++ b/boulder/config.py
@@ -101,7 +101,8 @@ def normalize_config(config: Dict[str, Any]) -> Dict[str, Any]:
         if "nodes" not in normalized:
             raise ValueError(
                 "STONE format required: top-level 'nodes' missing. "
-                "Please update your YAML configuration to use the new STONE schema with 'nodes', 'phases', and 'settings'."
+                "Please update your YAML configuration to use the new STONE schema with 'nodes', "
+                "'phases', and 'settings'."
             )
         # Merge phases/settings into simulation
         phases = normalized.pop("phases", None)

--- a/boulder/utils.py
+++ b/boulder/utils.py
@@ -18,8 +18,8 @@ def config_to_cyto_elements(config: Dict[str, Any]) -> List[Dict[str, Any]]:
     created_groups: set[str] = set()
 
     # Add nodes (reactors)
-    for component in config.get("components", []):
-        properties = component.get("properties", {})
+    for node in config.get("nodes", []):
+        properties = node.get("properties", {})
 
         # Determine group (if any) from properties
         group_name = (
@@ -45,9 +45,9 @@ def config_to_cyto_elements(config: Dict[str, Any]) -> List[Dict[str, Any]]:
                 )
 
         node_data: Dict[str, Any] = {
-            "id": component["id"],
-            "label": component["id"],
-            "type": component["type"],
+            "id": node["id"],
+            "label": node["id"],
+            "type": node["type"],
             "properties": properties,
         }
 

--- a/configs/README.md
+++ b/configs/README.md
@@ -13,7 +13,7 @@
 **Traditional YAML format:**
 
 ```yaml
-components:
+nodes:
   - id: reactor1
     type: IdealGasReactor
     properties:
@@ -24,7 +24,7 @@ components:
 **YAML with 🪨 STONE standard:**
 
 ```yaml
-components:
+nodes:
   - id: reactor1
     IdealGasReactor:
       temperature: 1000      # K
@@ -57,7 +57,7 @@ simulation:
   relative_tolerance: 1.0e-6
   absolute_tolerance: 1.0e-9
 
-components:
+nodes:
   - id: component_id
     ComponentType:
       property1: value1
@@ -78,7 +78,7 @@ connections:
 #### IdealGasReactor
 
 ```yaml
-components:
+nodes:
   - id: reactor1
     IdealGasReactor:
       temperature: 1000      # K
@@ -90,7 +90,7 @@ components:
 #### Reservoir
 
 ```yaml
-components:
+nodes:
   - id: inlet
     Reservoir:
       temperature: 300       # K
@@ -140,7 +140,7 @@ simulation:
   max_time: 10.0
   solver: "CVODE_BDF"
 
-components:
+nodes:
   - id: reactor1
     IdealGasReactor:
       temperature: 1000      # K
@@ -162,7 +162,7 @@ connections:
 
 ### 📁 sample_configs2.yaml
 
-Extended configuration with multiple components:
+Extended configuration with multiple nodes:
 
 ```yaml
 metadata:
@@ -170,7 +170,7 @@ metadata:
   description: "Multi-component reactor system with different flow controllers"
   version: "2.0"
 
-components:
+nodes:
   - id: reactor1
     IdealGasReactor:
       temperature: 1200      # K
@@ -213,7 +213,7 @@ metadata:
   description: "Complex multi-reactor network with interconnected streams"
   version: "3.0"
 
-components:
+nodes:
   - id: reactor1
     IdealGasReactor:
       temperature: 1100      # K
@@ -262,7 +262,7 @@ metadata:
 simulation:
   mechanism: "gri30.yaml"
 
-components:
+nodes:
   - id: res_in
     Reservoir:
       temperature: 300       # K

--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -3,15 +3,18 @@ metadata:
   description: "Simple configuration with one reactor and one reservoir"
   version: "1.0"
 
-simulation:
-  mechanism: "gri30.yaml"
+phases:
+  gas:
+    mechanism: "gri30.yaml"
+
+settings:
   time_step: 0.001  # s
   max_time: 10.0    # s
   solver: "CVODE_BDF"
   relative_tolerance: 1.0e-6
   absolute_tolerance: 1.0e-9
 
-components:
+nodes:
 - id: reactor1
   IdealGasReactor:
     temperature: 1000        # K

--- a/configs/grouped_nodes.yaml
+++ b/configs/grouped_nodes.yaml
@@ -3,10 +3,11 @@ metadata:
   description: "Two reactors solved together, displayed under a common group"
   version: "1.0"
 
-simulation:
-  mechanism: "gri30.yaml"
+phases:
+  gas:
+    mechanism: "gri30.yaml"
 
-components:
+nodes:
 - id: res_in
   Reservoir:
     temperature: 300         # K

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -19,20 +19,20 @@ class TestBoulderConfig:
         config = get_initial_config()
 
         assert isinstance(config, dict)
-        assert "components" in config
+        assert "nodes" in config
         assert "connections" in config
-        assert isinstance(config["components"], list)
+        assert isinstance(config["nodes"], list)
         assert isinstance(config["connections"], list)
 
     def test_get_initial_config_components(self):
         """Test initial config components have required fields."""
         config = get_initial_config()
 
-        for component in config["components"]:
-            assert "id" in component
-            assert "type" in component
-            assert "properties" in component
-            assert isinstance(component["properties"], dict)
+        for node in config["nodes"]:
+            assert "id" in node
+            assert "type" in node
+            assert "properties" in node
+            assert isinstance(node["properties"], dict)
 
 
 @pytest.mark.unit
@@ -41,14 +41,14 @@ class TestBoulderUtils:
 
     def test_config_to_cyto_elements_empty_config(self):
         """Test config conversion with empty config."""
-        config = {"components": [], "connections": []}
+        config = {"nodes": [], "connections": []}
         elements = config_to_cyto_elements(config)
         assert elements == []
 
     def test_config_to_cyto_elements_with_connection(self):
         """Test config conversion with reactor and connection."""
         config = {
-            "components": [
+            "nodes": [
                 {"id": "reactor1", "type": "IdealGasReactor", "properties": {}},
                 {"id": "reactor2", "type": "IdealGasReactor", "properties": {}},
             ],
@@ -109,23 +109,19 @@ class TestBoulderCallbacks:
     def test_duplicate_reactor_detection(self):
         """Test duplicate reactor ID detection logic."""
         config = {
-            "components": [
+            "nodes": [
                 {"id": "existing-reactor", "type": "IdealGasReactor", "properties": {}}
             ]
         }
 
         # Test adding reactor with existing ID
         new_reactor_id = "existing-reactor"
-        has_duplicate = any(
-            comp["id"] == new_reactor_id for comp in config["components"]
-        )
+        has_duplicate = any(node["id"] == new_reactor_id for node in config["nodes"])
         assert has_duplicate is True
 
         # Test adding reactor with new ID
         new_reactor_id = "new-reactor"
-        has_duplicate = any(
-            comp["id"] == new_reactor_id for comp in config["components"]
-        )
+        has_duplicate = any(node["id"] == new_reactor_id for node in config["nodes"])
         assert has_duplicate is False
 
     def test_mfc_validation_logic(self):
@@ -171,19 +167,19 @@ class TestBoulderCallbacks:
         """Test JSON configuration validation."""
         # Test valid JSON
         valid_json = (
-            '{"components": [{"id": "r1", "type": "IdealGasReactor", "properties": {}}], '
+            '{"nodes": [{"id": "r1", "type": "IdealGasReactor", "properties": {}}], '
             '"connections": []}'
         )
         try:
             parsed = json.loads(valid_json)
-            assert "components" in parsed
+            assert "nodes" in parsed
             assert "connections" in parsed
-            assert len(parsed["components"]) == 1
+            assert len(parsed["nodes"]) == 1
         except json.JSONDecodeError:
             pytest.fail("Valid JSON should parse successfully")
 
         # Test invalid JSON
-        invalid_json = '{"components": [}, "connections": []}'
+        invalid_json = '{"nodes": [}, "connections": []}'
         with pytest.raises(json.JSONDecodeError):
             json.loads(invalid_json)
 

--- a/tests/test_yaml_comment_system.py
+++ b/tests/test_yaml_comment_system.py
@@ -232,9 +232,9 @@ components:
         internal_config = normalize_config(loaded_data)
 
         # Verify internal format is correct
-        assert internal_config["components"][0]["type"] == "IdealGasReactor"
-        assert "properties" in internal_config["components"][0]
-        assert internal_config["components"][0]["properties"]["temperature"] == 1200.0
+        assert internal_config["nodes"][0]["type"] == "IdealGasReactor"
+        assert "properties" in internal_config["nodes"][0]
+        assert internal_config["nodes"][0]["properties"]["temperature"] == 1200.0
 
         # Convert back to STONE format
         stone_config = convert_to_stone_format(internal_config)
@@ -311,22 +311,13 @@ components:
 
         # Load the final result to verify it's valid
         final_data = load_yaml_string_with_comments(final_yaml)
-
-        # Check both possible formats for robustness
-        if "IdealGasReactor" in final_data["components"][0]:
-            # STONE format
-            assert (
-                final_data["components"][0]["IdealGasReactor"]["temperature"] == 1200.0
-            )
-        elif "type" in final_data["components"][0]:
-            # Internal format (current behavior)
-            assert final_data["components"][0]["type"] == "IdealGasReactor"
-            assert final_data["components"][0]["properties"]["temperature"] == 1200.0
-        else:
-            # Unexpected format
-            pytest.fail(
-                f"Unexpected component format: {list(final_data['components'][0].keys())}"
-            )
+        # Check that the final data matches the expected STONE format
+        assert "nodes" in final_data
+        assert len(final_data["nodes"]) > 0
+        assert "IdealGasReactor" in final_data["nodes"][0]
+        assert final_data["nodes"][0]["id"] == "test_reactor"
+        assert final_data["nodes"][0]["IdealGasReactor"]["temperature"] == 1200.0
+        assert final_data["nodes"][0]["IdealGasReactor"]["pressure"] == 101325.0
 
 
 class TestYAMLCommentIntegration:

--- a/tests/test_yaml_comment_system.py
+++ b/tests/test_yaml_comment_system.py
@@ -46,7 +46,7 @@ simulation:
   dt: 0.01       # seconds - integration time step
 
 # Reactor components with detailed comments and units
-components:
+nodes:
   - id: "reactor1"
     # Primary combustion chamber - high temperature operation
     IdealGasReactor:
@@ -126,8 +126,8 @@ connections:
 
         # Verify the data structure is loaded correctly
         assert result["metadata"]["name"] == "Test Configuration"
-        assert result["components"][0]["id"] == "reactor1"
-        assert result["components"][0]["IdealGasReactor"]["temperature"] == 1000.0
+        assert result["nodes"][0]["id"] == "reactor1"
+        assert result["nodes"][0]["IdealGasReactor"]["temperature"] == 1000.0
         assert result["connections"][0]["id"] == "mfc1"
         assert result["connections"][0]["MassFlowController"]["mass_flow_rate"] == 0.001
 
@@ -142,7 +142,7 @@ connections:
         # Verify it's a valid YAML string with substantial content
         assert isinstance(result, str)
         assert "metadata:" in result
-        assert "components:" in result
+        assert "nodes:" in result
         assert "connections:" in result
         assert len(result) > 100
 
@@ -178,17 +178,15 @@ connections:
         assert updated_data["metadata"]["name"] == "Updated Configuration"
         assert updated_data["metadata"]["version"] == "2.0"
         assert updated_data["simulation"]["end_time"] == 2.0
-        assert updated_data["components"][0]["IdealGasReactor"]["temperature"] == 1100.0
+        assert updated_data["nodes"][0]["IdealGasReactor"]["temperature"] == 1100.0
 
     def test_preserves_numeric_types(self, sample_yaml_with_comments):
         """Test that numeric types are preserved correctly."""
         data = load_yaml_string_with_comments(sample_yaml_with_comments)
 
         # Check that numbers are loaded as proper types
-        assert isinstance(
-            data["components"][0]["IdealGasReactor"]["temperature"], float
-        )
-        assert isinstance(data["components"][0]["IdealGasReactor"]["pressure"], float)
+        assert isinstance(data["nodes"][0]["IdealGasReactor"]["temperature"], float)
+        assert isinstance(data["nodes"][0]["IdealGasReactor"]["pressure"], float)
         assert isinstance(data["simulation"]["end_time"], float)
         assert isinstance(data["simulation"]["dt"], float)
 
@@ -198,8 +196,8 @@ connections:
 
         # Check that strings are loaded correctly
         assert isinstance(data["metadata"]["name"], str)
-        assert isinstance(data["components"][0]["id"], str)
-        assert isinstance(data["components"][0]["IdealGasReactor"]["composition"], str)
+        assert isinstance(data["nodes"][0]["id"], str)
+        assert isinstance(data["nodes"][0]["IdealGasReactor"]["composition"], str)
 
 
 class TestYAMLCommentRoundTrip:
@@ -216,7 +214,7 @@ metadata:
 simulation:
   end_time: 1.0  # seconds
 
-components:
+nodes:
   - id: "test_reactor"
     IdealGasReactor:
       temperature: 1200.0  # K
@@ -240,8 +238,8 @@ components:
         stone_config = convert_to_stone_format(internal_config)
 
         # Verify STONE format
-        assert "IdealGasReactor" in stone_config["components"][0]
-        assert stone_config["components"][0]["id"] == "test_reactor"
+        assert "IdealGasReactor" in stone_config["nodes"][0]
+        assert stone_config["nodes"][0]["id"] == "test_reactor"
 
         # Convert to YAML string
         yaml_string = yaml_to_string_with_comments(stone_config)
@@ -332,7 +330,7 @@ class TestYAMLCommentIntegration:
             assert len(original_yaml) > 0
 
             # Verify the original YAML contains expected sections
-            if "components:" in original_yaml:
+            if "nodes:" in original_yaml:
                 assert "metadata:" in original_yaml
 
         except FileNotFoundError:
@@ -346,7 +344,7 @@ class TestYAMLCommentIntegration:
         sample_yaml = """# Test upload
 metadata:
   name: "Upload Test"
-components:
+nodes:
   - id: "upload_reactor"
     IdealGasReactor:
       temperature: 900.0  # K
@@ -365,7 +363,7 @@ components:
 
         # Verify the data loaded correctly
         assert decoded["metadata"]["name"] == "Upload Test"
-        assert decoded["components"][0]["IdealGasReactor"]["temperature"] == 900.0
+        assert decoded["nodes"][0]["IdealGasReactor"]["temperature"] == 900.0
 
         # Verify we can convert back with comments preserved
         yaml_output = yaml_to_string_with_comments(decoded)
@@ -417,7 +415,7 @@ metadata:
         empty_sections_yaml = """# Config with empty sections
 metadata:
   name: "Empty Sections"
-components: []  # no components
+nodes: []  # no nodes
 connections: []  # no connections
 """
 
@@ -430,7 +428,7 @@ connections: []  # no connections
     def test_units_preservation_examples(self):
         """Test preservation of various unit formats in comments."""
         units_yaml = """# Configuration with various unit formats
-components:
+nodes:
   - id: "test"
     IdealGasReactor:
       temperature: 1000.0    # K (Kelvin)
@@ -446,7 +444,7 @@ components:
 
         # Verify numeric values are preserved correctly
         reloaded = load_yaml_string_with_comments(result)
-        reactor_props = reloaded["components"][0]["IdealGasReactor"]
+        reactor_props = reloaded["nodes"][0]["IdealGasReactor"]
 
         assert reactor_props["temperature"] == 1000.0
         assert reactor_props["pressure"] == 101325
@@ -476,7 +474,7 @@ simulation:
   dt: 0.01       # seconds - time step
 
 # Reactor components with detailed comments
-components:
+nodes:
   - id: "file_reactor"
     # Ideal gas reactor for file testing
     IdealGasReactor:
@@ -496,7 +494,7 @@ components:
 
         # Verify the data was loaded correctly
         assert loaded_data["metadata"]["name"] == "File Test Configuration"
-        assert loaded_data["components"][0]["IdealGasReactor"]["temperature"] == 1000.0
+        assert loaded_data["nodes"][0]["IdealGasReactor"]["temperature"] == 1000.0
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Introducing Boulder Plugins :

Allows other packages so define entry points in Boulder, extending the Cantera classes with custom classes that will be imported and solved in Boulder GUI.

- [x] BoulderPlugins container and get_plugins() to discover entry-point and env (BOULDER_PLUGINS) plugins once.
  No global registries; converters accept a plugins object.
- [x] Converter enhancements:
  - [x] Single converter: unchanged behavior, but coerces numeric props (MFC/Valve) to float.
  DualCanteraConverter:
    - Now uses plugin builders for custom reactors/connections.
    - Supports Wall connections; tracks walls; exposes reactor_meta.
    - Fail-fast on Cantera advance errors and non-finite states; raises RuntimeError for GUI surfacing.
- [x] GUI robustness:
  - Simulation callback always clears “Simulating…” overlay (sets simulation-running False) and shows red error banner.
  - Error path returns a payload so client callbacks unstick even after failures.
- [x] Housekeeping:
  Removed fragile “force-load” imports and global converter instance.
  Kept single/Dual parity for network assembly and results.

Still Todo:
- [ ] Write doc on how to set up your own pluggins 

## Reformatted Stone format   (variation of #7  ) 

- [x] Updated Boulder's internal configuration format to use "nodes" instead of "components" for better semantic consistency, while maintaining STONE format compatibility.
- [x] Uses ``settings`` and ``phases`` instead of ``simulation``

New 🪨 Stone format :: 

```yaml
metadata:
  name: "Basic Reactor Configuration"
  description: "Simple configuration with one reactor and one reservoir"
  version: "1.0"

phases:
  gas:
    mechanism: "gri30.yaml"

settings:
  time_step: 0.001  # s
  max_time: 10.0    # s
  solver: "CVODE_BDF"
  relative_tolerance: 1.0e-6
  absolute_tolerance: 1.0e-9

nodes:
- id: reactor1
  IdealGasReactor:
    temperature: 1000        # K
    pressure: 101325         # Pa
    composition: "CH4:1,O2:2,N2:7.52"

- id: res1
  Reservoir:
    temperature: 300         # K
    composition: "O2:1,N2:3.76"

connections:
- id: mfc1
  MassFlowController:
    mass_flow_rate: 0.1      # kg/s
  source: res1
  target: reactor1
```
