### PR TITLE
Update default yaml examples

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -143,7 +143,7 @@ def register_plugins(plugins: BoulderPlugins) -> None:
     ...
 ```
 
-The registrar mutates the shared ``BoulderPlugins`` container by registering
+The registrar mutates the shared `BoulderPlugins` container by registering
 reactor builders, connection builders, post-build hooks, unfolders, and/or
 output-pane extensions.
 
@@ -164,9 +164,9 @@ Two mechanisms both **add** to the same `BoulderPlugins` container:
    BOULDER_PLUGINS=my_local_pkg.boulder_plugins
    ```
 
-**Import resolution:** module names from ``BOULDER_PLUGINS`` are imported via
-``importlib.import_module(...)`` and therefore resolve using normal Python
-``sys.path`` rules (active environment site-packages, editable installs,
+**Import resolution:** module names from `BOULDER_PLUGINS` are imported via
+`importlib.import_module(...)` and therefore resolve using normal Python
+`sys.path` rules (active environment site-packages, editable installs,
 working directory, etc.).
 
 ### Inspecting what loaded

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -134,7 +134,20 @@ Downstream packages can extend Boulder without forking core code:
 
 Implementation: `boulder/output_pane_plugins.py`.
 
-### Plugin discovery
+### Plugin definition and discovery
+
+A Boulder plugin is a Python module that exposes a registrar function:
+
+```python
+def register_plugins(plugins: BoulderPlugins) -> None:
+    ...
+```
+
+The registrar mutates the shared ``BoulderPlugins`` container by registering
+reactor builders, connection builders, post-build hooks, unfolders, and/or
+output-pane extensions.
+
+### Discovery paths
 
 Two mechanisms both **add** to the same `BoulderPlugins` container:
 
@@ -150,6 +163,11 @@ Two mechanisms both **add** to the same `BoulderPlugins` container:
    ```bash
    BOULDER_PLUGINS=my_local_pkg.boulder_plugins
    ```
+
+**Import resolution:** module names from ``BOULDER_PLUGINS`` are imported via
+``importlib.import_module(...)`` and therefore resolve using normal Python
+``sys.path`` rules (active environment site-packages, editable installs,
+working directory, etc.).
 
 ### Inspecting what loaded
 

--- a/STONE_SPECIFICATIONS.md
+++ b/STONE_SPECIFICATIONS.md
@@ -42,6 +42,7 @@ ______________________________________________________________________
 ### `metadata:`
 
 A mapping for documentation and provenance fields. Key fields: `title`, `description`,
+`gui_app_title` (optional short label for the web UI header; defaults to `Boulder`),
 `scenario_id`, `author`, `date`, `project`. See `boulder/validation.py:MetadataModel` for the
 full vocabulary.
 

--- a/boulder/cli.py
+++ b/boulder/cli.py
@@ -328,7 +328,7 @@ def _run_validate_subcommand(argv: list[str]) -> int:
 
     from .config import load_config_file, normalize_config, validate_config
     from .schema_registry import validate_against_plugin_schemas
-    from .validation import warn_flow_device_conventions
+    from .validation import warn_flow_device_conventions, warn_simulation_quality
 
     if not os.path.isfile(config_path):
         print(f"Error: configuration file not found: {config_path}")
@@ -344,6 +344,7 @@ def _run_validate_subcommand(argv: list[str]) -> int:
             print(f"  - {err}")
         return 1
     notes = warn_flow_device_conventions(normalized)
+    notes.extend(warn_simulation_quality(normalized))
     for line in notes:
         print(f"  Note: {line}")
     print(f"OK: {config_path} is a valid STONE configuration.")

--- a/boulder/config.py
+++ b/boulder/config.py
@@ -121,6 +121,7 @@ _ISOTHERMAL_KINDS: frozenset = frozenset(
 _CONST_PRESSURE_KINDS: frozenset = frozenset(
     {
         "IdealGasConstPressureReactor",
+        "IdealGasConstPressureMoleReactor",
         "ConstPressureReactor",
         "DesignPSR",
         "DesignTorchInstantaneousHeating",
@@ -1499,15 +1500,32 @@ def _internal_node_to_stone_v2_item(node: Dict[str, Any]) -> Dict[str, Any]:
     node_type = node.get("type", "IdealGasReactor")
     props = dict(node.get("properties", {}) or {})
     mech_from_props = props.pop("mechanism", None)
+
+    # For const-pressure reactor kinds, ``pressure`` is the network operating
+    # pressure and lives inside the ``initial:`` block (seeding state).
+    # ``propagate_terminal_pressure_defaults`` also writes it to the top-level
+    # properties dict, which causes a duplicate when the YAML is re-emitted.
+    # Strip the outer ``pressure`` when ``initial.pressure`` already carries it.
+    initial = props.get("initial")
+    if (
+        node_type in _CONST_PRESSURE_KINDS
+        and isinstance(initial, dict)
+        and "pressure" in initial
+        and "pressure" in props
+    ):
+        props.pop("pressure")
+
     stone_node: Dict[str, Any] = {"id": node["id"], node_type: props}
     top_mech = node.get("mechanism")
     if top_mech is not None:
         stone_node["mechanism"] = top_mech
     elif mech_from_props is not None:
         stone_node["mechanism"] = mech_from_props
-    for fld in ("metadata", "description", "label"):
+    for fld in ("description", "label"):
         if fld in node:
             stone_node[fld] = node[fld]
+    if node.get("metadata") is not None:
+        stone_node["metadata"] = node["metadata"]
     return stone_node
 
 
@@ -1522,9 +1540,9 @@ def _internal_connection_to_stone_v2_item(conn: Dict[str, Any]) -> Dict[str, Any
         props = conn.get("properties") or {}
         if isinstance(props, dict) and props.get("mass_flow_rate") is not None:
             item["mass_flow_rate"] = props["mass_flow_rate"]
-        if "mechanism_switch" in conn:
+        if conn.get("mechanism_switch") is not None:
             item["mechanism_switch"] = conn["mechanism_switch"]
-        if "metadata" in conn:
+        if conn.get("metadata") is not None:
             item["metadata"] = conn["metadata"]
         return item
 
@@ -1536,9 +1554,9 @@ def _internal_connection_to_stone_v2_item(conn: Dict[str, Any]) -> Dict[str, Any
         "source": conn["source"],
         "target": conn["target"],
     }
-    if "mechanism_switch" in conn:
+    if conn.get("mechanism_switch") is not None:
         stone_conn["mechanism_switch"] = conn["mechanism_switch"]
-    if "metadata" in conn:
+    if conn.get("metadata") is not None:
         stone_conn["metadata"] = conn["metadata"]
     return stone_conn
 

--- a/boulder/config.py
+++ b/boulder/config.py
@@ -884,6 +884,7 @@ def normalize_config(config: Dict[str, Any], plugins: Any = None) -> Dict[str, A
             type: IdealGasReactor
             properties:
                 temperature: 1000
+
     """
     from .utils import coerce_config_units  # noqa: PLC0415
 

--- a/boulder/validation.py
+++ b/boulder/validation.py
@@ -476,6 +476,31 @@ def warn_flow_device_conventions(config: Dict[str, Any]) -> List[str]:
     return messages
 
 
+def warn_simulation_quality(config: Dict[str, Any]) -> List[str]:
+    """Return non-fatal notes for configurations that are valid but uninformative.
+
+    These checks intentionally do not fail validation: they guide authors toward
+    practical defaults without blocking intentionally minimal/diagnostic cases.
+    """
+    messages: List[str] = []
+    output_block = config.get("output")
+
+    if output_block is None:
+        messages.append(
+            "No top-level 'output:' block configured. The simulation can run, but there may be "
+            "no structured results selected for reporting/export."
+        )
+        return messages
+
+    if output_block == {} or output_block == []:
+        messages.append(
+            "Top-level 'output:' block is empty. Configure at least one output target "
+            "(temperature, pressure, composition, custom summary, etc.)."
+        )
+
+    return messages
+
+
 def validate_normalized_config(config: Dict[str, Any]) -> NormalizedConfigModel:
     """Validate a normalized config dict using Pydantic models.
 

--- a/boulder/validation.py
+++ b/boulder/validation.py
@@ -115,6 +115,7 @@ METADATA_OPTIONAL_KEYS: frozenset = frozenset(
     {
         "scenario_id",
         "title",
+        "gui_app_title",
         "name",
         "scenario_name",
         "architecture",
@@ -177,6 +178,8 @@ class MetadataModel(BaseModel):
 
     scenario_id: Optional[str] = None
     title: Optional[str] = None
+    #: Short label for the web UI header (e.g. ``Bloc``); omitted defaults to "Boulder".
+    gui_app_title: Optional[str] = None
     name: Optional[str] = None
     scenario_name: Optional[str] = None
     architecture: Optional[str] = None

--- a/configs/cstr_methane_air.yaml
+++ b/configs/cstr_methane_air.yaml
@@ -1,4 +1,4 @@
-﻿metadata:
+metadata:
   title: Lean methane/air CSTR — residence-time sweep template
   description: >-
     Well-stirred reactor (CSTR) for lean methane/air combustion at
@@ -27,12 +27,12 @@ phases:
 
 network:
   # ── Inlet (lean CH4/air, phi = 0.5) ────────────────────────────────────
-  - id: feed
-    Reservoir:
-      temperature: 300 K
-      pressure: 101325 Pa
+- id: feed
+  Reservoir:
+    temperature: 300 K
+    pressure: 101325 Pa
       # phi = 0.5: CH4:0.5 : O2:1.0 : N2:3.76 (mole ratios)
-      composition: "CH4:0.5,O2:1.0,N2:3.76"
+    composition: "CH4:0.5,O2:1.0,N2:3.76"
 
   # ── CSTR combustor ──────────────────────────────────────────────────────
   # Residence time  tres = combustor.mass / mass_flow_rate
@@ -40,35 +40,35 @@ network:
   # At atmospheric pressure, rho_products ~ 0.24 kg/m3 (1475 K, 1 atm).
   # tres ~ 0.24 * 1e-3 / 1e-4 ~ 2.4 s  (very stable; reduce mdot or volume
   # to approach the blowout limit near tres = 1.5 ms).
-  - id: combustor
-    IdealGasConstPressureMoleReactor:
-      volume: 1.0e-3 m**3   # [m^3]  — tune this for different geometries
-      initial:
+- id: combustor
+  IdealGasConstPressureMoleReactor:
+    volume: 1.0e-3 m**3     # [m^3]  — tune this for different geometries
+    initial:
         # Seed at HP-equilibrium products to start on the reacting branch.
-        temperature: 1475 K
-        pressure: 101325 Pa
-        composition: "CO2:0.04476,H2O:0.08951,N2:0.86573"
+      temperature: 1475 K
+      pressure: 101325 Pa
+      composition: "CO2:0.04476,H2O:0.08951,N2:0.86573"
 
   # ── Exhaust sink ────────────────────────────────────────────────────────
-  - id: exhaust
-    OutletSink: {}
+- id: exhaust
+  OutletSink: {}
 
   # ── Flow devices ────────────────────────────────────────────────────────
   # Tune mass_flow_rate to change residence time.
-  - id: feed_to_combustor
-    MassFlowController:
-      mass_flow_rate: 1.0e-4 kg/s   # [kg/s] — key sweep parameter
-    source: feed
-    target: combustor
+- id: feed_to_combustor
+  MassFlowController:
+    mass_flow_rate: 1.0e-4 kg/s     # [kg/s] — key sweep parameter
+  source: feed
+  target: combustor
 
   # PressureController keeps the system isobaric; its mass flow mirrors the
   # upstream MFC so no extra accumulation occurs.
-  - id: combustor_to_exhaust
-    PressureController:
-      pressure_coeff: 0.0
-      master: feed_to_combustor
-    source: combustor
-    target: exhaust
+- id: combustor_to_exhaust
+  PressureController:
+    pressure_coeff: 0.0
+    master: feed_to_combustor
+  source: combustor
+  target: exhaust
 
 settings:
   end_time: 0.5   # [s] — long enough to reach steady state at tres ~ 10 ms
@@ -76,5 +76,5 @@ settings:
 
 output:
   combustor:
-    - "temperature, K"
-    - "pressure, Pa"
+  - "temperature, K"
+  - "pressure, Pa"

--- a/configs/cstr_methane_air.yaml
+++ b/configs/cstr_methane_air.yaml
@@ -1,0 +1,80 @@
+﻿metadata:
+  title: Lean methane/air CSTR — residence-time sweep template
+  description: >-
+    Well-stirred reactor (CSTR) for lean methane/air combustion at
+    equivalence ratio phi = 0.5.  The key tuning knobs are annotated
+    inline: change mass_flow_rate to sweep residence time, or
+    change the reactor volume to fix a different reference length scale.
+
+    Physical context
+    ----------------
+    At phi = 0.5 and T_inlet = 300 K, the adiabatic flame temperature is
+    approximately 1475 K (HP equilibrium on GRI-Mech 3.0).  The burning branch
+    is stable for residence times roughly above 1.5 ms; below that the reactor
+    extinguishes to the cold branch.  This file is pre-set to tres ~ 10 ms.
+
+    Inspired by: cantera.org/stable/examples/python/reactors/combustor.html
+  remarks:
+    phi: 0.5
+    fuel: CH4
+    oxidizer: "air (O2:N2 = 1:3.76)"
+    T_adiabatic_K: 1475
+    tres_ms: 10
+
+phases:
+  gas:
+    mechanism: gri30.yaml
+
+network:
+  # ── Inlet (lean CH4/air, phi = 0.5) ────────────────────────────────────
+  - id: feed
+    Reservoir:
+      temperature: 300 K
+      pressure: 101325 Pa
+      # phi = 0.5: CH4:0.5 : O2:1.0 : N2:3.76 (mole ratios)
+      composition: "CH4:0.5,O2:1.0,N2:3.76"
+
+  # ── CSTR combustor ──────────────────────────────────────────────────────
+  # Residence time  tres = combustor.mass / mass_flow_rate
+  #               ~ rho * volume / mdot
+  # At atmospheric pressure, rho_products ~ 0.24 kg/m3 (1475 K, 1 atm).
+  # tres ~ 0.24 * 1e-3 / 1e-4 ~ 2.4 s  (very stable; reduce mdot or volume
+  # to approach the blowout limit near tres = 1.5 ms).
+  - id: combustor
+    IdealGasConstPressureMoleReactor:
+      volume: 1.0e-3 m**3   # [m^3]  — tune this for different geometries
+      initial:
+        # Seed at HP-equilibrium products to start on the reacting branch.
+        temperature: 1475 K
+        pressure: 101325 Pa
+        composition: "CO2:0.04476,H2O:0.08951,N2:0.86573"
+
+  # ── Exhaust sink ────────────────────────────────────────────────────────
+  - id: exhaust
+    OutletSink: {}
+
+  # ── Flow devices ────────────────────────────────────────────────────────
+  # Tune mass_flow_rate to change residence time.
+  - id: feed_to_combustor
+    MassFlowController:
+      mass_flow_rate: 1.0e-4 kg/s   # [kg/s] — key sweep parameter
+    source: feed
+    target: combustor
+
+  # PressureController keeps the system isobaric; its mass flow mirrors the
+  # upstream MFC so no extra accumulation occurs.
+  - id: combustor_to_exhaust
+    PressureController:
+      pressure_coeff: 0.0
+      master: feed_to_combustor
+    source: combustor
+    target: exhaust
+
+settings:
+  end_time: 0.5   # [s] — long enough to reach steady state at tres ~ 10 ms
+  dt: 5.0e-3      # [s]
+
+output:
+  combustor:
+    - "temperature, K"
+    - "pressure, Pa"

--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -1,35 +1,58 @@
 metadata:
-  name: "Basic Reactor Configuration"
-  description: "Simple configuration with one reactor and one reservoir"
-  version: "1.0"
+  title: Lean methane/air combustor (CSTR)
+  description: >-
+    Steady-state well-stirred reactor (CSTR) burning lean methane/air at
+    equivalence ratio phi = 0.5, 300 K inlet, atmospheric pressure.
+    The reactor is initialised near its adiabatic flame temperature so the
+    solver converges on the reacting (burning) branch.
+    Inspired by the Cantera combustor residence-time example
+    (cantera.org/stable/examples/python/reactors/combustor.html).
+  remarks:
+    phi: 0.5
+    fuel: CH4
+    oxidizer: "air (O2:N2 = 1:3.76)"
+    initial_condition: HP-equilibrium seed (reacting branch)
 
 phases:
   gas:
-    mechanism: "gri30.yaml"
-
-settings:
-  dt: 0.001
-  end_time: 10.0
-  solver: "CVODE_BDF"
-  relative_tolerance: 1.0e-6
-  absolute_tolerance: 1.0e-9
+    mechanism: gri30.yaml
 
 network:
-- id: res1
+- id: feed
   Reservoir:
     temperature: 300 K
-    composition: "O2:1,N2:3.76"
+    pressure: 101325 Pa
+    composition: "CH4:0.5,O2:1.0,N2:3.76"
 
-- id: reactor1
-  IdealGasReactor:
-    volume: 0.01 m**3
+- id: combustor
+  IdealGasConstPressureMoleReactor:
+    volume: 1.0e-3 m**3
     initial:
-      temperature: 1000 K
+      temperature: 1475 K
       pressure: 101325 Pa
-      composition: "CH4:1,O2:2,N2:7.52"
+      composition: "CO2:0.04476,H2O:0.08951,N2:0.86573"
 
-- id: mfc1
+- id: exhaust
+  OutletSink: {}
+
+- id: feed_to_combustor
   MassFlowController:
-    mass_flow_rate: 0.1 kg/s
-  source: res1
-  target: reactor1
+    mass_flow_rate: 1.0e-4 kg/s
+  source: feed
+  target: combustor
+
+- id: combustor_to_exhaust
+  PressureController:
+    pressure_coeff: 0.0
+    master: feed_to_combustor
+  source: combustor
+  target: exhaust
+
+settings:
+  end_time: 0.5
+  dt: 5.0e-3
+
+output:
+  combustor:
+  - "temperature, K"
+  - "pressure, Pa"

--- a/configs/grouped_nodes.yaml
+++ b/configs/grouped_nodes.yaml
@@ -1,21 +1,22 @@
 metadata:
   name: "Grouped Reactors"
-  description: "Two reactors in the same stage"
+  description: "Two reactors in series in a single advance_to_steady_state stage."
   version: "1.0"
 
 phases:
   gas:
-    mechanism: "gri30.yaml"
+    mechanism: gri30.yaml
 
 stages:
   train_a:
-    mechanism: "gri30.yaml"
+    mechanism: gri30.yaml
     solve: advance_to_steady_state
 
 train_a:
 - id: res_in
   Reservoir:
     temperature: 300 K
+    pressure: 101325 Pa
     composition: "CH4:1,O2:2,N2:7.52"
 
 - id: r1
@@ -54,3 +55,9 @@ train_a:
     mass_flow_rate: 0.05 kg/s
   source: r2
   target: res_out
+
+output:
+  r1:
+  - "temperature, K"
+  r2:
+  - "temperature, K"

--- a/configs/mix_react_streams.yaml
+++ b/configs/mix_react_streams.yaml
@@ -10,11 +10,13 @@ network:
 - id: stream_a
   Reservoir:
     temperature: 300 K
+    pressure: 101325 Pa
     composition: N2:0.79,AR:0.21
 
 - id: stream_b
   Reservoir:
     temperature: 300 K
+    pressure: 101325 Pa
     composition: N2:1
 
 - id: mixer
@@ -26,7 +28,7 @@ network:
       composition: N2:1
 
 - id: outlet
-  OutletSink:
+  OutletSink: {}
 
 - id: a_to_mixer
   MassFlowController:
@@ -46,4 +48,11 @@ network:
   source: mixer
   target: outlet
 
-settings: {}
+settings:
+  end_time: 1.0
+  dt: 0.01
+
+output:
+  mixer:
+  - "temperature, K"
+  - "pressure, Pa"

--- a/configs/sample_configs2.yaml
+++ b/configs/sample_configs2.yaml
@@ -1,6 +1,8 @@
 metadata:
-  name: "Extended Reactor Configuration"
-  description: "Multi-component reactor system"
+  title: Two-stream reactor
+  description: >-
+    Two inlet streams (air and methane) feeding a single stirred reactor with
+    a Valve outlet. A simple two-MFC topology for testing network construction.
   version: "2.0"
 
 phases:
@@ -11,12 +13,13 @@ network:
 - id: res1
   Reservoir:
     temperature: 300 K
+    pressure: 101325 Pa
     composition: "O2:1,N2:3.76"
 
 - id: res2
   Reservoir:
     temperature: 350 K
-    pressure: 202650 Pa
+    pressure: 101325 Pa
     composition: "CH4:1"
 
 - id: reactor1
@@ -26,6 +29,9 @@ network:
       temperature: 1200 K
       pressure: 101325 Pa
       composition: "CH4:1,O2:2,N2:7.52"
+
+- id: exhaust
+  OutletSink: {}
 
 - id: mfc1
   MassFlowController:
@@ -38,3 +44,18 @@ network:
     mass_flow_rate: 0.02 kg/s
   source: res2
   target: reactor1
+
+- id: reactor1_to_exhaust
+  Valve:
+    valve_coeff: 1.0
+  source: reactor1
+  target: exhaust
+
+settings:
+  end_time: 1.0
+  dt: 0.01
+
+output:
+  reactor1:
+  - "temperature, K"
+  - "pressure, Pa"

--- a/configs/staged_psr_pfr.yaml
+++ b/configs/staged_psr_pfr.yaml
@@ -51,7 +51,7 @@ pfr_stage:
     initial:
       temperature: 2200 K
       pressure: 101325 Pa
-      composition: CO2:1,H2O:2,N2:7.52
+      composition: "CO2:1,H2O:2,N2:7.52"
   description: First cell of the PFR chain.
 
 - id: pfr_cell_2
@@ -60,7 +60,7 @@ pfr_stage:
     initial:
       temperature: 2200 K
       pressure: 101325 Pa
-      composition: CO2:1,H2O:2,N2:7.52
+      composition: "CO2:1,H2O:2,N2:7.52"
 
 - id: pfr_cell_3
   IdealGasConstPressureMoleReactor:
@@ -68,7 +68,7 @@ pfr_stage:
     initial:
       temperature: 2200 K
       pressure: 101325 Pa
-      composition: CO2:1,H2O:2,N2:7.52
+      composition: "CO2:1,H2O:2,N2:7.52"
 
 - id: pfr_cell_4
   IdealGasConstPressureMoleReactor:
@@ -76,7 +76,7 @@ pfr_stage:
     initial:
       temperature: 2200 K
       pressure: 101325 Pa
-      composition: CO2:1,H2O:2,N2:7.52
+      composition: "CO2:1,H2O:2,N2:7.52"
 
 - id: psr_to_pfr
   source: psr
@@ -102,4 +102,13 @@ pfr_stage:
   source: pfr_cell_3
   target: pfr_cell_4
 
-settings: {}
+settings:
+  end_time: 1.0e-3
+  dt: 1.0e-5
+
+output:
+  psr:
+  - "temperature, K"
+  - "pressure, Pa"
+  pfr_cell_4:
+  - "temperature, K"

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -37,6 +37,16 @@ Boulder's plugin system lets downstream packages add custom reactor kinds,
 post-build hooks, mechanism resolvers, and UI panes without modifying
 the core library.
 
+**What counts as a plugin**
+
+A plugin is a Python module that exposes a registrar function::
+
+    def register_plugins(plugins):
+        ...
+
+The registrar receives the shared ``BoulderPlugins`` container and registers
+one or more extension points on it.
+
 **Quick summary of extension points**
 
 - ``plugins.reactor_builders[kind] = fn`` — register a callable
@@ -61,10 +71,15 @@ Boulder discovers plugins automatically at startup via two mechanisms:
        [project.entry-points."boulder.plugins"]
        my_plugin = "my_package.boulder_plugins:register_plugins"
 
-2. *Environment variable* (``BOULDER_PLUGINS``) — comma-separated module names
+2. *Environment variable* (``BOULDER_PLUGINS``) — comma- or semicolon-separated
+   module names
    for local or unpackaged plugins::
 
        BOULDER_PLUGINS=my_local_pkg.boulder_plugins boulder
+
+   Module names are imported with ``importlib.import_module(...)``, so
+   resolution follows normal Python ``sys.path`` rules from your active
+   environment.
 
 Inspect which plugins loaded with::
 
@@ -75,4 +90,5 @@ Inspect which plugins loaded with::
 See :doc:`auto_examples/plugin_example` for a complete, runnable demonstration
 using a ``Monolith`` reactor that exercises all extension points above.
 
-Full architecture and plugin reference: ``ARCHITECTURE.md`` at the repository root (plugin system, staged networks, discovery).
+Full architecture and plugin reference: ``ARCHITECTURE.md`` at the repository
+root (plugin system, staged networks, definition, and discovery).

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect } from "react";
+import { useState, useCallback, useEffect, useMemo } from "react";
 import { useThemeStore } from "@/stores/themeStore";
 import { useConfigStore } from "@/stores/configStore";
 import { useSimulationStore } from "@/stores/simulationStore";
@@ -65,12 +65,25 @@ export function AppShell() {
 
   useKeyboardShortcuts(handleRunSimulation);
 
+  const headerTitle = useMemo(() => {
+    const raw = config.metadata?.gui_app_title;
+    if (typeof raw === "string") {
+      const t = raw.trim();
+      if (t) return t;
+    }
+    return "Boulder";
+  }, [config.metadata]);
+
+  useEffect(() => {
+    document.title = headerTitle;
+  }, [headerTitle]);
+
   return (
     <div className="min-h-screen bg-background text-foreground">
       {/* Header */}
       <header className="border-b border-border px-4 py-3 flex items-center justify-between">
         <div className="flex items-center gap-3">
-          <h1 className="text-xl font-bold">Boulder</h1>
+          <h1 className="text-xl font-bold">{headerTitle}</h1>
           <Button
             id="config-file-name-span"
             onClick={() => setShowYamlEditor(true)}

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -15,7 +15,7 @@ from typing import List
 import pytest
 
 from boulder.config import load_config_file, normalize_config
-from boulder.validation import validate_normalized_config
+from boulder.validation import validate_normalized_config, warn_simulation_quality
 
 
 @pytest.mark.unit
@@ -236,3 +236,41 @@ def test_dynamic_unit_system_flexibility() -> None:
     sim_dict = model.settings.__dict__
     assert abs(sim_dict["dt"] - 0.001) < 1e-6  # 1 ms = 0.001 s
     assert abs(sim_dict["end_time"] - 600.0) < 1e-6  # 10 min = 600 s
+
+
+@pytest.mark.unit
+def test_warn_simulation_quality_missing_output() -> None:
+    """Missing top-level output block should trigger a non-fatal quality note."""
+    data = {
+        "nodes": [{"id": "r1", "type": "IdealGasReactor", "properties": {}}],
+        "connections": [],
+    }
+    normalized = normalize_config(data)
+    notes = warn_simulation_quality(normalized)
+    assert any("No top-level 'output:' block configured" in note for note in notes)
+
+
+@pytest.mark.unit
+def test_warn_simulation_quality_empty_output() -> None:
+    """Empty top-level output block should trigger a non-fatal quality note."""
+    data = {
+        "nodes": [{"id": "r1", "type": "IdealGasReactor", "properties": {}}],
+        "connections": [],
+        "output": {},
+    }
+    normalized = normalize_config(data)
+    notes = warn_simulation_quality(normalized)
+    assert any("Top-level 'output:' block is empty" in note for note in notes)
+
+
+@pytest.mark.unit
+def test_warn_simulation_quality_with_output_configured() -> None:
+    """Configured output block should not trigger simulation-quality notes."""
+    data = {
+        "nodes": [{"id": "r1", "type": "IdealGasReactor", "properties": {}}],
+        "connections": [],
+        "output": {"r1": ["temperature"]},
+    }
+    normalized = normalize_config(data)
+    notes = warn_simulation_quality(normalized)
+    assert notes == []

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -4,14 +4,18 @@ Covers:
 1. ``from_yaml`` round-trip with a minimal YAML (no plugins, pure Boulder).
 2. ``build()`` returns self; ``runner.network`` and ``runner.code`` are set.
 3. ``solve()`` returns self with a non-None ``result``.
-4. ``boulder.cli.main`` accepts a ``runner_class`` kwarg and instantiates it.
-5. ``resolve_mechanism`` on the base class returns the name unchanged
+4. Shipped ``configs/default.yaml`` (GUI default when no CLI config) executes via ``solve()``.
+5. ``boulder.cli.main`` accepts a ``runner_class`` kwarg and instantiates it.
+6. ``resolve_mechanism`` on the base class returns the name unchanged
    (no resolver registered; Cantera handles built-ins).
 """
 
 from __future__ import annotations
 
 import textwrap
+from pathlib import Path
+
+import pytest
 
 # ---------------------------------------------------------------------------
 # Minimal YAML fixture (no external plugins; pure Boulder)
@@ -186,7 +190,37 @@ def test_boulder_runner_solve_returns_self(tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# Test 4: CLI main() accepts runner_class kwarg
+# Test 4: configs/default.yaml executes end-to-end
+# ---------------------------------------------------------------------------
+
+
+def test_default_yaml_executes():
+    """configs/default.yaml loads and BoulderRunner.solve() completes.
+
+    Asserts the repository default (same file as ``get_initial_config`` / GUI no-args
+    preload) runs without error and returns a ``SimulationResult`` with a staged network.
+    """
+    import cantera as ct  # type: ignore
+
+    from boulder.runner import BoulderRunner
+    from boulder.simulation_result import SimulationResult
+    from boulder.staged_network import StagedReactorNet
+
+    repo_root = Path(__file__).resolve().parent.parent
+    default_path = repo_root / "configs" / "default.yaml"
+    if not default_path.is_file():
+        pytest.skip(f"Missing default config: {default_path}")
+
+    runner = BoulderRunner.from_yaml(str(default_path)).solve()
+
+    assert runner.result is not None
+    assert isinstance(runner.result, SimulationResult)
+    assert isinstance(runner.result.network, StagedReactorNet)
+    assert isinstance(runner.result.network.visualization_network, ct.ReactorNet)
+
+
+# ---------------------------------------------------------------------------
+# Test 5: CLI main() accepts runner_class kwarg
 # ---------------------------------------------------------------------------
 
 
@@ -233,7 +267,7 @@ def test_boulder_cli_main_accepts_runner_class_kwarg(tmp_path, monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# Test 5: resolve_mechanism default returns name unchanged
+# Test 6: resolve_mechanism default returns name unchanged
 # ---------------------------------------------------------------------------
 
 

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -4,7 +4,7 @@ import json
 
 import pytest
 
-from boulder.config import get_initial_config
+from boulder.config import get_initial_config, normalize_config, validate_config
 from boulder.styles import CYTOSCAPE_STYLESHEET
 from boulder.utils import config_to_cyto_elements
 from boulder.validation import validate_normalized_config
@@ -56,6 +56,21 @@ class TestBoulderConfig:
         }
         model = validate_normalized_config(config)
         assert model.nodes[0].id == "r1"
+
+    def test_metadata_gui_app_title_round_trip(self):
+        """``metadata.gui_app_title`` validates and appears on the validated dict.
+
+        Assertions:
+        1. Normalized config with ``gui_app_title`` passes ``validate_config``
+        2. Returned metadata contains the same non-empty string
+        """
+        raw = {
+            "metadata": {"gui_app_title": "Bloc", "description": "test"},
+            "nodes": [{"id": "r1", "type": "IdealGasReactor", "properties": {}}],
+            "connections": [],
+        }
+        validated = validate_config(normalize_config(raw))
+        assert validated["metadata"]["gui_app_title"] == "Bloc"
 
     def test_get_initial_config_components(self):
         """Test initial config components have required fields.


### PR DESCRIPTION

- [x] Replace `configs/default.yaml` with a lean methane/air CSTR combustor (φ = 0.5), complete inlet/outlet topology, and a non-empty `output:` block aligned with the GUI default load path.
- [x] Add `configs/cstr_methane_air.yaml` as an annotated sweep-ready variant and standardise `output:` across the curated `configs/*.yaml` set.
- [x] Extend CI coverage: default config existence/non-empty `output`, full curated-library checks, and `BoulderRunner.solve()` on `default.yaml`.
- [x] Fix STONE round-trip export so optional connection/node fields are not re-emitted when unset (`mechanism_switch`, `metadata`).
- [x] Fix duplicate operating pressure on export for `IdealGasConstPressureMoleReactor` when `initial.pressure` is already set; register that kind in const-pressure handling used by the exporter.
- [x] Refresh `configs/README.md` for the real file list and physical intent of each example.
- [x] Add `warn_simulation_quality` notes on `boulder validate` when `output:` is missing or empty (non-fatal).