### PR TITLE
Add Reactor-net Network pane

### DIFF
--- a/boulder/app.py
+++ b/boulder/app.py
@@ -8,6 +8,7 @@ import dash_bootstrap_components as dbc
 from . import (
     callbacks,
     cantera_converter,  # noqa: F401
+    network_plugin,
     output_pane_plugins,  # noqa: F401
 )
 from .config import (
@@ -15,6 +16,9 @@ from .config import (
 )
 from .layout import get_layout
 from .styles import CYTOSCAPE_STYLESHEET
+
+# Register built-in plugins
+network_plugin.register_network_plugin()
 
 # Create a single, shared converter instance for the app
 # This ensures that the same set of discovered plugins is used everywhere.

--- a/boulder/cantera_converter.py
+++ b/boulder/cantera_converter.py
@@ -837,6 +837,15 @@ class DualCanteraConverter:
             results["sankey_links"] = None
             results["sankey_nodes"] = None
 
+            # Propagate Sankey errors to the UI error system
+            sankey_error_msg = f"Sankey diagram generation failed: {str(e)}"
+            if "error_message" in results:
+                results["error_message"] = (
+                    f"{results['error_message']}\n\n{sankey_error_msg}"
+                )
+            else:
+                results["error_message"] = sankey_error_msg
+
         # Evaluate custom output summary if configured
         try:
             cfg = self._last_config or {}

--- a/boulder/layout.py
+++ b/boulder/layout.py
@@ -158,28 +158,58 @@ def get_results_tabs(initial_config: Dict[str, Any]) -> List[dbc.Tab]:
             f"🏗️  [LAYOUT] Found {len(registry.plugins)} output-pane plugins in registry"
         )
 
-        # Create tabs for ALL plugins, not just available ones
-        # Ensure Summary tab (if present) is listed first among plugins
-        plugin_list = registry.plugins[:]
+        # Handle Network plugin separately - insert it after Sankey tab
+        network_plugin = None
+        other_plugins = []
+        
+        for plugin in registry.plugins:
+            if getattr(plugin, "plugin_id", "") == "network-visualization":
+                network_plugin = plugin
+            else:
+                other_plugins.append(plugin)
+        
+        # Insert Network plugin right after Sankey tab (index 1)
+        if network_plugin:
+            verbose_print(f"🏗️  [LAYOUT] Creating Network tab after Sankey")
+            tab_label = network_plugin.tab_label
+            network_tab = dbc.Tab(
+                label=tab_label,
+                tab_id=f"plugin-{network_plugin.plugin_id}-tab",
+                children=[
+                    html.Div(
+                        id=f"plugin-{network_plugin.plugin_id}-content",
+                        className="mt-3",
+                        children=[
+                            html.Div(
+                                [
+                                    html.H5(f"{network_plugin.tab_label}"),
+                                    html.P(
+                                        "Select an element in the network to use this plugin."
+                                    ),
+                                ]
+                            )
+                        ],
+                    )
+                ],
+            )
+            tabs.insert(2, network_tab)  # Insert after Sankey (index 1)
+            print(f"✅ [LAYOUT] Added Network tab after Sankey: {network_plugin.plugin_id}")
+
+        # Sort remaining plugins - Summary first, others after
         try:
-            plugin_list.sort(
+            other_plugins.sort(
                 key=lambda p: 0
                 if getattr(p, "plugin_id", "") == "summary-output-pane"
                 else 1
             )
         except Exception:
-            plugin_list = registry.plugins
+            pass
 
-        for plugin in plugin_list:
+        for plugin in other_plugins:
             verbose_print(f"🏗️  [LAYOUT] Creating tab for plugin: {plugin.plugin_id}")
 
             # For dbc.Tab, label must be a string, not a component
             tab_label = plugin.tab_label
-            if plugin.tab_icon:
-                # Use a simple string with icon class name for now
-                tab_label = (
-                    f"📊 {plugin.tab_label}"  # Using emoji instead of Bootstrap icon
-                )
 
             plugin_tab = dbc.Tab(
                 label=tab_label,

--- a/boulder/network_plugin.py
+++ b/boulder/network_plugin.py
@@ -1,0 +1,171 @@
+"""Network visualization plugin for Boulder.
+
+This plugin provides a Network output pane that displays the Cantera ReactorNet
+structure using the network.draw() method.
+"""
+
+import base64
+import io
+import tempfile
+from typing import Any, Dict, Optional, Union, List
+
+import dash_bootstrap_components as dbc
+from dash import html
+
+from .live_simulation import get_live_simulation
+from .output_pane_plugins import OutputPaneContext, OutputPanePlugin
+
+
+class NetworkPlugin(OutputPanePlugin):
+    """Plugin for displaying the Cantera ReactorNet structure."""
+
+    @property
+    def plugin_id(self) -> str:
+        """Unique identifier for this plugin."""
+        return "network-visualization"
+
+    @property
+    def tab_label(self) -> str:
+        """Label to display on the tab."""
+        return "Network"
+
+    @property
+    def tab_icon(self) -> Optional[str]:
+        """Optional icon for the tab."""
+        return "diagram-3"  # Bootstrap icon for network diagram
+
+    @property
+    def requires_selection(self) -> bool:
+        """Whether this plugin requires a reactor/element to be selected."""
+        return False  # Network view doesn't require selection
+
+    @property
+    def supported_element_types(self) -> List[str]:
+        """List of element types this plugin supports."""
+        return ["reactor", "connection"]  # Support all element types
+
+    def is_available(self, context: OutputPaneContext) -> bool:
+        """Check if this plugin should be available given the current context."""
+        # Available when simulation data exists and live simulation is available
+        live_sim = get_live_simulation()
+        return (
+            context.simulation_data is not None
+            and live_sim.is_available()
+            and live_sim.get_network() is not None
+        )
+
+    def create_content(self, context: OutputPaneContext) -> Union[html.Div, dbc.Card, List[Any]]:
+        """Create the content for the Network output pane."""
+        live_sim = get_live_simulation()
+        
+        if not live_sim.is_available():
+            return html.Div([
+                html.H5("Network Not Available"),
+                html.P("No simulation network is currently available. Run a simulation first."),
+            ])
+
+        network = live_sim.get_network()
+        if network is None:
+            return html.Div([
+                html.H5("Network Not Available"),
+                html.P("No network found in the current simulation."),
+            ])
+
+        try:
+            # Generate the network diagram using Cantera's draw() method
+            network_image, error_message = self._generate_network_diagram(network)
+            
+            if network_image is None:
+                return html.Div([
+                    html.H5("Network Diagram Generation Failed"),
+                    html.P(error_message or "Could not generate network diagram."),
+                    html.Details([
+                        html.Summary("Troubleshooting"),
+                        html.P("Common issues:"),
+                        html.Ul([
+                            html.Li("Missing graphviz: pip install graphviz"),
+                            html.Li("Species not found in mechanism (check Error pane for details)"),
+                            html.Li("Network drawing not supported for this reactor type"),
+                        ])
+                    ])
+                ])
+
+            return dbc.Card([
+                dbc.CardHeader([
+                    html.H5("Reactor Network Structure", className="mb-0"),
+                ]),
+                dbc.CardBody([
+                    html.Div([
+                        html.Img(
+                            src=f"data:image/png;base64,{network_image}",
+                            style={
+                                "max-width": "100%",
+                                "height": "auto",
+                                "display": "block",
+                                "margin": "0 auto"
+                            }
+                        )
+                    ], className="text-center"),
+                    html.Hr(),
+                    html.P([
+                        "This diagram shows the structure of the Cantera ReactorNet, including ",
+                        "reactors, reservoirs, and their connections (mass flow controllers, valves, etc.)."
+                    ], className="text-muted small"),
+                ])
+            ])
+
+        except Exception as e:
+            return html.Div([
+                html.H5("Error Generating Network Diagram"),
+                html.P(f"An unexpected error occurred: {str(e)}"),
+                html.Details([
+                    html.Summary("Error Details"),
+                    html.Pre(str(e), className="text-danger small")
+                ])
+            ])
+
+    def _generate_network_diagram(self, network) -> tuple[Optional[str], Optional[str]]:
+        """Generate network diagram and return as base64 encoded PNG.
+        
+        Returns:
+            tuple: (encoded_image, error_message) where encoded_image is base64 PNG or None,
+                   and error_message is the error description if generation failed.
+        """
+        try:
+            # Try to import graphviz to check if it's available
+            import graphviz
+            
+            # Generate the diagram using Cantera's draw() method
+            diagram = network.draw(
+                print_state=True,
+                species="X",  # Show mole fractions
+                graph_attr={'rankdir': 'LR', 'bgcolor': 'white'},
+                node_attr={'shape': 'box', 'style': 'filled', 'fillcolor': 'lightblue'},
+                edge_attr={'color': 'black'}
+            )
+            
+            # Render to PNG format in memory
+            png_data = diagram.pipe(format='png')
+            
+            # Convert to base64 for embedding in HTML
+            encoded_image = base64.b64encode(png_data).decode('utf-8')
+            return encoded_image, None
+            
+        except ImportError as e:
+            # graphviz not available
+            return None, f"Graphviz not available: {str(e)}. Install with: pip install graphviz"
+        except Exception as e:
+            # Other errors during diagram generation
+            return None, f"Network diagram generation failed: {str(e)}"
+
+
+def register_network_plugin() -> None:
+    """Register the Network plugin with Boulder's output pane system."""
+    from .output_pane_plugins import register_output_pane_plugin
+    
+    plugin = NetworkPlugin()
+    register_output_pane_plugin(plugin)
+
+
+
+

--- a/boulder/network_plugin.py
+++ b/boulder/network_plugin.py
@@ -5,9 +5,7 @@ structure using the network.draw() method.
 """
 
 import base64
-import io
-import tempfile
-from typing import Any, Dict, Optional, Union, List
+from typing import Any, List, Optional, Union
 
 import dash_bootstrap_components as dbc
 from dash import html
@@ -54,106 +52,138 @@ class NetworkPlugin(OutputPanePlugin):
             and live_sim.get_network() is not None
         )
 
-    def create_content(self, context: OutputPaneContext) -> Union[html.Div, dbc.Card, List[Any]]:
+    def create_content(
+        self, context: OutputPaneContext
+    ) -> Union[html.Div, dbc.Card, List[Any]]:
         """Create the content for the Network output pane."""
         live_sim = get_live_simulation()
-        
+
         if not live_sim.is_available():
-            return html.Div([
-                html.H5("Network Not Available"),
-                html.P("No simulation network is currently available. Run a simulation first."),
-            ])
+            return html.Div(
+                [
+                    html.H5("Network Not Available"),
+                    html.P(
+                        "No simulation network is currently available. Run a simulation first."
+                    ),
+                ]
+            )
 
         network = live_sim.get_network()
         if network is None:
-            return html.Div([
-                html.H5("Network Not Available"),
-                html.P("No network found in the current simulation."),
-            ])
+            return html.Div(
+                [
+                    html.H5("Network Not Available"),
+                    html.P("No network found in the current simulation."),
+                ]
+            )
 
         try:
             # Generate the network diagram using Cantera's draw() method
             network_image, error_message = self._generate_network_diagram(network)
-            
-            if network_image is None:
-                return html.Div([
-                    html.H5("Network Diagram Generation Failed"),
-                    html.P(error_message or "Could not generate network diagram."),
-                    html.Details([
-                        html.Summary("Troubleshooting"),
-                        html.P("Common issues:"),
-                        html.Ul([
-                            html.Li("Missing graphviz: pip install graphviz"),
-                            html.Li("Species not found in mechanism (check Error pane for details)"),
-                            html.Li("Network drawing not supported for this reactor type"),
-                        ])
-                    ])
-                ])
 
-            return dbc.Card([
-                dbc.CardHeader([
-                    html.H5("Reactor Network Structure", className="mb-0"),
-                ]),
-                dbc.CardBody([
-                    html.Div([
-                        html.Img(
-                            src=f"data:image/png;base64,{network_image}",
-                            style={
-                                "max-width": "100%",
-                                "height": "auto",
-                                "display": "block",
-                                "margin": "0 auto"
-                            }
-                        )
-                    ], className="text-center"),
-                    html.Hr(),
-                    html.P([
-                        "This diagram shows the structure of the Cantera ReactorNet, including ",
-                        "reactors, reservoirs, and their connections (mass flow controllers, valves, etc.)."
-                    ], className="text-muted small"),
-                ])
-            ])
+            if network_image is None:
+                return html.Div(
+                    [
+                        html.H5("Network Diagram Generation Failed"),
+                        html.P(error_message or "Could not generate network diagram."),
+                        html.Details(
+                            [
+                                html.Summary("Troubleshooting"),
+                                html.P("Common issues:"),
+                                html.Ul(
+                                    [
+                                        html.Li(
+                                            "Missing graphviz: pip install graphviz"
+                                        ),
+                                        html.Li(
+                                            "Species not found in mechanism (check Error pane for details)"
+                                        ),
+                                        html.Li(
+                                            "Network drawing not supported for this reactor type"
+                                        ),
+                                    ]
+                                ),
+                            ]
+                        ),
+                    ]
+                )
+
+            return dbc.Card(
+                [
+                    dbc.CardHeader(
+                        [
+                            html.H5("Reactor Network Structure", className="mb-0"),
+                        ]
+                    ),
+                    dbc.CardBody(
+                        [
+                            html.Div(
+                                [
+                                    html.Img(
+                                        src=f"data:image/png;base64,{network_image}",
+                                        style={
+                                            "max-width": "100%",
+                                            "height": "auto",
+                                            "display": "block",
+                                            "margin": "0 auto",
+                                        },
+                                    )
+                                ],
+                                className="text-center",
+                            ),
+                        ]
+                    ),
+                ]
+            )
 
         except Exception as e:
-            return html.Div([
-                html.H5("Error Generating Network Diagram"),
-                html.P(f"An unexpected error occurred: {str(e)}"),
-                html.Details([
-                    html.Summary("Error Details"),
-                    html.Pre(str(e), className="text-danger small")
-                ])
-            ])
+            return html.Div(
+                [
+                    html.H5("Error Generating Network Diagram"),
+                    html.P(f"An unexpected error occurred: {str(e)}"),
+                    html.Details(
+                        [
+                            html.Summary("Error Details"),
+                            html.Pre(str(e), className="text-danger small"),
+                        ]
+                    ),
+                ]
+            )
 
     def _generate_network_diagram(self, network) -> tuple[Optional[str], Optional[str]]:
         """Generate network diagram and return as base64 encoded PNG.
-        
-        Returns:
+
+        Returns
+        -------
             tuple: (encoded_image, error_message) where encoded_image is base64 PNG or None,
                    and error_message is the error description if generation failed.
         """
         try:
             # Try to import graphviz to check if it's available
-            import graphviz
-            
+            import graphviz  # noqa: F401
+
             # Generate the diagram using Cantera's draw() method
             diagram = network.draw(
                 print_state=True,
                 species="X",  # Show mole fractions
-                graph_attr={'rankdir': 'LR', 'bgcolor': 'white'},
-                node_attr={'shape': 'box', 'style': 'filled', 'fillcolor': 'lightblue'},
-                edge_attr={'color': 'black'}
+                graph_attr={"rankdir": "LR", "bgcolor": "white"},
+                node_attr={"shape": "box", "style": "filled", "fillcolor": "lightblue"},
+                edge_attr={"color": "black"},
             )
-            
+
             # Render to PNG format in memory
-            png_data = diagram.pipe(format='png')
-            
+            png_data = diagram.pipe(format="png")
+
             # Convert to base64 for embedding in HTML
-            encoded_image = base64.b64encode(png_data).decode('utf-8')
+            encoded_image = base64.b64encode(png_data).decode("utf-8")
             return encoded_image, None
-            
+
         except ImportError as e:
             # graphviz not available
-            return None, f"Graphviz not available: {str(e)}. Install with: pip install graphviz"
+            return (
+                None,
+                f"Graphviz not available: {str(e)}. Install with: pip install graphviz",
+            )
         except Exception as e:
             # Other errors during diagram generation
             return None, f"Network diagram generation failed: {str(e)}"
@@ -162,10 +192,6 @@ class NetworkPlugin(OutputPanePlugin):
 def register_network_plugin() -> None:
     """Register the Network plugin with Boulder's output pane system."""
     from .output_pane_plugins import register_output_pane_plugin
-    
+
     plugin = NetworkPlugin()
     register_output_pane_plugin(plugin)
-
-
-
-

--- a/environment.yml
+++ b/environment.yml
@@ -12,6 +12,7 @@ dependencies:
 - dash-html-components
 - dash-extensions
 - dash-bootstrap-components
+- graphviz  # for reactor networks
 - numpy
 - pandas
 - plotly

--- a/tests/test_network_plugin.py
+++ b/tests/test_network_plugin.py
@@ -1,0 +1,197 @@
+"""Tests for the Network plugin functionality."""
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+from boulder.network_plugin import NetworkPlugin
+from boulder.output_pane_plugins import OutputPaneContext
+from boulder.live_simulation import update_live_simulation, clear_live_simulation
+
+
+class TestNetworkPlugin:
+    """Test cases for the Network plugin."""
+
+    def setup_method(self):
+        """Set up test fixtures."""
+        self.plugin = NetworkPlugin()
+        clear_live_simulation()
+
+    def teardown_method(self):
+        """Clean up after tests."""
+        clear_live_simulation()
+
+    def test_plugin_properties(self):
+        """Test basic plugin properties."""
+        assert self.plugin.plugin_id == "network-visualization"
+        assert self.plugin.tab_label == "Network"
+        assert self.plugin.tab_icon == "diagram-3"
+        assert not self.plugin.requires_selection
+        assert "reactor" in self.plugin.supported_element_types
+        assert "connection" in self.plugin.supported_element_types
+
+    def test_is_available_no_simulation(self):
+        """Test plugin availability when no simulation data exists."""
+        context = OutputPaneContext(
+            simulation_data=None,
+            config={},
+            theme="light"
+        )
+        assert not self.plugin.is_available(context)
+
+    def test_is_available_no_live_simulation(self):
+        """Test plugin availability when simulation data exists but no live simulation."""
+        context = OutputPaneContext(
+            simulation_data={"results": {"time": [0, 1]}},
+            config={},
+            theme="light"
+        )
+        assert not self.plugin.is_available(context)
+
+    def test_is_available_with_live_simulation(self):
+        """Test plugin availability when live simulation is available."""
+        # Mock a network
+        mock_network = MagicMock()
+        mock_reactor = MagicMock()
+        mock_reactor.name = "test_reactor"
+        mock_network.reactors = [mock_reactor]
+
+        # Update live simulation
+        update_live_simulation(
+            network=mock_network,
+            reactors={"test_reactor": mock_reactor},
+            mechanism="gri30.yaml"
+        )
+
+        context = OutputPaneContext(
+            simulation_data={"results": {"time": [0, 1]}},
+            config={},
+            theme="light"
+        )
+        assert self.plugin.is_available(context)
+
+    def test_create_content_no_live_simulation(self):
+        """Test content creation when no live simulation is available."""
+        context = OutputPaneContext(
+            simulation_data={"results": {"time": [0, 1]}},
+            config={},
+            theme="light"
+        )
+        
+        content = self.plugin.create_content(context)
+        
+        # Should return a div with error message
+        assert hasattr(content, 'children')
+        # Check that it contains the expected error message
+        content_str = str(content)
+        assert "Network Not Available" in content_str
+
+    @patch('boulder.network_plugin.get_live_simulation')
+    def test_create_content_network_drawing_success(self, mock_get_live_sim):
+        """Test successful network diagram generation."""
+        # Mock live simulation
+        mock_live_sim = MagicMock()
+        mock_live_sim.is_available.return_value = True
+        
+        # Mock network
+        mock_network = MagicMock()
+        mock_live_sim.get_network.return_value = mock_network
+        
+        # Mock the _generate_network_diagram method to return success
+        with patch.object(self.plugin, '_generate_network_diagram') as mock_generate:
+            mock_generate.return_value = ("base64encodedimage", None)
+            
+            mock_get_live_sim.return_value = mock_live_sim
+            
+            context = OutputPaneContext(
+                simulation_data={"results": {"time": [0, 1]}},
+                config={},
+                theme="light"
+            )
+            
+            content = self.plugin.create_content(context)
+            
+            # Should return a Card with the network diagram
+            assert hasattr(content, 'children')
+            content_str = str(content)
+            assert "Reactor Network Structure" in content_str
+
+    @patch('boulder.network_plugin.get_live_simulation')
+    def test_create_content_network_drawing_failure(self, mock_get_live_sim):
+        """Test network diagram generation failure."""
+        # Mock live simulation
+        mock_live_sim = MagicMock()
+        mock_live_sim.is_available.return_value = True
+        
+        # Mock network
+        mock_network = MagicMock()
+        mock_live_sim.get_network.return_value = mock_network
+        
+        # Mock the _generate_network_diagram method to return failure
+        with patch.object(self.plugin, '_generate_network_diagram') as mock_generate:
+            mock_generate.return_value = (None, "Graphviz not available")
+            
+            mock_get_live_sim.return_value = mock_live_sim
+            
+            context = OutputPaneContext(
+                simulation_data={"results": {"time": [0, 1]}},
+                config={},
+                theme="light"
+            )
+            
+            content = self.plugin.create_content(context)
+            
+            # Should return a div with error message
+            content_str = str(content)
+            assert "Network Diagram Generation Failed" in content_str
+            assert "Graphviz not available" in content_str
+
+    def test_generate_network_diagram_no_graphviz(self):
+        """Test network diagram generation when graphviz is not available."""
+        mock_network = MagicMock()
+        
+        with patch('builtins.__import__', side_effect=ImportError("No module named 'graphviz'")):
+            encoded_image, error_message = self.plugin._generate_network_diagram(mock_network)
+            
+            assert encoded_image is None
+            assert "Graphviz not available" in error_message
+
+    def test_generate_network_diagram_success(self):
+        """Test successful network diagram generation."""
+        mock_network = MagicMock()
+        
+        # Mock the draw method to return a mock diagram
+        mock_diagram = MagicMock()
+        mock_diagram.pipe.return_value = b'fake_png_data'
+        mock_network.draw.return_value = mock_diagram
+        
+        # Mock the graphviz import inside the method
+        with patch('builtins.__import__') as mock_import:
+            # Make import succeed
+            mock_import.return_value = MagicMock()
+            
+            encoded_image, error_message = self.plugin._generate_network_diagram(mock_network)
+            
+            assert encoded_image is not None
+            assert error_message is None
+            # Check that the image is base64 encoded
+            import base64
+            try:
+                base64.b64decode(encoded_image)
+            except Exception:
+                pytest.fail("Returned image is not valid base64")
+
+    def test_generate_network_diagram_draw_failure(self):
+        """Test network diagram generation when draw() fails."""
+        mock_network = MagicMock()
+        mock_network.draw.side_effect = Exception("Network drawing failed")
+        
+        # Mock the graphviz import inside the method
+        with patch('builtins.__import__') as mock_import:
+            # Make import succeed
+            mock_import.return_value = MagicMock()
+            
+            encoded_image, error_message = self.plugin._generate_network_diagram(mock_network)
+            
+            assert encoded_image is None
+            assert "Network diagram generation failed" in error_message
+            assert "Network drawing failed" in error_message

--- a/tests/test_sankey_if_no_species.py
+++ b/tests/test_sankey_if_no_species.py
@@ -1,0 +1,27 @@
+"""Tests for the if_no_species parameter in Sankey generation."""
+
+import pytest
+
+from boulder.sankey import generate_sankey_input_from_sim
+
+
+class TestSankeyIfNoSpecies:
+    """Test cases for the if_no_species parameter in Sankey generation."""
+
+    def test_if_no_species_parameter_exists(self):
+        """Test that the if_no_species parameter exists and has correct default."""
+        # Test that we can call the function with the if_no_species parameter
+        # This is a basic test to ensure the parameter was added correctly
+        import inspect
+        
+        sig = inspect.signature(generate_sankey_input_from_sim)
+        assert 'if_no_species' in sig.parameters
+        assert sig.parameters['if_no_species'].default == "ignore"
+
+    def test_if_no_species_docstring(self):
+        """Test that the if_no_species parameter is documented."""
+        docstring = generate_sankey_input_from_sim.__doc__
+        assert "if_no_species" in docstring
+        assert "ignore" in docstring
+        assert "warn" in docstring
+        assert "error" in docstring


### PR DESCRIPTION
- [x] Shows the Reactor-net computed by ``sim.draw()`` in a "Network" pane  
  
  <img width="1827" height="987" alt="image" src="https://github.com/user-attachments/assets/eb867a96-1007-4666-84e7-36faf89b9c78" />


- [x] Also fix some issues related to Sankey diagrams (see #5, #32)  not working properly if H2 or CH4 were not in the species. 