### PR TITLE
Read python files directly from CLI and GUI

### DIFF
--- a/boulder/app.py
+++ b/boulder/app.py
@@ -11,7 +11,6 @@ from . import (
     output_pane_plugins,  # noqa: F401
 )
 from .config import (
-    get_config_from_path_with_comments,
     get_initial_config_with_comments,
 )
 from .layout import get_layout
@@ -52,9 +51,23 @@ env_config_path = os.environ.get("BOULDER_CONFIG_PATH") or os.environ.get(
 
 if env_config_path and env_config_path.strip():
     cleaned = env_config_path.strip()
-    initial_config, original_yaml = get_config_from_path_with_comments(cleaned)
+    # Use Python-aware loading for environment config
+    from .config import (
+        load_config_file_with_py_support_and_comments,
+        normalize_config,
+        validate_config,
+    )
+
+    config, original_yaml, actual_yaml_path = (
+        load_config_file_with_py_support_and_comments(
+            cleaned, verbose=os.environ.get("BOULDER_VERBOSE") == "1"
+        )
+    )
+    normalized = normalize_config(config)
+    initial_config = validate_config(normalized)
+
     # When a specific file is provided, propagate its base name to the UI store
-    provided_filename = os.path.basename(cleaned)
+    provided_filename = os.path.basename(actual_yaml_path)
 else:
     initial_config, original_yaml = get_initial_config_with_comments()
 

--- a/boulder/assets/dark_mode.css
+++ b/boulder/assets/dark_mode.css
@@ -440,6 +440,18 @@ pre {
   letter-spacing: 0.3px;
 }
 
+[data-theme="light"] #simulation-overlay .overlay-timer {
+  position: absolute;
+  top: 60px;
+  right: 20px;
+  padding: 4px 8px;
+  background: rgba(25,135,84,0.15);
+  color: var(--text-primary);
+  border-radius: 4px;
+  font-size: 0.9em;
+  font-weight: 500;
+}
+
 /* Simulation overlay visuals - Dark mode */
 [data-theme="dark"] #simulation-overlay {
   backdrop-filter: blur(2px) brightness(0.95);
@@ -466,6 +478,19 @@ pre {
   border-radius: 6px;
   font-weight: 600;
   letter-spacing: 0.3px;
+  box-shadow: 0 2px 6px var(--shadow);
+}
+
+[data-theme="dark"] #simulation-overlay .overlay-timer {
+  position: absolute;
+  top: 60px;
+  right: 20px;
+  padding: 4px 8px;
+  background: rgba(25,135,84,0.20);
+  color: var(--text-primary);
+  border-radius: 4px;
+  font-size: 0.9em;
+  font-weight: 500;
   box-shadow: 0 2px 6px var(--shadow);
 }
 

--- a/boulder/callbacks/config_callbacks.py
+++ b/boulder/callbacks/config_callbacks.py
@@ -167,7 +167,9 @@ def register_callbacks(app) -> None:  # type: ignore
 
                         # Convert Python content to YAML
                         yaml_path = convert_py_to_yaml(
-                            decoded_string, output_path=temp_yaml_path, verbose=is_verbose_mode()
+                            decoded_string,
+                            output_path=temp_yaml_path,
+                            verbose=is_verbose_mode(),
                         )
 
                         # Read the converted YAML content
@@ -183,7 +185,8 @@ def register_callbacks(app) -> None:  # type: ignore
                             )
 
                     try:
-                        # Step 1 & 2: Common YAML processing pipeline (for both original YAML and converted Python)
+                        # Step 1 & 2: Common YAML processing pipeline 
+                        # (for both original YAML and converted Python)
                         # Use comment-preserving YAML loader with fallback
                         try:
                             decoded = load_yaml_string_with_comments(yaml_content)
@@ -215,8 +218,8 @@ def register_callbacks(app) -> None:  # type: ignore
                                 os.unlink(cleanup_file)
                 else:
                     print(
-                        "Only YAML format with 🪨 STONE standard (.yaml/.yml) and Python (.py) files are supported. Got:"
-                        f" {upload_filename}"
+                        "Only YAML format with 🪨 STONE standard (.yaml/.yml) and "
+                        f"Python (.py) files are supported. Got: {upload_filename}"
                     )
                     return dash.no_update, "", "", dash.no_update
             except Exception as e:

--- a/boulder/callbacks/config_callbacks.py
+++ b/boulder/callbacks/config_callbacks.py
@@ -185,7 +185,7 @@ def register_callbacks(app) -> None:  # type: ignore
                             )
 
                     try:
-                        # Step 1 & 2: Common YAML processing pipeline 
+                        # Step 1 & 2: Common YAML processing pipeline
                         # (for both original YAML and converted Python)
                         # Use comment-preserving YAML loader with fallback
                         try:

--- a/boulder/callbacks/notification_callbacks.py
+++ b/boulder/callbacks/notification_callbacks.py
@@ -61,8 +61,14 @@ def register_callbacks(app) -> None:  # type: ignore
                         f"File content preview (first 200 chars): {decoded_string[:200]}..."
                     )
 
-                # Validate as YAML (STONE standard) instead of JSON
-                parsed_yaml = yaml.safe_load(decoded_string)
+                # Handle both YAML and Python files
+                if upload_filename and upload_filename.lower().endswith(".py"):
+                    # For Python files, we'll validate that they can be processed
+                    # The actual conversion happens in config_callbacks
+                    parsed_yaml = {"type": "python_file", "filename": upload_filename}
+                else:
+                    # Validate as YAML (STONE standard) instead of JSON
+                    parsed_yaml = yaml.safe_load(decoded_string)
 
                 if is_verbose_mode():
                     keys_info = (

--- a/boulder/callbacks/simulation_callbacks.py
+++ b/boulder/callbacks/simulation_callbacks.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, List, Tuple, Union
 
 import dash
 import plotly.graph_objects as go  # type: ignore
-from dash import Input, NoUpdate, Output, State, dcc
+from dash import Input, Output, State, dcc, no_update
 
 from ..simulation_worker import get_simulation_worker
 from ..verbose_utils import get_verbose_logger, is_verbose_mode
@@ -213,6 +213,7 @@ def register_callbacks(app) -> None:  # type: ignore
             Output("error-tab-pane", "tab_style"),
             Output("simulation-progress-interval", "disabled"),
             Output("simulation-running", "data"),
+            Output("simulation-timer", "children"),
         ],
         [
             Input("simulation-progress-interval", "n_intervals"),
@@ -245,6 +246,7 @@ def register_callbacks(app) -> None:  # type: ignore
         Dict[str, str],
         bool,
         bool,
+        str,
     ]:
         """Update plots with streaming simulation data."""
         from ..utils import apply_theme_to_figure
@@ -262,6 +264,17 @@ def register_callbacks(app) -> None:  # type: ignore
         logger.info(
             f"  Data: {len(progress.times)} time points, {len(progress.reactors_series)} reactors"
         )
+
+        # Generate timer text
+        timer_text = ""
+        if progress.is_running:
+            elapsed = progress.get_elapsed_time()
+            if elapsed is not None:
+                timer_text = f"Time elapsed: {elapsed:.1f}s"
+        elif progress.is_complete:
+            calc_time = progress.get_calculation_time()
+            if calc_time is not None:
+                timer_text = f"Completed in {calc_time:.1f}s"
 
         # If simulation not running and not complete, show error if present and disable interval
         if not progress.is_running and not progress.is_complete:
@@ -320,6 +333,7 @@ def register_callbacks(app) -> None:  # type: ignore
                 error_tab_style,
                 True,  # Disable interval
                 False,  # Not running
+                timer_text,  # Timer text
             )
 
         # Build plots from current progress
@@ -351,6 +365,7 @@ def register_callbacks(app) -> None:  # type: ignore
                         {"display": "none"},
                         True,
                         False,
+                        timer_text,  # Timer text
                     )
                 selected_node_id = sel_data.get("id")
 
@@ -489,6 +504,7 @@ def register_callbacks(app) -> None:  # type: ignore
             error_tab_style,
             interval_disabled,
             simulation_running,
+            timer_text,  # Timer text
         )
 
     print("✅ [SIMULATION CALLBACKS] Streaming update callback registered successfully")
@@ -710,12 +726,12 @@ def register_callbacks(app) -> None:  # type: ignore
     ) -> Union[
         Tuple[Any, Any, Any, Dict[str, str], Dict[str, str], Dict[str, str]],
         Tuple[
-            NoUpdate,
-            NoUpdate,
-            NoUpdate,
-            NoUpdate,
-            NoUpdate,
-            NoUpdate,
+            no_update,
+            no_update,
+            no_update,
+            no_update,
+            no_update,
+            no_update,
         ],
     ]:
         import plotly.graph_objects as go
@@ -832,6 +848,7 @@ def register_callbacks(app) -> None:  # type: ignore
         import dash
 
         from ..output_summary import format_summary_text
+        from ..simulation_worker import get_simulation_worker
 
         if active_tab != "summary-tab":
             return dash.no_update
@@ -848,7 +865,12 @@ def register_callbacks(app) -> None:  # type: ignore
                 "output:\n  reactor_id: temperature\n  reactor_id: pressure, bar"
             )
 
-        return format_summary_text(summary)
+        # Get calculation time from simulation worker
+        worker = get_simulation_worker()
+        progress = worker.get_progress()
+        calculation_time = progress.get_calculation_time()
+
+        return format_summary_text(summary, calculation_time)
 
     # Update composition plot and thermo report when a reactor node is selected
     @app.callback(

--- a/boulder/callbacks/simulation_callbacks.py
+++ b/boulder/callbacks/simulation_callbacks.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, List, Tuple, Union
 
 import dash
 import plotly.graph_objects as go  # type: ignore
-from dash import Input, Output, State, dcc, no_update
+from dash import Input, Output, State, dcc
 
 from ..simulation_worker import get_simulation_worker
 from ..verbose_utils import get_verbose_logger, is_verbose_mode
@@ -725,14 +725,7 @@ def register_callbacks(app) -> None:  # type: ignore
         last_selected: Dict[str, Any], simulation_data: Dict[str, Any], theme: str
     ) -> Union[
         Tuple[Any, Any, Any, Dict[str, str], Dict[str, str], Dict[str, str]],
-        Tuple[
-            no_update,
-            no_update,
-            no_update,
-            no_update,
-            no_update,
-            no_update,
-        ],
+        Tuple[Any, Any, Any, Any, Any, Any],
     ]:
         import plotly.graph_objects as go
 

--- a/boulder/cli.py
+++ b/boulder/cli.py
@@ -240,7 +240,7 @@ def run_headless_mode(
 def main(argv: list[str] | None = None) -> None:
     args = parse_args(argv)
 
-    # Handle .py files with conversion-only mode (no GUI launch)
+    # Handle .py files: convert first, then continue to launch GUI
     if args.config and args.config.lower().endswith(".py") and not args.headless:
         from .config import (
             load_config_file_with_py_support,
@@ -262,7 +262,11 @@ def main(argv: list[str] | None = None) -> None:
 
         if args.verbose:
             print(f"Validated configuration successfully loaded from: {yaml_path}")
-        return
+
+        # Update args.config to point to the generated YAML file for GUI launch
+        args.config = yaml_path
+        print("🚀 Launching Boulder GUI with converted configuration...")
+        # Continue to GUI launch (don't return here)
 
     # Validate argument combinations for headless mode
     if args.download and not args.headless:

--- a/boulder/cli.py
+++ b/boulder/cli.py
@@ -45,7 +45,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "config",
         nargs="?",
         default=None,
-        help="Path to a YAML configuration file to preload",
+        help="Path to a configuration file to preload (.yaml, .yml, or .py)",
     )
     parser.add_argument(
         "--host",
@@ -160,8 +160,12 @@ def run_headless_mode(
     data to files or create custom plots.
     """
     try:
-        # Load and validate YAML config
-        from .config import load_config_file, normalize_config, validate_config
+        # Load and validate config (supports .py, .yaml, .yml)
+        from .config import (
+            load_config_file_with_py_support,
+            normalize_config,
+            validate_config,
+        )
 
         if verbose:
             print(f"Loading configuration from: {config_path}")
@@ -169,7 +173,9 @@ def run_headless_mode(
         if not os.path.isfile(config_path):
             raise FileNotFoundError(f"Configuration file not found: {config_path}")
 
-        config = load_config_file(config_path)
+        config, actual_yaml_path = load_config_file_with_py_support(
+            config_path, verbose
+        )
         normalized_config = normalize_config(config)
         validated_config = validate_config(normalized_config)
 

--- a/boulder/cli.py
+++ b/boulder/cli.py
@@ -240,6 +240,30 @@ def run_headless_mode(
 def main(argv: list[str] | None = None) -> None:
     args = parse_args(argv)
 
+    # Handle .py files with conversion-only mode (no GUI launch)
+    if args.config and args.config.lower().endswith(".py") and not args.headless:
+        from .config import (
+            load_config_file_with_py_support,
+            normalize_config,
+            validate_config,
+        )
+
+        # Use the unified pipeline to convert and load
+        config, yaml_path = load_config_file_with_py_support(args.config, args.verbose)
+        normalized = normalize_config(config)
+        validated = validate_config(normalized)
+
+        num_nodes = len(validated.get("nodes", []))
+        num_conns = len(validated.get("connections", []))
+
+        print("✅ Conversion complete!")
+        print(f"📄 YAML file: {yaml_path}")
+        print(f"🔧 Configuration: {num_nodes} nodes, {num_conns} connections")
+
+        if args.verbose:
+            print(f"Validated configuration successfully loaded from: {yaml_path}")
+        return
+
     # Validate argument combinations for headless mode
     if args.download and not args.headless:
         print("Error: --download requires --headless")

--- a/boulder/config.py
+++ b/boulder/config.py
@@ -5,7 +5,7 @@ where component types are keys containing their properties.
 """
 
 import os
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Tuple
 
 import yaml
 from ruamel.yaml import YAML
@@ -29,7 +29,11 @@ def get_yaml_with_comments():
     yaml_obj = YAML()
     yaml_obj.preserve_quotes = True
     yaml_obj.width = 4096  # Prevent line wrapping
-    yaml_obj.indent(mapping=2, sequence=4, offset=2)
+    # Configure indentation to match pretty-format-yaml expectations
+    # mapping=2: 2 spaces for dictionary keys
+    # sequence=2: 2 spaces for list items after the dash
+    # offset=0: no extra indentation for the dash itself
+    yaml_obj.indent(mapping=2, sequence=2, offset=0)
     return yaml_obj
 
 
@@ -488,3 +492,189 @@ def _update_yaml_item_preserving_comments(original_item, new_item):
                 updated_item[key] = new_value
 
     return updated_item
+
+
+def _convert_py_to_yaml(py_path: str, verbose: bool = False) -> str:
+    """Convert a Python file to YAML using sim2stone.
+
+    Args:
+        py_path: Path to the Python file
+        verbose: Enable verbose output
+
+    Returns
+    -------
+        Path to the generated YAML file
+
+    Raises
+    ------
+        RuntimeError: If conversion fails
+    """
+    from .sim2stone_cli import main as sim2stone_main
+
+    # Generate output path
+    base, _ = os.path.splitext(os.path.abspath(py_path))
+    yaml_path = base + ".yaml"
+
+    # Prepare arguments for sim2stone
+    args = [py_path, "-o", yaml_path]
+    if verbose:
+        args.append("--verbose")
+
+    # Run sim2stone conversion
+    exit_code = sim2stone_main(args)
+    if exit_code != 0:
+        raise RuntimeError(f"sim2stone conversion failed with exit code {exit_code}")
+
+    if not os.path.exists(yaml_path):
+        raise RuntimeError(f"Expected YAML file was not created: {yaml_path}")
+
+    return yaml_path
+
+
+def _generate_unique_yaml_path(original_yaml_path: str) -> str:
+    """Generate a unique YAML path when a conflict exists.
+
+    Args:
+        original_yaml_path: The original YAML path that would conflict
+
+    Returns
+    -------
+        A unique path with a suffix like _converted, _converted_2, etc.
+    """
+    base, ext = os.path.splitext(original_yaml_path)
+    counter = 1
+
+    # Try _converted first
+    new_path = f"{base}_converted{ext}"
+    while os.path.exists(new_path):
+        counter += 1
+        new_path = f"{base}_converted_{counter}{ext}"
+
+    return new_path
+
+
+def _yaml_files_are_different(yaml_path1: str, yaml_path2: str) -> bool:
+    """Compare two YAML files to see if they have different content.
+
+    Args:
+        yaml_path1: Path to first YAML file
+        yaml_path2: Path to second YAML file
+
+    Returns
+    -------
+        True if files are different, False if they are the same
+    """
+    with open(yaml_path1, "r", encoding="utf-8") as f1:
+        content1 = yaml.safe_load(f1)
+    with open(yaml_path2, "r", encoding="utf-8") as f2:
+        content2 = yaml.safe_load(f2)
+
+    return content1 != content2
+
+
+def load_config_file_with_py_support(
+    config_path: str, verbose: bool = False
+) -> Tuple[Dict[str, Any], str]:
+    """Load configuration file with automatic Python to YAML conversion support.
+
+    Logic:
+    1. If .py file: convert to .yaml first, then load the .yaml
+    2. If .yaml/.yml file: load directly
+    3. Always return loaded config from a YAML file
+
+    Args:
+        config_path: Path to configuration file (.yaml, .yml, or .py)
+        verbose: Enable verbose output
+
+    Returns
+    -------
+        Tuple of (config_dict, yaml_file_path)
+
+    Raises
+    ------
+        ValueError: If file type is not supported
+        FileNotFoundError: If file doesn't exist
+        RuntimeError: If conversion fails
+    """
+    if not os.path.exists(config_path):
+        raise FileNotFoundError(f"Configuration file not found: {config_path}")
+
+    _, ext = os.path.splitext(config_path.lower())
+
+    if ext == ".py":
+        # Step 1: Convert Python to YAML
+        if verbose:
+            print(f"[Boulder] Detected Python file: {config_path}")
+            print("[Boulder] Converting to YAML using sim2stone...")
+
+        yaml_path = _convert_py_to_yaml(config_path, verbose)
+
+        # Handle conflicts with existing YAML files
+        base, _ = os.path.splitext(os.path.abspath(config_path))
+        original_yaml_path = base + ".yaml"
+
+        if os.path.exists(original_yaml_path) and yaml_path == original_yaml_path:
+            # We would overwrite the existing file, check if they're different
+            temp_yaml = yaml_path + ".tmp"
+            os.rename(yaml_path, temp_yaml)
+
+            if _yaml_files_are_different(original_yaml_path, temp_yaml):
+                # Files are different, create unique name
+                unique_yaml_path = _generate_unique_yaml_path(original_yaml_path)
+                os.rename(temp_yaml, unique_yaml_path)
+                yaml_path = unique_yaml_path
+                if verbose:
+                    print("[Boulder] Existing YAML differs from converted version")
+                    print(f"[Boulder] Created new file: {yaml_path}")
+            else:
+                # Files are the same, just use the existing one
+                os.remove(temp_yaml)
+                yaml_path = original_yaml_path
+                if verbose:
+                    print(
+                        f"[Boulder] Converted YAML matches existing file: {yaml_path}"
+                    )
+
+        if verbose:
+            print(f"[Boulder] Conversion complete. Loading YAML: {yaml_path}")
+
+    elif ext in [".yaml", ".yml"]:
+        # Use the YAML file directly
+        yaml_path = config_path
+        if verbose:
+            print(f"[Boulder] Loading YAML file: {yaml_path}")
+    else:
+        raise ValueError(
+            f"Unsupported file format. Supported formats: .py, .yaml, .yml. Got: {ext}"
+        )
+
+    # Step 2: Always load from YAML file
+    config = load_config_file(yaml_path)
+    return config, yaml_path
+
+
+def load_config_file_with_py_support_and_comments(
+    config_path: str, verbose: bool = False
+) -> Tuple[Dict[str, Any], str, str]:
+    """Load configuration file with Python support, preserving comments.
+
+    Logic:
+    1. If .py file: convert to .yaml first
+    2. Always load from the resulting .yaml file with comments preserved
+
+    Args:
+        config_path: Path to configuration file (.yaml, .yml, or .py)
+        verbose: Enable verbose output
+
+    Returns
+    -------
+        Tuple of (config_dict, original_yaml_string, yaml_file_path)
+    """
+    # Step 1: Handle conversion if needed, get the YAML path
+    config, yaml_path = load_config_file_with_py_support(config_path, verbose)
+
+    # Step 2: Always read the YAML file with comments preserved
+    with open(yaml_path, "r", encoding="utf-8") as f:
+        original_yaml = f.read()
+
+    return config, original_yaml, yaml_path

--- a/boulder/layout.py
+++ b/boulder/layout.py
@@ -253,7 +253,12 @@ def get_layout(
                 id="simulation-overlay",
                 children=[
                     html.Div(className="flowing-background"),
-                    html.Div("Simulating...", className="overlay-text"),
+                    html.Div(
+                        children=[
+                            html.Div("Simulating...", className="overlay-text"),
+                            html.Div(id="simulation-timer", className="overlay-timer"),
+                        ]
+                    ),
                 ],
                 style={
                     "display": "none",

--- a/boulder/layout.py
+++ b/boulder/layout.py
@@ -152,7 +152,9 @@ def get_results_tabs(initial_config: Dict[str, Any]) -> List[dbc.Tab]:
         from .output_pane_plugins import get_output_pane_registry
 
         registry = get_output_pane_registry()
-        print(f"🏗️  [LAYOUT] Found {len(registry.plugins)} plugins in registry")
+        print(
+            f"🏗️  [LAYOUT] Found {len(registry.plugins)} output-pane plugins in registry"
+        )
 
         # Create tabs for ALL plugins, not just available ones
         # Ensure Summary tab (if present) is listed first among plugins
@@ -200,7 +202,7 @@ def get_results_tabs(initial_config: Dict[str, Any]) -> List[dbc.Tab]:
             tabs.append(plugin_tab)
             print(f"✅ [LAYOUT] Added tab for plugin: {plugin.plugin_id}")
 
-        print(f"🏗️  [LAYOUT] Created {len(registry.plugins)} plugin tabs")
+        print(f"🏗️  [LAYOUT] Created {len(registry.plugins)} output-pane plugin tabs")
 
     except ImportError as e:
         print(f"⚠️  [LAYOUT] Output pane plugins not available: {e}")

--- a/boulder/output_summary.py
+++ b/boulder/output_summary.py
@@ -190,12 +190,19 @@ def _evaluate_formula(expression: str, results: Dict[str, Any]) -> float:
     return float(eval(compile(tree, "<formula>", "eval"), namespace))
 
 
-def format_summary_text(evaluated_items: List[Dict[str, Any]]) -> str:
+def format_summary_text(
+    evaluated_items: List[Dict[str, Any]], calculation_time: Optional[float] = None
+) -> str:
     """Format evaluated items as readable text."""
     if not evaluated_items:
         return "No output summary configured."
 
     lines = ["SIMULATION SUMMARY", "=" * 50, ""]
+
+    # Add calculation time if available
+    if calculation_time is not None:
+        lines.append(f"Calculation time: {calculation_time:.2f} seconds")
+        lines.append("")
 
     for item in evaluated_items:
         reactor = item["reactor"]

--- a/boulder/parser/__init__.py
+++ b/boulder/parser/__init__.py
@@ -1,0 +1,13 @@
+"""Parser module for file format conversions in Boulder.
+
+This module handles conversion between different file formats:
+- Python (.py) to YAML (.yaml) conversion using sim2stone
+- YAML loading and validation
+- File conflict resolution
+"""
+
+from .py_to_yaml import convert_py_to_yaml
+
+__all__ = [
+    "convert_py_to_yaml",
+]

--- a/boulder/parser/py_to_yaml.py
+++ b/boulder/parser/py_to_yaml.py
@@ -2,101 +2,109 @@
 
 import os
 import tempfile
-from typing import Tuple
 
 
 def _run_sim2stone_conversion(py_path: str, verbose: bool = False) -> str:
     """Run sim2stone conversion on a Python file.
-    
+
     Args:
         py_path: Path to the Python file
         verbose: Enable verbose output
-        
-    Returns:
+
+    Returns
+    -------
         Path to the generated YAML file
-        
-    Raises:
+
+    Raises
+    ------
         RuntimeError: If conversion fails
     """
     from ..sim2stone_cli import main as sim2stone_main
-    
+
     # Generate output path
     base, _ = os.path.splitext(os.path.abspath(py_path))
     yaml_path = base + ".yaml"
-    
+
     # Prepare arguments for sim2stone
     args = [py_path, "-o", yaml_path]
     if verbose:
         args.append("--verbose")
-    
+
     # Run sim2stone conversion
     exit_code = sim2stone_main(args)
     if exit_code != 0:
         raise RuntimeError(f"sim2stone conversion failed with exit code {exit_code}")
-    
+
     # Check if the expected file exists
     if os.path.exists(yaml_path):
         return yaml_path
-    
+
     # If not, check for common variations (like .tmp files)
     temp_yaml_path = yaml_path + ".tmp"
     if os.path.exists(temp_yaml_path):
         return temp_yaml_path
-    
+
     # If neither exists, raise an error
-    raise RuntimeError(f"Expected YAML file was not created: {yaml_path} (also checked {temp_yaml_path})")
+    raise RuntimeError(
+        f"Expected YAML file was not created: {yaml_path} (also checked {temp_yaml_path})"
+    )
 
 
 def _generate_unique_yaml_path(original_yaml_path: str) -> str:
     """Generate a unique YAML path when a conflict exists.
-    
+
     Args:
         original_yaml_path: The original YAML path that would conflict
-        
-    Returns:
+
+    Returns
+    -------
         A unique path with a suffix like _converted, _converted_2, etc.
     """
     base, ext = os.path.splitext(original_yaml_path)
     counter = 1
-    
+
     # Try _converted first
     new_path = f"{base}_converted{ext}"
     while os.path.exists(new_path):
         counter += 1
         new_path = f"{base}_converted_{counter}{ext}"
-        
+
     return new_path
 
 
 def _yaml_files_are_different(yaml_path1: str, yaml_path2: str) -> bool:
     """Compare two YAML files to see if they have different content.
-    
+
     Args:
         yaml_path1: Path to first YAML file
         yaml_path2: Path to second YAML file
-        
-    Returns:
+
+    Returns
+    -------
         True if files are different, False if they are the same
     """
     import yaml
-    
+
     with open(yaml_path1, "r", encoding="utf-8") as f1:
         content1 = yaml.safe_load(f1)
     with open(yaml_path2, "r", encoding="utf-8") as f2:
         content2 = yaml.safe_load(f2)
-        
+
     return content1 != content2
 
 
-def _handle_yaml_conflicts(yaml_path: str, config_path: str, verbose: bool = False) -> str:
+def _handle_yaml_conflicts(
+    yaml_path: str, config_path: str, verbose: bool = False
+) -> str:
     """Handle conflicts with existing YAML files.
-    
+
     Args:
         yaml_path: Path to the newly generated YAML file
         config_path: Path to the original Python file
         verbose: Enable verbose output
-        
-    Returns:
+
+    Returns
+    -------
         Final path to use for the YAML file
     """
     base, _ = os.path.splitext(os.path.abspath(config_path))
@@ -105,7 +113,7 @@ def _handle_yaml_conflicts(yaml_path: str, config_path: str, verbose: bool = Fal
     # Handle .tmp files from sim2stone
     if yaml_path.endswith(".tmp"):
         proper_yaml_path = yaml_path[:-4]  # Remove .tmp extension
-        
+
         if os.path.exists(proper_yaml_path):
             # There's an existing YAML file, check if they're different
             if _yaml_files_are_different(proper_yaml_path, yaml_path):
@@ -113,11 +121,15 @@ def _handle_yaml_conflicts(yaml_path: str, config_path: str, verbose: bool = Fal
                 unique_yaml_path = _generate_unique_yaml_path(proper_yaml_path)
                 os.rename(yaml_path, unique_yaml_path)
                 yaml_path = unique_yaml_path
-                print(f"⚠️  WARNING: Existing YAML file has different content!")
+                print("⚠️  WARNING: Existing YAML file has different content!")
                 print(f"⚠️  Created new file: {yaml_path}")
                 print(f"⚠️  Original file unchanged: {proper_yaml_path}")
-                print(f"⚠️  The data currently loaded in Boulder is the one from the .py file.")
-                print(f"⚠️  Investigate the differences manually, and choose whether to load the")
+                print(
+                    "⚠️  The data currently loaded in Boulder is the one from the .py file."
+                )
+                print(
+                    "⚠️  Investigate the differences manually, and choose whether to load the"
+                )
                 print(f"⚠️  python file or the other YAML file {proper_yaml_path}")
             else:
                 # Files are the same, use existing file and suggest direct loading
@@ -134,43 +146,43 @@ def _handle_yaml_conflicts(yaml_path: str, config_path: str, verbose: bool = Fal
             yaml_path = proper_yaml_path
             if verbose:
                 print(f"[Boulder] Created YAML file: {yaml_path}")
-                
+
     elif os.path.exists(expected_yaml_path):
         # sim2stone created the file directly, but there's already an existing one
         if _yaml_files_are_different(expected_yaml_path, yaml_path):
             # Files are different, create unique name and warn user
             unique_yaml_path = _generate_unique_yaml_path(expected_yaml_path)
-            
+
             # Move the newly created file to unique name
             if yaml_path != unique_yaml_path:
                 # If yaml_path is the same as expected_yaml_path, we need to be careful
                 if yaml_path == expected_yaml_path:
                     # Create a temporary backup of the original
-                    temp_backup = expected_yaml_path + ".orig_backup"
+                    # temp_backup = expected_yaml_path + ".orig_backup"  # Unused variable
                     # Read original content first
-                    with open(expected_yaml_path, 'r', encoding='utf-8') as f:
+                    with open(expected_yaml_path, "r", encoding="utf-8") as f:
                         original_content = f.read()
                     # Read new content
-                    with open(yaml_path, 'r', encoding='utf-8') as f:
+                    with open(yaml_path, "r", encoding="utf-8") as f:
                         new_content = f.read()
                     # Write original back
-                    with open(expected_yaml_path, 'w', encoding='utf-8') as f:
+                    with open(expected_yaml_path, "w", encoding="utf-8") as f:
                         f.write(original_content)
                     # Write new content to unique path
-                    with open(unique_yaml_path, 'w', encoding='utf-8') as f:
+                    with open(unique_yaml_path, "w", encoding="utf-8") as f:
                         f.write(new_content)
                 else:
                     os.rename(yaml_path, unique_yaml_path)
-                    
+
             yaml_path = unique_yaml_path
-            print(f"⚠️  WARNING: Existing YAML file has different content!")
+            print("⚠️  WARNING: Existing YAML file has different content!")
             print(f"⚠️  Created new file: {yaml_path}")
             print(f"⚠️  Original file unchanged: {expected_yaml_path}")
         else:
             # Files are the same, use existing file and suggest direct loading
             yaml_path = expected_yaml_path
-            print(f"⚠️  WARNING: YAML file already exists with identical content!")
-            print(f"⚠️  To avoid unnecessary conversion, load YAML directly:")
+            print("⚠️  WARNING: YAML file already exists with identical content!")
+            print("⚠️  To avoid unnecessary conversion, load YAML directly:")
             print(f"⚠️  Command: boulder {os.path.basename(expected_yaml_path)}")
 
     return yaml_path
@@ -178,63 +190,73 @@ def _handle_yaml_conflicts(yaml_path: str, config_path: str, verbose: bool = Fal
 
 def convert_py_to_yaml(py_input, output_path: str = None, verbose: bool = False) -> str:
     """Convert Python file or content to YAML using sim2stone.
-    
+
     This function handles the complete conversion process including:
     - Printing conversion message
     - Running sim2stone conversion
     - Handling temporary files
     - Resolving conflicts with existing YAML files
-    
+
     Args:
         py_input: Either a file path (str) or Python code content (str)
         output_path: Path where to save the YAML file (optional for file input)
         verbose: Enable verbose output
-        
-    Returns:
+
+    Returns
+    -------
         Path to the final YAML file
-        
-    Raises:
+
+    Raises
+    ------
         RuntimeError: If conversion fails
         FileNotFoundError: If the Python file doesn't exist
     """
     # Always print the conversion message
-    print("🐍 Python file detected: will execute, convert to 🪨 STONE YAML format, then load into Boulder.")
+    print(
+        "🐍 Python file detected: will execute, convert to 🪨 STONE YAML format, then load into Boulder."
+    )
     print("----------------------------------------------------------")
-    
+    print("")
+
     # Determine if input is a file path or content
     is_file_path = os.path.exists(py_input) if isinstance(py_input, str) else False
     cleanup_temp_file = False
-    
+
     if is_file_path:
         # Input is a file path
         py_path = py_input
         config_path_for_conflicts = py_input
     else:
         # Input is Python content - save to temporary file
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.py', delete=False, encoding='utf-8') as temp_file:
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".py", delete=False, encoding="utf-8"
+        ) as temp_file:
             temp_file.write(py_input)
             py_path = temp_file.name
         cleanup_temp_file = True
         config_path_for_conflicts = py_path
-    
+
     try:
         # Run the conversion
         yaml_path = _run_sim2stone_conversion(py_path, verbose)
-        
+
         # Handle conflicts and temporary files
-        final_yaml_path = _handle_yaml_conflicts(yaml_path, config_path_for_conflicts, verbose)
-        
+        final_yaml_path = _handle_yaml_conflicts(
+            yaml_path, config_path_for_conflicts, verbose
+        )
+
         # If output_path is specified and different, move the file
         if output_path and final_yaml_path != output_path:
             import shutil
+
             shutil.move(final_yaml_path, output_path)
             final_yaml_path = output_path
-        
+
         if verbose:
             print(f"[Boulder] Conversion complete. Final YAML: {final_yaml_path}")
-        
+
         return final_yaml_path
-        
+
     finally:
         # Clean up temporary file if we created one
         if cleanup_temp_file and os.path.exists(py_path):

--- a/boulder/parser/py_to_yaml.py
+++ b/boulder/parser/py_to_yaml.py
@@ -1,0 +1,241 @@
+"""Python to YAML conversion utilities using sim2stone."""
+
+import os
+import tempfile
+from typing import Tuple
+
+
+def _run_sim2stone_conversion(py_path: str, verbose: bool = False) -> str:
+    """Run sim2stone conversion on a Python file.
+    
+    Args:
+        py_path: Path to the Python file
+        verbose: Enable verbose output
+        
+    Returns:
+        Path to the generated YAML file
+        
+    Raises:
+        RuntimeError: If conversion fails
+    """
+    from ..sim2stone_cli import main as sim2stone_main
+    
+    # Generate output path
+    base, _ = os.path.splitext(os.path.abspath(py_path))
+    yaml_path = base + ".yaml"
+    
+    # Prepare arguments for sim2stone
+    args = [py_path, "-o", yaml_path]
+    if verbose:
+        args.append("--verbose")
+    
+    # Run sim2stone conversion
+    exit_code = sim2stone_main(args)
+    if exit_code != 0:
+        raise RuntimeError(f"sim2stone conversion failed with exit code {exit_code}")
+    
+    # Check if the expected file exists
+    if os.path.exists(yaml_path):
+        return yaml_path
+    
+    # If not, check for common variations (like .tmp files)
+    temp_yaml_path = yaml_path + ".tmp"
+    if os.path.exists(temp_yaml_path):
+        return temp_yaml_path
+    
+    # If neither exists, raise an error
+    raise RuntimeError(f"Expected YAML file was not created: {yaml_path} (also checked {temp_yaml_path})")
+
+
+def _generate_unique_yaml_path(original_yaml_path: str) -> str:
+    """Generate a unique YAML path when a conflict exists.
+    
+    Args:
+        original_yaml_path: The original YAML path that would conflict
+        
+    Returns:
+        A unique path with a suffix like _converted, _converted_2, etc.
+    """
+    base, ext = os.path.splitext(original_yaml_path)
+    counter = 1
+    
+    # Try _converted first
+    new_path = f"{base}_converted{ext}"
+    while os.path.exists(new_path):
+        counter += 1
+        new_path = f"{base}_converted_{counter}{ext}"
+        
+    return new_path
+
+
+def _yaml_files_are_different(yaml_path1: str, yaml_path2: str) -> bool:
+    """Compare two YAML files to see if they have different content.
+    
+    Args:
+        yaml_path1: Path to first YAML file
+        yaml_path2: Path to second YAML file
+        
+    Returns:
+        True if files are different, False if they are the same
+    """
+    import yaml
+    
+    with open(yaml_path1, "r", encoding="utf-8") as f1:
+        content1 = yaml.safe_load(f1)
+    with open(yaml_path2, "r", encoding="utf-8") as f2:
+        content2 = yaml.safe_load(f2)
+        
+    return content1 != content2
+
+
+def _handle_yaml_conflicts(yaml_path: str, config_path: str, verbose: bool = False) -> str:
+    """Handle conflicts with existing YAML files.
+    
+    Args:
+        yaml_path: Path to the newly generated YAML file
+        config_path: Path to the original Python file
+        verbose: Enable verbose output
+        
+    Returns:
+        Final path to use for the YAML file
+    """
+    base, _ = os.path.splitext(os.path.abspath(config_path))
+    expected_yaml_path = base + ".yaml"
+
+    # Handle .tmp files from sim2stone
+    if yaml_path.endswith(".tmp"):
+        proper_yaml_path = yaml_path[:-4]  # Remove .tmp extension
+        
+        if os.path.exists(proper_yaml_path):
+            # There's an existing YAML file, check if they're different
+            if _yaml_files_are_different(proper_yaml_path, yaml_path):
+                # Files are different, create unique name and warn user
+                unique_yaml_path = _generate_unique_yaml_path(proper_yaml_path)
+                os.rename(yaml_path, unique_yaml_path)
+                yaml_path = unique_yaml_path
+                print(f"⚠️  WARNING: Existing YAML file has different content!")
+                print(f"⚠️  Created new file: {yaml_path}")
+                print(f"⚠️  Original file unchanged: {proper_yaml_path}")
+                print(f"⚠️  The data currently loaded in Boulder is the one from the .py file.")
+                print(f"⚠️  Investigate the differences manually, and choose whether to load the")
+                print(f"⚠️  python file or the other YAML file {proper_yaml_path}")
+            else:
+                # Files are the same, use existing file and suggest direct loading
+                os.remove(yaml_path)
+                yaml_path = proper_yaml_path
+                print("⚠️  WARNING: YAML file already exists with identical content!")
+                print("⚠️ You could have loaded the YAML file directly.")
+                print("⚠️  It will be faster, for the same results. Use:")
+                print("⚠️ Bash/Terminal:")
+                print(f"⚠️       boulder {os.path.basename(proper_yaml_path)}")
+        else:
+            # No existing file, just rename temp to proper name
+            os.rename(yaml_path, proper_yaml_path)
+            yaml_path = proper_yaml_path
+            if verbose:
+                print(f"[Boulder] Created YAML file: {yaml_path}")
+                
+    elif os.path.exists(expected_yaml_path):
+        # sim2stone created the file directly, but there's already an existing one
+        if _yaml_files_are_different(expected_yaml_path, yaml_path):
+            # Files are different, create unique name and warn user
+            unique_yaml_path = _generate_unique_yaml_path(expected_yaml_path)
+            
+            # Move the newly created file to unique name
+            if yaml_path != unique_yaml_path:
+                # If yaml_path is the same as expected_yaml_path, we need to be careful
+                if yaml_path == expected_yaml_path:
+                    # Create a temporary backup of the original
+                    temp_backup = expected_yaml_path + ".orig_backup"
+                    # Read original content first
+                    with open(expected_yaml_path, 'r', encoding='utf-8') as f:
+                        original_content = f.read()
+                    # Read new content
+                    with open(yaml_path, 'r', encoding='utf-8') as f:
+                        new_content = f.read()
+                    # Write original back
+                    with open(expected_yaml_path, 'w', encoding='utf-8') as f:
+                        f.write(original_content)
+                    # Write new content to unique path
+                    with open(unique_yaml_path, 'w', encoding='utf-8') as f:
+                        f.write(new_content)
+                else:
+                    os.rename(yaml_path, unique_yaml_path)
+                    
+            yaml_path = unique_yaml_path
+            print(f"⚠️  WARNING: Existing YAML file has different content!")
+            print(f"⚠️  Created new file: {yaml_path}")
+            print(f"⚠️  Original file unchanged: {expected_yaml_path}")
+        else:
+            # Files are the same, use existing file and suggest direct loading
+            yaml_path = expected_yaml_path
+            print(f"⚠️  WARNING: YAML file already exists with identical content!")
+            print(f"⚠️  To avoid unnecessary conversion, load YAML directly:")
+            print(f"⚠️  Command: boulder {os.path.basename(expected_yaml_path)}")
+
+    return yaml_path
+
+
+def convert_py_to_yaml(py_input, output_path: str = None, verbose: bool = False) -> str:
+    """Convert Python file or content to YAML using sim2stone.
+    
+    This function handles the complete conversion process including:
+    - Printing conversion message
+    - Running sim2stone conversion
+    - Handling temporary files
+    - Resolving conflicts with existing YAML files
+    
+    Args:
+        py_input: Either a file path (str) or Python code content (str)
+        output_path: Path where to save the YAML file (optional for file input)
+        verbose: Enable verbose output
+        
+    Returns:
+        Path to the final YAML file
+        
+    Raises:
+        RuntimeError: If conversion fails
+        FileNotFoundError: If the Python file doesn't exist
+    """
+    # Always print the conversion message
+    print("🐍 Python file detected: will execute, convert to 🪨 STONE YAML format, then load into Boulder.")
+    print("----------------------------------------------------------")
+    
+    # Determine if input is a file path or content
+    is_file_path = os.path.exists(py_input) if isinstance(py_input, str) else False
+    cleanup_temp_file = False
+    
+    if is_file_path:
+        # Input is a file path
+        py_path = py_input
+        config_path_for_conflicts = py_input
+    else:
+        # Input is Python content - save to temporary file
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.py', delete=False, encoding='utf-8') as temp_file:
+            temp_file.write(py_input)
+            py_path = temp_file.name
+        cleanup_temp_file = True
+        config_path_for_conflicts = py_path
+    
+    try:
+        # Run the conversion
+        yaml_path = _run_sim2stone_conversion(py_path, verbose)
+        
+        # Handle conflicts and temporary files
+        final_yaml_path = _handle_yaml_conflicts(yaml_path, config_path_for_conflicts, verbose)
+        
+        # If output_path is specified and different, move the file
+        if output_path and final_yaml_path != output_path:
+            import shutil
+            shutil.move(final_yaml_path, output_path)
+            final_yaml_path = output_path
+        
+        if verbose:
+            print(f"[Boulder] Conversion complete. Final YAML: {final_yaml_path}")
+        
+        return final_yaml_path
+        
+    finally:
+        # Clean up temporary file if we created one
+        if cleanup_temp_file and os.path.exists(py_path):
+            os.unlink(py_path)

--- a/boulder/parser/py_to_yaml.py
+++ b/boulder/parser/py_to_yaml.py
@@ -2,6 +2,7 @@
 
 import os
 import tempfile
+from typing import Optional
 
 
 def _run_sim2stone_conversion(py_path: str, verbose: bool = False) -> str:
@@ -188,7 +189,9 @@ def _handle_yaml_conflicts(
     return yaml_path
 
 
-def convert_py_to_yaml(py_input, output_path: str = None, verbose: bool = False) -> str:
+def convert_py_to_yaml(
+    py_input, output_path: Optional[str] = None, verbose: bool = False
+) -> str:
     """Convert Python file or content to YAML using sim2stone.
 
     This function handles the complete conversion process including:

--- a/boulder/sim2stone_cli.py
+++ b/boulder/sim2stone_cli.py
@@ -75,6 +75,7 @@ def _execute_and_find_network(
     """Execute a Python script and return the single ReactorNet it defines.
 
     Adds the script directory to sys.path to resolve relative imports.
+    Suppresses visualizations by temporarily hiding visualization dependencies.
     """
     import runpy
 
@@ -86,8 +87,19 @@ def _execute_and_find_network(
     if script_dir and script_dir not in sys.path:
         sys.path.insert(0, script_dir)
 
-    # Execute script in its own globals namespace
-    globals_dict = runpy.run_path(script_abspath, run_name="__main__")
+    # Set BOULDER_NO_GUI environment variable to suppress GUI output in user scripts
+    original_boulder_no_gui = os.environ.get("BOULDER_NO_GUI")
+    os.environ["BOULDER_NO_GUI"] = "true"
+
+    try:
+        # Execute script in its own globals namespace
+        globals_dict = runpy.run_path(script_abspath, run_name="__main__")
+    finally:
+        # Restore original BOULDER_NO_GUI environment variable
+        if original_boulder_no_gui is None:
+            os.environ.pop("BOULDER_NO_GUI", None)
+        else:
+            os.environ["BOULDER_NO_GUI"] = original_boulder_no_gui
 
     # If a specific variable name is provided, use it
     if var_name:

--- a/boulder/validation.py
+++ b/boulder/validation.py
@@ -260,7 +260,7 @@ class NormalizedConfigModel(BaseModel):
                                     "pressure units like 'atm', 'bar', 'Pa', 'psi'"
                                 ),
                                 "[mass]": "mass units like 'kg', 'g', 'lb'",
-                                "[length] ** 3": "volume units like 'm3', 'L', 'mL', 'ft3'",
+                                "[length] ** 3": "volume units like 'm**3', 'L', 'mL', 'ft**3'",
                                 "[mass] / [time]": "flow rate units like 'kg/s', 'g/min', 'lb/hr'",
                                 "[time]": "time units like 's', 'ms', 'min', 'hr'",
                                 "[mass] * [length] ** 2 / [time] ** 3": (


### PR DESCRIPTION
Following #28 , Python files can be converted in a suitable Yaml file, with STONE format, by ``sim2stone``.  

This PR implements it automatically when : 
1. Loading Python files from the command-line-interface (CLI) with
  ```bash
  boulder some_file.py
  ```
2. Loading Python files from the "Drop or Select Config File" in the graphical-user-interface (GUI)
  <img width="446" height="79" alt="image" src="https://github.com/user-attachments/assets/fd84607f-3bbe-4afc-89a6-0813518e1a46" />

---

Therefore:
- [x] ``.py`` can now be read directly by Boulder. 
- [x] A corresponding YAML file is generated on-the-fly. 
- [x] If another YAML file already existed, it is compared and a warning message is raised. If different, the on-the-fly YAML corresponding to the .py file is generated next to the existing YAML file ; the existing YAML file is not replaced. 

   