### PR TITLE
Fix re-loading a config file after delete

### DIFF
--- a/boulder/callbacks/config_callbacks.py
+++ b/boulder/callbacks/config_callbacks.py
@@ -68,20 +68,40 @@ def register_callbacks(app) -> None:  # type: ignore
             )
         else:
             return (
-                dcc.Upload(
-                    id="upload-config",
-                    children=html.Div(["Drop or ", html.A("Select Config File")]),
-                    style={
-                        "width": "100%",
-                        "height": "60px",
-                        "lineHeight": "60px",
-                        "borderWidth": "1px",
-                        "borderStyle": "dashed",
-                        "borderRadius": "5px",
-                        "textAlign": "center",
-                        "margin": "10px 0",
-                    },
-                    multiple=False,
+                html.Div(
+                    [
+                        dcc.Upload(
+                            id="upload-config",
+                            children=html.Div(
+                                ["Drop or ", html.A("Select Config File")]
+                            ),
+                            style={
+                                "width": "100%",
+                                "height": "60px",
+                                "lineHeight": "60px",
+                                "borderWidth": "1px",
+                                "borderStyle": "dashed",
+                                "borderRadius": "5px",
+                                "textAlign": "center",
+                                "margin": "10px 0",
+                            },
+                            multiple=False,
+                        ),
+                        # Always include delete button but hide it when no file is loaded
+                        html.Button(
+                            "✕",
+                            id="delete-config-file",
+                            n_clicks=0,
+                            style={
+                                "color": "red",
+                                "border": "none",
+                                "background": "none",
+                                "fontSize": 18,
+                                "cursor": "pointer",
+                                "display": "none",  # Hidden when no file is loaded
+                            },
+                        ),
+                    ]
                 ),
             )
 

--- a/boulder/layout.py
+++ b/boulder/layout.py
@@ -185,9 +185,6 @@ def get_layout(
             # Hidden dummy elements for callback IDs (always present)
             html.Div(
                 [
-                    html.Button(
-                        "✕", id="delete-config-file", style={"display": "none"}
-                    ),
                     html.Span(
                         "", id="config-file-name-span", style={"display": "none"}
                     ),


### PR DESCRIPTION
- [x] fix an issue that prevented to re-click on load a file again after it was deleted a first time