### PR TITLE
Update YAML editing window

### DIFF
--- a/boulder/api/routes/configs.py
+++ b/boulder/api/routes/configs.py
@@ -17,6 +17,7 @@ from ...config import (
     convert_to_stone_format,
     get_initial_config_with_comments,
     load_yaml_string_with_comments,
+    merge_config_into_yaml,
     normalize_config,
     validate_config,
     yaml_to_string_with_comments,
@@ -40,6 +41,11 @@ class ConfigExportRequest(BaseModel):
 
 class ConfigValidateRequest(BaseModel):
     config: Dict[str, Any]
+
+
+class ConfigSyncRequest(BaseModel):
+    config: Dict[str, Any]
+    original_yaml: str
 
 
 # ---------------------------------------------------------------------------
@@ -115,6 +121,28 @@ async def export_config(body: ConfigExportRequest) -> Dict[str, Any]:
         stone = convert_to_stone_format(body.config)
         yaml_str = yaml_to_string_with_comments(stone)
         return {"yaml": yaml_str}
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc))
+
+
+@router.post("/sync")
+async def sync_config(body: ConfigSyncRequest) -> Dict[str, Any]:
+    """Merge an updated config back into the original YAML, preserving comments and units.
+
+    Accepts the live (normalized, SI) config from the frontend together with
+    the original YAML string that was loaded from disk.  Returns the merged
+    YAML and a list of non-fatal warnings (e.g. Pint back-conversion failures).
+
+    Returns HTTP 422 when the sync cannot be performed safely, e.g.:
+
+    * The original YAML used inline port shortcuts (``inlet:`` / ``outlet:``).
+    * Top-level shape mismatch between original YAML and current config.
+    """
+    try:
+        yaml_str, warnings = merge_config_into_yaml(body.config, body.original_yaml)
+        return {"yaml": yaml_str, "warnings": warnings}
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc))
     except Exception as exc:
         raise HTTPException(status_code=500, detail=str(exc))
 

--- a/boulder/config.py
+++ b/boulder/config.py
@@ -847,9 +847,10 @@ def expand_composite_kinds(config: Dict[str, Any], plugins: Any) -> None:
         for n in result.get("nodes", []):
             existing = by_node_id.get(n["id"])
             if existing is None:
+                n["__synthesized"] = True
                 nodes.append(n)
                 by_node_id[n["id"]] = n
-            elif existing != n:
+            elif {k: v for k, v in existing.items() if k != "__synthesized"} != n:
                 raise ValueError(
                     f"Composite unfold collision: node id '{n['id']}' "
                     f"emitted by unfolder for '{node['id']}' conflicts "
@@ -863,9 +864,10 @@ def expand_composite_kinds(config: Dict[str, Any], plugins: Any) -> None:
         for c in result.get("connections", []):
             existing = by_conn_id.get(c["id"])
             if existing is None:
+                c["__synthesized"] = True
                 conns.append(c)
                 by_conn_id[c["id"]] = c
-            elif existing != c:
+            elif {k: v for k, v in existing.items() if k != "__synthesized"} != c:
                 raise ValueError(
                     f"Composite unfold collision: connection id '{c['id']}' "
                     f"emitted by unfolder for '{node['id']}' conflicts "
@@ -1181,6 +1183,15 @@ def expand_port_shortcuts(config: Dict[str, Any]) -> None:
         synthesized.append(entry)
         explicit_conn_ids.add(cid)
         explicit_edges.add((nid, to_id))
+
+    # Tag every port-shortcut-derived connection as synthesized so the live
+    # YAML sync endpoint can filter them out (they are never in the user's file).
+    for entry in synthesized:
+        entry["__synthesized"] = True
+    # Also record that port shortcuts were present in this config so that the
+    # sync endpoint can reject requests for configs derived from inline-port YAML.
+    if synthesized:
+        config["__has_inline_ports"] = True
 
     connections.extend(synthesized)
 
@@ -1509,6 +1520,7 @@ def _internal_node_to_stone_v2_item(node: Dict[str, Any]) -> Dict[str, Any]:
     """Map one internal node dict to a STONE v2 stage/network list item."""
     node_type = node.get("type", "IdealGasReactor")
     props = dict(node.get("properties", {}) or {})
+    props.pop("__synthesized", None)
     mech_from_props = props.pop("mechanism", None)
 
     # For const-pressure reactor kinds, ``pressure`` is the network operating
@@ -1534,8 +1546,12 @@ def _internal_node_to_stone_v2_item(node: Dict[str, Any]) -> Dict[str, Any]:
     for fld in ("description", "label"):
         if fld in node:
             stone_node[fld] = node[fld]
-    if node.get("metadata") is not None:
-        stone_node["metadata"] = node["metadata"]
+    metadata = node.get("metadata")
+    if metadata is not None:
+        # Strip internal private key before emitting YAML
+        metadata = {k: v for k, v in metadata.items() if k != "__synthesized"}
+        if metadata:
+            stone_node["metadata"] = metadata
     return stone_node
 
 
@@ -1558,6 +1574,7 @@ def _internal_connection_to_stone_v2_item(conn: Dict[str, Any]) -> Dict[str, Any
 
     connection_type = conn.get("type", "MassFlowController")
     props = dict(conn.get("properties", {}) or {})
+    props.pop("__synthesized", None)
     stone_conn: Dict[str, Any] = {
         "id": conn["id"],
         connection_type: props,
@@ -1566,8 +1583,11 @@ def _internal_connection_to_stone_v2_item(conn: Dict[str, Any]) -> Dict[str, Any
     }
     if conn.get("mechanism_switch") is not None:
         stone_conn["mechanism_switch"] = conn["mechanism_switch"]
-    if conn.get("metadata") is not None:
-        stone_conn["metadata"] = conn["metadata"]
+    metadata = conn.get("metadata")
+    if metadata is not None:
+        metadata = {k: v for k, v in metadata.items() if k != "__synthesized"}
+        if metadata:
+            stone_conn["metadata"] = metadata
     return stone_conn
 
 
@@ -1653,178 +1673,535 @@ def load_yaml_string_with_comments(yaml_str: str):
     return yaml_obj.load(stream)
 
 
+def _yaml_has_inline_ports(ruamel_tree: Any) -> bool:
+    """Return True if any node in *ruamel_tree* declares an inline port shortcut.
+
+    Inline ports are ``inlet:`` or ``outlet:`` keys nested inside a node's
+    component-property dict in a STONE v2 YAML.
+    """
+    _PORT_KEYS = {"inlet", "outlet"}
+    _NON_KIND_TOP = {
+        "id",
+        "source",
+        "target",
+        "metadata",
+        "mechanism",
+        "description",
+        "label",
+        "mechanism_switch",
+        "group",
+        "mass_flow_rate",
+        "stages",
+    }
+
+    def _check_item(item: Any) -> bool:
+        if not isinstance(item, dict):
+            return False
+        for k, v in item.items():
+            if k not in _NON_KIND_TOP and isinstance(v, dict):
+                if _PORT_KEYS.intersection(v.keys()):
+                    return True
+        return False
+
+    if not isinstance(ruamel_tree, dict):
+        return False
+
+    # Walk all list values at the top level (network:, stage lists).
+    for val in ruamel_tree.values():
+        if isinstance(val, list):
+            for item in val:
+                if _check_item(item):
+                    return True
+    return False
+
+
+def _collect_authored_ids(ruamel_tree: Any) -> set:
+    """Return the set of ``id`` values present in the original YAML network/stage lists.
+
+    These are the IDs the user actually wrote.  Any ID produced by an expander
+    (``expand_composite_kinds``, ``expand_port_shortcuts``) will NOT be in this
+    set and should be treated as synthesized.
+    """
+    ids: set = set()
+    if not isinstance(ruamel_tree, dict):
+        return ids
+    for val in ruamel_tree.values():
+        if isinstance(val, list):
+            for item in val:
+                if isinstance(item, dict) and "id" in item:
+                    ids.add(item["id"])
+    return ids
+
+
+def _fresh_normalize_original(
+    original_yaml_str: str,
+) -> Tuple[set, Dict[str, Dict[str, Any]]]:
+    """Re-normalize *original_yaml_str* and return synthesized IDs + default properties.
+
+    Returns
+    -------
+    tuple
+        ``(synthesized_ids, default_props_by_id)``
+
+        * ``synthesized_ids`` – IDs produced by expanders (not in the original
+          YAML tree).
+        * ``default_props_by_id`` – ``{node_or_conn_id: properties_dict}`` for
+          every authored node/connection in the fresh normalize result.  These
+          are the normalization-default properties that should NOT be injected
+          back into the YAML when they weren't explicitly authored.
+    """
+    try:
+        original_data = load_yaml_string_with_comments(original_yaml_str)
+        authored_ids = _collect_authored_ids(original_data)
+        plain = _to_plain_dict(original_data)
+        normalized = normalize_config(plain)
+        all_ids: set = set()
+        default_props: Dict[str, Dict[str, Any]] = {}
+        for n in normalized.get("nodes") or []:
+            nid = n.get("id")
+            if nid:
+                all_ids.add(nid)
+                default_props[nid] = n.get("properties") or {}
+        for c in normalized.get("connections") or []:
+            cid = c.get("id")
+            if cid:
+                all_ids.add(cid)
+                default_props[cid] = c.get("properties") or {}
+        return all_ids - authored_ids, default_props
+    except Exception:
+        return set(), {}
+
+
+def _collect_synthesized_ids_from_fresh_normalize(original_yaml_str: str) -> set:
+    """Re-normalize *original_yaml_str* and return IDs added by expanders."""
+    synthesized_ids, _ = _fresh_normalize_original(original_yaml_str)
+    return synthesized_ids
+
+
+def merge_config_into_yaml(
+    config: dict,
+    original_yaml_str: str,
+) -> Tuple[str, List[str]]:
+    """Merge *config* into *original_yaml_str* while preserving comments and units.
+
+    This is the shared backend entry-point used by both the live-sync API
+    endpoint (``POST /api/configs/sync``) and
+    :func:`save_config_to_file_with_comments`.
+
+    Parameters
+    ----------
+    config:
+        Normalized (SI) internal config dict, as stored in the frontend Zustand
+        store.
+    original_yaml_str:
+        The verbatim YAML text from the user's file, as loaded by the frontend.
+
+    Returns
+    -------
+    tuple
+        ``(yaml_string, warnings)`` — the merged YAML text plus any non-fatal
+        warning messages (e.g. Pint back-conversion failures).
+
+    Raises
+    ------
+    ValueError
+        If the config cannot be safely synced into the original YAML:
+
+        * Inline port shortcuts (``inlet:`` / ``outlet:`` on nodes) were
+          detected in the original YAML — the mapping is lossy and sync cannot
+          reconstruct it.
+        * Top-level shape mismatch — original used ``network:`` but current
+          config would produce ``stages:`` (or vice versa).
+    """
+    from .yaml_unit_map import apply_unit_map_inplace, build_unit_map  # noqa: PLC0415
+
+    # 1. Parse original YAML preserving comments.
+    original_data = load_yaml_string_with_comments(original_yaml_str)
+
+    # 2. Build unit_map from original tree before any mutation.
+    unit_map = build_unit_map(original_data)
+
+    # 3. Detect inline port shortcuts in the original YAML by walking its
+    #    network/stage lists without a full normalize cycle.
+    if _yaml_has_inline_ports(original_data):
+        raise ValueError(
+            "Inline port shortcuts (inlet: / outlet: on a node) are not yet "
+            "supported by the YAML live-sync editor. Convert them to explicit "
+            "connections: entries in your file and reopen."
+        )
+
+    # 4. Build STONE representation from config, filtering synthesized items.
+    #
+    # The ``__synthesized`` flag is set by expand_composite_kinds /
+    # expand_port_shortcuts but is stripped by ``validate_config`` (Pydantic
+    # serialisation).  The frontend therefore sends back the validated config
+    # without ``__synthesized`` on satellite nodes.
+    #
+    # Two-source filter:
+    # a) Explicit ``__synthesized=True`` flag (present on fresh normalize; may
+    #    be absent on configs that passed through validate_config).
+    # b) ID is in ``fresh_synthesized_ids``: IDs produced by expanders when
+    #    we re-normalize the original YAML here, minus IDs already in the
+    #    original YAML tree.  These are always synthesized satellites.
+    #
+    # An item absent from the original YAML AND not in fresh_synthesized_ids
+    # was added by the GUI → keep it.
+    fresh_synthesized_ids, default_props_by_id = _fresh_normalize_original(
+        original_yaml_str
+    )
+
+    def _should_keep(item: dict) -> bool:
+        if item.get("__synthesized"):
+            return False
+        item_id = item.get("id")
+        if item_id and item_id in fresh_synthesized_ids:
+            return False
+        return True
+
+    config_for_stone = dict(config)
+    config_for_stone["nodes"] = [
+        n for n in (config.get("nodes") or []) if _should_keep(n)
+    ]
+    config_for_stone["connections"] = [
+        c for c in (config.get("connections") or []) if _should_keep(c)
+    ]
+    stone = convert_to_stone_format(config_for_stone)
+
+    # 5. Shape-conflict guard: original uses network: XOR stages:.
+    orig_has_network = "network" in original_data
+    orig_has_stages = "stages" in original_data
+    stone_has_network = "network" in stone
+    stone_has_stages = "stages" in stone
+
+    if orig_has_network and stone_has_stages:
+        raise ValueError(
+            "Shape conflict: the original YAML uses a flat network: list but "
+            "the current configuration has multiple stages. Stage management "
+            "via the YAML editor is not yet supported."
+        )
+    if orig_has_stages and stone_has_network:
+        raise ValueError(
+            "Shape conflict: the original YAML uses stages: but the current "
+            "configuration has no stage grouping. Removing stages via the "
+            "YAML editor is not yet supported."
+        )
+
+    # 6. Warn about anchors/aliases (limited support).
+    warnings: List[str] = []
+    if "&" in original_yaml_str or "*" in original_yaml_str:
+        warnings.append(
+            "The original YAML contains anchors (&) or aliases (*). "
+            "Comment and value preservation for anchored nodes is not "
+            "guaranteed after sync."
+        )
+
+    # 7. Strip top-level keys from stone that are absent from the original YAML.
+    #    Keys like ``settings`` and ``output`` are injected by
+    #    ``convert_to_stone_format`` from normalization artifacts; if the user
+    #    didn't write them they must not appear in the merged output.
+    stone_for_merge = {k: v for k, v in stone.items() if k in original_data}
+
+    # 8. Merge STONE dict into original ruamel tree in-place.
+    _update_yaml_preserving_comments(
+        original_data, stone_for_merge, default_props_by_id=default_props_by_id
+    )
+
+    # 9. Apply unit map: replace SI floats with original unit strings.
+    unit_warnings = apply_unit_map_inplace(original_data, unit_map, config)
+    warnings.extend(unit_warnings)
+
+    # 10. Dump to string using the same sequence indentation as the original.
+    yaml_str = _yaml_to_string_matching_indent(original_data, original_yaml_str)
+    return yaml_str, warnings
+
+
+def _detect_sequence_indent(yaml_str: str) -> Optional[int]:
+    """Return the number of spaces before the first ``-`` list item, or None."""
+    import re as _re
+
+    m = _re.search(r"^( +)-", yaml_str, _re.MULTILINE)
+    if m:
+        return len(m.group(1))
+    return None
+
+
+def _yaml_to_string_matching_indent(data: Any, original_yaml_str: str) -> str:
+    """Dump *data* to YAML string, matching the sequence indentation of *original_yaml_str*.
+
+    The original file may use ``  - `` (2-space) indentation for list items.
+    ruamel's default (sequence=2, offset=0) emits ``- `` at column 0.  We
+    detect the original indent and adjust the dump settings accordingly.
+    """
+    from io import StringIO
+
+    yaml_obj = get_yaml_with_comments()
+    orig_indent = _detect_sequence_indent(original_yaml_str)
+    if orig_indent is not None and orig_indent > 0:
+        # sequence=indent+2 (dash + space + content), offset=indent
+        yaml_obj.indent(mapping=2, sequence=orig_indent + 2, offset=orig_indent)
+    stream = StringIO()
+    yaml_obj.dump(data, stream)
+    return stream.getvalue()
+
+
+def _to_plain_dict(data: Any) -> Any:
+    """Recursively convert ruamel CommentedMap/Seq to plain Python dicts/lists.
+
+    Defined here as a module-level helper so it can be used by both the API
+    routes and :func:`merge_config_into_yaml` without an import cycle.
+    """
+    if isinstance(data, dict):
+        return {k: _to_plain_dict(v) for k, v in data.items()}
+    if isinstance(data, list):
+        return [_to_plain_dict(item) for item in data]
+    return data
+
+
 def save_config_to_file_with_comments(
     config: dict, file_path: str, original_yaml_str: Optional[str] = None
 ):
     """Save configuration to file, preserving comments when possible."""
-    stone_config = convert_to_stone_format(config)
-
     if original_yaml_str:
-        # Try to preserve the original structure and comments
         try:
-            # Load the original YAML with comments
-            original_data = load_yaml_string_with_comments(original_yaml_str)
-
-            # Update the original data with new values while preserving structure
-            updated_data = _update_yaml_preserving_comments(original_data, stone_config)
-
-            # Save with comments preserved
-            yaml_obj = get_yaml_with_comments()
+            yaml_str, _warnings = merge_config_into_yaml(config, original_yaml_str)
             with open(file_path, "w", encoding="utf-8") as f:
-                yaml_obj.dump(updated_data, f)
+                f.write(yaml_str)
             return
         except Exception as e:
             print(f"Warning: Could not preserve comments, using standard format: {e}")
 
-    # Fallback: save without comment preservation
+    stone_config = convert_to_stone_format(config)
     yaml_str = yaml_to_string_with_comments(stone_config)
     with open(file_path, "w", encoding="utf-8") as f:
         f.write(yaml_str)
 
 
-def _update_yaml_preserving_comments(original_data, new_data):
-    """Update YAML data while preserving comments and structure.
+def _update_yaml_preserving_comments(original_data, new_data, default_props_by_id=None):
+    """Merge *new_data* into *original_data* in-place, preserving ruamel comments.
 
-    This function recursively updates the original YAML structure with new values
-    while preserving all comments and formatting.
+    Mutates *original_data* directly so that ``.ca`` comment metadata attached
+    to the ``CommentedMap`` container survives (rebuilding a new container would
+    lose top-level / EOL / blank-line comments).
+
+    Rules for dict merging:
+    - Keys present in both: recurse for dicts/lists; replace scalar otherwise.
+    - Keys only in *new_data*: added to *original_data*.
+    - Keys only in *original_data*: **left unchanged** (not removed).
+      Top-level passthrough keys (``metadata``, ``phases``, ``sweeps``, …)
+      must survive across merge cycles.
+
+    *default_props_by_id* is forwarded to array merges so that normalization-
+    injected properties on existing nodes are not polluted into the YAML.
     """
-    # Import here to avoid circular imports
-    from ruamel.yaml.comments import CommentedMap, CommentedSeq
+    from ruamel.yaml.comments import CommentedSeq  # noqa: F401
 
     if not isinstance(original_data, dict) or not isinstance(new_data, dict):
         return new_data
 
-    # Create a copy that preserves comments and structure
-    if isinstance(original_data, CommentedMap):
-        updated = CommentedMap()
-        # Copy original data to preserve comments
-        for key, value in original_data.items():
-            updated[key] = value
-    else:
-        updated = (
-            original_data.copy()
-            if hasattr(original_data, "copy")
-            else dict(original_data)
-        )
-
-    # Update with new values
     for key, new_value in new_data.items():
-        if key in updated:
-            original_value = updated[key]
-
-            # Handle dictionaries recursively
+        if key in original_data:
+            original_value = original_data[key]
             if isinstance(original_value, dict) and isinstance(new_value, dict):
-                updated[key] = _update_yaml_preserving_comments(
-                    original_value, new_value
-                )
-
-            # Handle arrays/lists - this is the key fix
+                _update_yaml_preserving_comments(original_value, new_value)
             elif isinstance(original_value, (list, CommentedSeq)) and isinstance(
                 new_value, list
             ):
-                updated[key] = _update_yaml_array_preserving_comments(
-                    original_value, new_value
+                _update_yaml_array_preserving_comments(
+                    original_data,
+                    key,
+                    new_value,
+                    default_props_by_id=default_props_by_id,
                 )
-
-            # For scalar values, just update
             else:
-                updated[key] = new_value
+                original_data[key] = new_value
         else:
-            # New key, add it
-            updated[key] = new_value
+            original_data[key] = new_value
 
-    return updated
+    return original_data
 
 
-def _update_yaml_array_preserving_comments(original_array, new_array):
-    """Update an array while preserving comments on array items.
+def _update_yaml_array_preserving_comments(
+    parent_map, array_key, new_array, default_props_by_id=None
+):
+    """Replace the list at *parent_map[array_key]* with items from *new_array*.
 
-    This function matches items in the arrays by their 'id' field and preserves
-    comments on each item while updating their values.
+    Items are matched by their ``id`` field.  For matched items, the original
+    entry is mutated in-place via :func:`_update_yaml_item_preserving_comments`.
+    Items in the original not present in *new_array* are dropped.
+    New items (GUI-added) not in the original are appended at the end.
+    Original ordering is preserved for existing items.
+
+    Mutating in-place (rather than rebuilding the ``CommentedSeq``) keeps
+    ruamel's sequence-level ``.ca`` comment metadata intact.
+
+    *default_props_by_id* is forwarded to the item merge so normalization-
+    injected properties are not written into items that didn't have them.
     """
     from ruamel.yaml.comments import CommentedSeq
 
-    # Create a new commented sequence to preserve array comments
-    if isinstance(original_array, CommentedSeq):
-        updated_array = CommentedSeq()
-        # Copy array-level comments by copying the entire original array first
-        # then updating its contents
-        for item in original_array:
-            updated_array.append(item)
+    original_array = parent_map[array_key]
 
-        # Now clear and rebuild with updated items
-        updated_array.clear()
-    else:
-        updated_array = []
-
-    # Create a mapping of original items by their ID for easy lookup
     original_by_id = {}
     for item in original_array:
         if isinstance(item, dict) and "id" in item:
             original_by_id[item["id"]] = item
 
-    # Process each new item
+    new_by_id = {}
     for new_item in new_array:
         if isinstance(new_item, dict) and "id" in new_item:
-            item_id = new_item["id"]
+            new_by_id[new_item["id"]] = new_item
 
-            # If we have an original item with the same ID, merge it
-            if item_id in original_by_id:
-                original_item = original_by_id[item_id]
-                updated_item = _update_yaml_item_preserving_comments(
-                    original_item, new_item
+    # Build the new sequence preserving original ordering for existing items,
+    # then appending new (GUI-added) items at the end.
+    new_items = []
+    for orig_item in original_array:
+        if isinstance(orig_item, dict) and "id" in orig_item:
+            item_id = orig_item["id"]
+            if item_id in new_by_id:
+                injected = (default_props_by_id or {}).get(item_id)
+                merged = _update_yaml_item_preserving_comments(
+                    orig_item, new_by_id[item_id], injected_props=injected
                 )
-                updated_array.append(updated_item)
-            else:
-                # New item, add as-is
-                updated_array.append(new_item)
+                new_items.append(merged)
+            # If item_id not in new_by_id, the item was removed — skip it.
         else:
-            # Item without ID, add as-is
-            updated_array.append(new_item)
+            new_items.append(orig_item)
+    # Append GUI-added items (those not in the original).
+    for new_item in new_array:
+        if isinstance(new_item, dict) and "id" in new_item:
+            if new_item["id"] not in original_by_id:
+                new_items.append(new_item)
+        elif new_item not in new_items:
+            new_items.append(new_item)
 
-    return updated_array
+    if isinstance(original_array, CommentedSeq):
+        # Mutate the existing CommentedSeq in-place so .ca survives.
+        original_array.clear()
+        for item in new_items:
+            original_array.append(item)
+    else:
+        parent_map[array_key] = new_items
 
 
-def _update_yaml_item_preserving_comments(original_item, new_item):
-    """Update a single YAML item while preserving its STONE format structure.
+def _update_yaml_item_preserving_comments(original_item, new_item, injected_props=None):
+    """Merge *new_item* into the original STONE network/stage list item.
 
-    This function handles the specific case of nodes and connections
-    which have a special structure in STONE format.
+    Handles STONE v2 shape where items look like::
+
+        {id: ..., <KindKey>: {prop1: v1, ...}, source: ..., target: ...}
+
+    - **Kind-key change**: if ``new_item`` has a different component-type key
+      (e.g. ``IdealGasConstPressureReactor`` instead of ``IdealGasReactor``),
+      the old kind key is removed and the new one is added.
+    - **New properties**: keys present only in ``new_item`` that are not
+      normalization-injected defaults are added to the component property dict.
+    - **Property deletion**: keys present in the original component property dict
+      but absent from the new one are deleted (propagates GUI property removal).
+    - **In-place mutation**: ``original_item`` (a ``CommentedMap``) is mutated
+      directly so ``.ca`` comment metadata survives.
+
+    *injected_props* is a ``{key: value}`` dict of properties that a fresh
+    normalize of the original YAML would inject automatically.  New properties
+    matching these are skipped to avoid polluting the YAML.
     """
-    from ruamel.yaml.comments import CommentedMap
-
     if not isinstance(original_item, dict) or not isinstance(new_item, dict):
         return new_item
 
-    # Create a copy that preserves comments and structure
-    if isinstance(original_item, CommentedMap):
-        updated_item = CommentedMap()
-        # Copy original data to preserve comments
-        for key, value in original_item.items():
-            updated_item[key] = value
-    else:
-        updated_item = original_item.copy()
+    # Identify the component-type key in each item (the key whose value is a
+    # dict of properties, i.e. not id/source/target/metadata/etc.).
+    _NON_KIND_KEYS = {
+        "id",
+        "source",
+        "target",
+        "metadata",
+        "mechanism",
+        "description",
+        "label",
+        "mechanism_switch",
+        "group",
+        "mass_flow_rate",
+    }
 
-    # For STONE format, we need to preserve the structure but update values
-    # The new_item comes in STONE format, so we can directly update
+    def _kind_key(item):
+        for k, v in item.items():
+            if k not in _NON_KIND_KEYS and isinstance(v, dict):
+                return k
+        return None
+
+    orig_kind = _kind_key(original_item)
+    new_kind = _kind_key(new_item)
+
+    # -- Handle kind-key change --
+    if orig_kind and new_kind and orig_kind != new_kind:
+        # Remove old kind key; the new one will be added below.
+        del original_item[orig_kind]
+
+    # -- Merge all keys from new_item into original_item --
     for key, new_value in new_item.items():
-        if key == "id":
-            # Always update the ID
-            updated_item[key] = new_value
-        elif key in ["source", "target"]:
-            # For connections, update source/target
-            updated_item[key] = new_value
-        elif key in updated_item:
-            # For other keys that exist in original (like component type keys)
-            if isinstance(updated_item[key], dict) and isinstance(new_value, dict):
-                # Recursively update nested dictionaries
-                updated_item[key] = _update_yaml_preserving_comments(
-                    updated_item[key], new_value
-                )
-            else:
-                updated_item[key] = new_value
+        if key == orig_kind and new_kind and orig_kind != new_kind:
+            continue  # already removed above
 
-    return updated_item
+        if key in original_item:
+            original_value = original_item[key]
+            if (
+                key == (new_kind or orig_kind)
+                and isinstance(original_value, dict)
+                and isinstance(new_value, dict)
+            ):
+                # Property dict: merge and delete removed keys.
+                _merge_property_dict_inplace(original_value, new_value, injected_props)
+            elif isinstance(original_value, dict) and isinstance(new_value, dict):
+                _update_yaml_preserving_comments(original_value, new_value)
+            else:
+                original_item[key] = new_value
+        else:
+            original_item[key] = new_value
+
+    return original_item
+
+
+def _merge_property_dict_inplace(original_props, new_props, injected_props=None):
+    """Merge *new_props* into *original_props* in-place.
+
+    Rules:
+    - Keys present in *original_props* that are absent from *new_props*:
+      deleted (propagates GUI property removal).
+    - Keys present in both: updated in-place.
+    - Keys only in *new_props* (not in original):
+      - If they also appear in *injected_props* with the same value:
+        they are normalization artifacts (e.g. ``pressure`` injected by
+        ``propagate_terminal_pressure_defaults``) → **skip**.
+      - Otherwise they were explicitly set by the user in the GUI → **add**.
+
+    *injected_props* is an optional dict of ``{prop_key: value}`` for
+    properties that a fresh normalize of the original YAML would produce
+    automatically.  Pass ``None`` to skip injection-filtering (all new
+    keys are added).
+
+    Depth is limited to the component property block (one level down from the
+    kind key), not the full document.
+    """
+    injected = injected_props or {}
+
+    # Delete keys removed by the GUI.
+    keys_to_delete = [k for k in original_props if k not in new_props]
+    for k in keys_to_delete:
+        del original_props[k]
+
+    # Add/update keys.
+    for k, v in new_props.items():
+        if k in original_props:
+            old_v = original_props[k]
+            if isinstance(old_v, dict) and isinstance(v, dict):
+                _update_yaml_preserving_comments(old_v, v)
+            else:
+                original_props[k] = v
+        elif k in injected and injected[k] == v:
+            # Normalization-injected default — do not pollute the YAML.
+            pass
+        else:
+            # Explicitly set by the user via the GUI → add it.
+            original_props[k] = v
 
 
 def load_config_file_with_py_support(

--- a/boulder/config.py
+++ b/boulder/config.py
@@ -853,7 +853,12 @@ def expand_composite_kinds(config: Dict[str, Any], plugins: Any) -> None:
                 raise ValueError(
                     f"Composite unfold collision: node id '{n['id']}' "
                     f"emitted by unfolder for '{node['id']}' conflicts "
-                    "with an existing node. Rename one of them."
+                    "with an existing node.\n"
+                    f"  Composite reactor '{node['id']}' (type '{node.get('type')}') "
+                    f"automatically generates a satellite node named '{n['id']}'.\n"
+                    "  Fix: remove or rename the explicit node whose id matches "
+                    f"'{n['id']}' in your YAML — it is managed internally and must "
+                    "not be declared by the user."
                 )
         for c in result.get("connections", []):
             existing = by_conn_id.get(c["id"])
@@ -864,7 +869,12 @@ def expand_composite_kinds(config: Dict[str, Any], plugins: Any) -> None:
                 raise ValueError(
                     f"Composite unfold collision: connection id '{c['id']}' "
                     f"emitted by unfolder for '{node['id']}' conflicts "
-                    "with an existing connection."
+                    "with an existing connection.\n"
+                    f"  Composite reactor '{node['id']}' (type '{node.get('type')}') "
+                    f"automatically generates a satellite connection named '{c['id']}'.\n"
+                    "  Fix: remove or rename the explicit connection whose id matches "
+                    f"'{c['id']}' in your YAML — it is managed internally and must "
+                    "not be declared by the user."
                 )
 
 

--- a/boulder/yaml_unit_map.py
+++ b/boulder/yaml_unit_map.py
@@ -1,0 +1,307 @@
+"""Unit-map helpers for YAML live sync.
+
+Builds a map of unit-bearing scalar paths from a ruamel CommentedMap tree so
+that SI float values in the updated config can be converted back to the
+original unit strings (e.g. ``1 atm``, ``10 kg/h``, ``500 degC``) when the
+YAML editor is synced with the live GUI state.
+
+Key types
+---------
+UnitEntry : tuple
+    ``(original_text: str, orig_unit_str: str, si_value: float,
+       scalar_cls: type)``
+
+    * ``original_text``  – verbatim text as it appeared in the YAML, e.g.
+      ``"1 atm"`` or ``"298.15 K"``.
+    * ``orig_unit_str``  – unit token extracted from the text, e.g. ``"atm"``.
+    * ``si_value``       – canonical SI float the original text converts to.
+    * ``scalar_cls``     – the ruamel scalar subclass (or ``str``) that should
+      be used when emitting a replacement so quoting style is preserved.
+
+UnitMap : dict
+    ``{(item_id_or_none, key_path_tuple): UnitEntry}``
+
+    *item_id_or_none* is the value of the ``id`` key inside the nearest
+    enclosing network/stage list item, or ``None`` for top-level scalars.
+    *key_path_tuple* is a tuple of string keys leading from the item root
+    (or from the document root for top-level scalars) to the scalar.
+
+    Using ``id`` instead of list indices makes the map stable when the list
+    is reordered or filtered (e.g. synthesized satellites removed).
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any, Dict, List, Optional, Tuple
+
+from .utils import _UNIT_STRING_RE, _get_pint_ureg
+
+# ---------------------------------------------------------------------------
+# Type aliases
+# ---------------------------------------------------------------------------
+
+# (orig_text, orig_unit_str, si_value, scalar_cls)
+UnitEntry = Tuple[str, str, float, type]
+# {(item_id_or_none, key_path_tuple) -> UnitEntry}
+UnitMap = Dict[Tuple[Optional[str], tuple], UnitEntry]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _scalar_cls(val: Any) -> type:
+    """Return the ruamel scalar subclass (or str) for *val*."""
+    try:
+        from ruamel.yaml.scalarstring import (  # noqa: PLC0415
+            DoubleQuotedScalarString,
+            PlainScalarString,
+            SingleQuotedScalarString,
+        )
+
+        for cls in (SingleQuotedScalarString, DoubleQuotedScalarString, PlainScalarString):
+            if isinstance(val, cls):
+                return cls
+    except ImportError:
+        pass
+    return str
+
+
+def _parse_unit_entry(text: str, property_name: str) -> Optional[UnitEntry]:
+    """Parse *text* as ``"<number> <unit>"`` and return a :data:`UnitEntry`.
+
+    Returns ``None`` if *text* does not match the unit-string pattern or if
+    Pint cannot parse the unit.
+    """
+    if not isinstance(text, str):
+        return None
+    m = _UNIT_STRING_RE.match(text)
+    if not m:
+        return None
+    num_str, unit_str = m.group(1), m.group(2)
+    from .utils import _PROPERTY_UNIT_HINTS  # noqa: PLC0415
+
+    target_unit = _PROPERTY_UNIT_HINTS.get(property_name)
+    try:
+        ureg = _get_pint_ureg()
+        qty = ureg.Quantity(float(num_str), unit_str)
+        if target_unit is not None:
+            si_val = float(qty.to(target_unit).magnitude)
+        else:
+            si_val = float(qty.to_base_units().magnitude)
+        return (text, unit_str, si_val, _scalar_cls(text))
+    except Exception:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# build_unit_map
+# ---------------------------------------------------------------------------
+
+def build_unit_map(ruamel_tree: Any) -> UnitMap:
+    """Walk a ruamel YAML tree and record every unit-bearing scalar.
+
+    Parameters
+    ----------
+    ruamel_tree:
+        A ``CommentedMap`` (or plain ``dict``) returned by
+        ``load_yaml_string_with_comments``.
+
+    Returns
+    -------
+    UnitMap
+        Dict keyed by ``(item_id_or_none, key_path_tuple)``.
+    """
+    result: UnitMap = {}
+
+    def _walk_item(node: Any, item_id: Optional[str], path: tuple) -> None:
+        """Recurse into *node* collecting unit entries."""
+        if isinstance(node, dict):
+            for k, v in node.items():
+                child_path = path + (k,)
+                entry = _parse_unit_entry(v, property_name=k)
+                if entry is not None:
+                    result[(item_id, child_path)] = entry
+                else:
+                    _walk_item(v, item_id, child_path)
+        elif isinstance(node, list):
+            for item in node:
+                if isinstance(item, dict) and "id" in item:
+                    # Network/stage list item — use its id as key prefix.
+                    _walk_item(item, item["id"], ())
+                else:
+                    _walk_item(item, item_id, path)
+        # Scalars without a unit match are ignored.
+
+    if not isinstance(ruamel_tree, dict):
+        return result
+
+    # Walk top-level network or stages lists, plus top-level scalar keys.
+    for top_key, top_val in ruamel_tree.items():
+        if isinstance(top_val, list):
+            # Could be network: or a stage list.
+            _walk_item(top_val, None, (top_key,))
+        elif isinstance(top_val, dict):
+            _walk_item(top_val, None, (top_key,))
+        else:
+            entry = _parse_unit_entry(top_val, property_name=top_key)
+            if entry is not None:
+                result[(None, (top_key,))] = entry
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# apply_unit_map_inplace
+# ---------------------------------------------------------------------------
+
+def apply_unit_map_inplace(
+    merged_tree: Any,
+    unit_map: UnitMap,
+    updated_config: Dict[str, Any],
+) -> List[str]:
+    """Replace SI float scalars in *merged_tree* with original unit strings.
+
+    Walks the merged ruamel tree **in place**.  For each leaf scalar that has
+    an entry in *unit_map*:
+
+    * If the corresponding SI value in *updated_config* equals the original SI
+      value (within ``rel_tol=1e-9``): the original verbatim text is restored
+      (style-preserving, no change if ruamel already emitted it correctly).
+    * If the value differs: a new string of the form
+      ``"<new_magnitude_in_orig_unit:g> <orig_unit>"`` is written, using the
+      same ruamel scalar subclass as the original for quoting style.
+
+    Parameters
+    ----------
+    merged_tree:
+        Ruamel ``CommentedMap`` as returned by the merge step.
+    updated_config:
+        Internal (normalized, SI) config dict from the frontend.  Used only to
+        look up the current SI value for each property.
+    unit_map:
+        Built by :func:`build_unit_map` from the ``original_yaml`` string.
+
+    Returns
+    -------
+    List[str]
+        Warning strings for any paths where Pint inverse conversion failed.
+        An empty list means full success.
+    """
+    warnings: List[str] = []
+
+    # Build a fast lookup: item_id -> internal node/connection properties.
+    node_props: Dict[str, Dict[str, Any]] = {}
+    for n in updated_config.get("nodes", []):
+        node_props[n["id"]] = n.get("properties") or {}
+    conn_props: Dict[str, Dict[str, Any]] = {}
+    for c in updated_config.get("connections", []):
+        conn_props[c["id"]] = c.get("properties") or {}
+
+    def _get_si_value(item_id: Optional[str], key_path: tuple) -> Optional[float]:
+        """Look up the current SI float for *key_path* under *item_id*."""
+        if item_id is None:
+            # Top-level scalar (e.g. inside metadata).
+            node = merged_tree
+            for k in key_path:
+                if not isinstance(node, dict) or k not in node:
+                    return None
+                node = node[k]
+            return node if isinstance(node, (int, float)) else None
+
+        # Item inside a network list.  The key_path is relative to the item
+        # root.  STONE format: first key is the component-type key, rest is
+        # the property name.
+        if item_id in node_props:
+            props = node_props[item_id]
+        elif item_id in conn_props:
+            props = conn_props[item_id]
+        else:
+            return None
+
+        # Flatten key_path: skip the component-type key (index 0) and dig in.
+        if len(key_path) >= 2:
+            # path[0] is the STONE kind key (e.g. "Reservoir") – skip it.
+            prop_key = key_path[-1]
+        elif len(key_path) == 1:
+            prop_key = key_path[0]
+        else:
+            return None
+
+        val = props.get(prop_key)
+        return val if isinstance(val, (int, float)) else None
+
+    def _make_replacement(orig_text: str, orig_unit_str: str, new_si_val: float,
+                          scalar_cls: type, path_label: str) -> Optional[str]:
+        """Convert *new_si_val* back to *orig_unit_str* and format as string."""
+        from .utils import _PROPERTY_UNIT_HINTS  # noqa: PLC0415
+
+        # Infer the property name from the last segment of the path.
+        prop_name = path_label.split(".")[-1] if path_label else ""
+        target_unit = _PROPERTY_UNIT_HINTS.get(prop_name)
+        try:
+            ureg = _get_pint_ureg()
+            if target_unit is not None:
+                qty = ureg.Quantity(new_si_val, target_unit)
+            else:
+                # Try to parse orig_unit_str to know which SI unit this is.
+                orig_m = _UNIT_STRING_RE.match(orig_text)
+                if orig_m:
+                    orig_qty = ureg.Quantity(float(orig_m.group(1)), orig_m.group(2))
+                    base_unit = str(orig_qty.to_base_units().units)
+                    qty = ureg.Quantity(new_si_val, base_unit)
+                else:
+                    return None
+            converted = qty.to(orig_unit_str)
+            magnitude = converted.magnitude
+            formatted = f"{magnitude:g} {orig_unit_str}"
+            return formatted
+        except Exception as exc:
+            warnings.append(
+                f"Unit back-conversion failed for '{path_label}': {exc}. "
+                f"Falling back to SI float."
+            )
+            return None
+
+    def _apply_to_item(node: Any, item_id: Optional[str], path: tuple) -> None:
+        """Recursively walk *node* and replace unit scalars in place."""
+        if isinstance(node, dict):
+            for k in list(node.keys()):
+                child_path = path + (k,)
+                map_key = (item_id, child_path)
+                if map_key in unit_map:
+                    orig_text, orig_unit_str, orig_si, scalar_cls = unit_map[map_key]
+                    # Get the current SI value from the updated config.
+                    current_si = _get_si_value(item_id, child_path)
+                    if current_si is None:
+                        # Can't determine new value — restore original text.
+                        node[k] = orig_text
+                        continue
+                    if math.isclose(current_si, orig_si, rel_tol=1e-9):
+                        # Unchanged — restore verbatim original.
+                        node[k] = orig_text
+                    else:
+                        path_label = ".".join(str(p) for p in (item_id,) + child_path if p)
+                        replacement = _make_replacement(
+                            orig_text, orig_unit_str, current_si, scalar_cls, path_label
+                        )
+                        if replacement is not None:
+                            try:
+                                # Use the original scalar subclass for quoting.
+                                node[k] = scalar_cls(replacement)
+                            except Exception:
+                                node[k] = replacement
+                        # On failure, _make_replacement already appended a warning;
+                        # leave the bare SI float as-is.
+                else:
+                    _apply_to_item(node[k], item_id, child_path)
+        elif isinstance(node, list):
+            for item in node:
+                if isinstance(item, dict) and "id" in item:
+                    _apply_to_item(item, item["id"], ())
+                else:
+                    _apply_to_item(item, item_id, path)
+
+    _apply_to_item(merged_tree, None, ())
+    return warnings

--- a/frontend/src/api/configs.ts
+++ b/frontend/src/api/configs.ts
@@ -32,6 +32,11 @@ interface UploadResponse {
   filename: string;
 }
 
+interface SyncResponse {
+  yaml: string;
+  warnings: string[];
+}
+
 export function fetchDefaultConfig() {
   return apiFetch<DefaultConfigResponse>("/configs/default");
 }
@@ -58,6 +63,13 @@ export function exportConfig(config: NormalizedConfig) {
   return apiFetch<ExportResponse>("/configs/export", {
     method: "POST",
     body: JSON.stringify({ config }),
+  });
+}
+
+export function syncConfig(config: NormalizedConfig, originalYaml: string) {
+  return apiFetch<SyncResponse>("/configs/sync", {
+    method: "POST",
+    body: JSON.stringify({ config, original_yaml: originalYaml }),
   });
 }
 

--- a/frontend/src/components/modals/YAMLEditorModal.tsx
+++ b/frontend/src/components/modals/YAMLEditorModal.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, lazy, Suspense } from "react";
 import { useConfigStore } from "@/stores/configStore";
-import { parseYaml } from "@/api/configs";
+import { parseYaml, syncConfig } from "@/api/configs";
 import { Button } from "@/components/ui/Button";
 import { toast } from "sonner";
 
@@ -12,21 +12,47 @@ interface Props {
 }
 
 export function YAMLEditorModal({ open, onClose }: Props) {
-  const { originalYaml, setConfig } = useConfigStore();
+  const { config, originalYaml, setConfig } = useConfigStore();
   const [value, setValue] = useState("");
+  const [syncing, setSyncing] = useState(false);
   const [saving, setSaving] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const [syncError, setSyncError] = useState<string | null>(null);
+  const [syncWarnings, setSyncWarnings] = useState<string[]>([]);
 
-  // Show the raw YAML from disk when the modal opens.
+  // Sync YAML when modal opens: call /api/configs/sync to merge live config
+  // into the original YAML (preserving comments and unit strings).
   useEffect(() => {
     if (!open) return;
-    setError(null);
+    setSyncError(null);
+    setSyncWarnings([]);
 
-    if (originalYaml) {
-      setValue(originalYaml);
-    } else {
-      setError("No configuration available to edit");
+    if (!originalYaml) {
+      setSyncError("No configuration available to edit.");
+      return;
     }
+
+    if (config.nodes.length === 0) {
+      // Empty config — just show the raw original YAML.
+      setValue(originalYaml);
+      return;
+    }
+
+    setSyncing(true);
+    syncConfig(config, originalYaml)
+      .then((resp) => {
+        setValue(resp.yaml);
+        setSyncWarnings(resp.warnings ?? []);
+      })
+      .catch((err) => {
+        const msg = err instanceof Error ? err.message : String(err);
+        setSyncError(
+          `Failed to sync YAML with current configuration: ${msg}. ` +
+            "The displayed YAML may not match the live config — close and reopen, " +
+            "or fix the configuration first.",
+        );
+        // Do NOT fall back to stale originalYaml — saving it would overwrite GUI edits.
+      })
+      .finally(() => setSyncing(false));
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open]);
 
@@ -36,6 +62,7 @@ export function YAMLEditorModal({ open, onClose }: Props) {
     setSaving(true);
     try {
       const resp = await parseYaml(value);
+      // Update both config and originalYaml so next open stays fresh.
       setConfig(resp.config, undefined, value);
       toast.success("YAML config updated");
       onClose();
@@ -47,6 +74,8 @@ export function YAMLEditorModal({ open, onClose }: Props) {
       setSaving(false);
     }
   };
+
+  const canSave = !saving && !syncing && !syncError;
 
   return (
     <div
@@ -72,10 +101,29 @@ export function YAMLEditorModal({ open, onClose }: Props) {
           </Button>
         </div>
 
+        {syncWarnings.length > 0 && (
+          <div
+            id="sync-warnings-banner"
+            className="px-4 py-2 text-xs bg-yellow-50 dark:bg-yellow-900/20 border-b border-yellow-200 dark:border-yellow-800 text-yellow-800 dark:text-yellow-300 space-y-0.5"
+          >
+            <p className="font-semibold">Sync warnings (non-blocking):</p>
+            {syncWarnings.map((w, i) => (
+              <p key={i}>{w}</p>
+            ))}
+          </div>
+        )}
+
         <div className="flex-1 overflow-hidden">
-          {error ? (
-            <div className="flex items-center justify-center h-full text-destructive p-4 text-center">
-              {error}
+          {syncing ? (
+            <div className="flex items-center justify-center h-full text-muted-foreground">
+              Syncing YAML with current configuration…
+            </div>
+          ) : syncError ? (
+            <div
+              id="sync-error-message"
+              className="flex items-center justify-center h-full text-destructive p-4 text-center text-sm"
+            >
+              {syncError}
             </div>
           ) : (
             <Suspense
@@ -111,11 +159,11 @@ export function YAMLEditorModal({ open, onClose }: Props) {
           <Button
             id="save-config-yaml-edit-btn"
             onClick={handleSave}
-            disabled={saving}
+            disabled={!canSave}
             variant="primary"
             size="sm"
           >
-            {saving ? "Saving..." : "Save"}
+            {saving ? "Saving…" : "Save"}
           </Button>
         </div>
       </div>

--- a/frontend/src/components/modals/YAMLEditorModal.tsx
+++ b/frontend/src/components/modals/YAMLEditorModal.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, lazy, Suspense } from "react";
 import { useConfigStore } from "@/stores/configStore";
-import { parseYaml, exportConfig } from "@/api/configs";
+import { parseYaml } from "@/api/configs";
 import { Button } from "@/components/ui/Button";
 import { toast } from "sonner";
 
@@ -12,34 +12,17 @@ interface Props {
 }
 
 export function YAMLEditorModal({ open, onClose }: Props) {
-  const { config, originalYaml, setConfig } = useConfigStore();
+  const { originalYaml, setConfig } = useConfigStore();
   const [value, setValue] = useState("");
-  const [fetching, setFetching] = useState(false);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  // Fetch YAML when modal opens – depends only on `open` so edits
-  // inside the editor are never overwritten by a re-render.
+  // Show the raw YAML from disk when the modal opens.
   useEffect(() => {
     if (!open) return;
     setError(null);
 
-    if (config.nodes.length > 0) {
-      setFetching(true);
-      exportConfig(config)
-        .then((resp) => setValue(resp.yaml))
-        .catch((err) => {
-          // Fallback to the raw YAML stored at load time
-          if (originalYaml) {
-            setValue(originalYaml);
-          } else {
-            setError(
-              `Failed to load YAML: ${err instanceof Error ? err.message : String(err)}`,
-            );
-          }
-        })
-        .finally(() => setFetching(false));
-    } else if (originalYaml) {
+    if (originalYaml) {
       setValue(originalYaml);
     } else {
       setError("No configuration available to edit");
@@ -90,11 +73,7 @@ export function YAMLEditorModal({ open, onClose }: Props) {
         </div>
 
         <div className="flex-1 overflow-hidden">
-          {fetching ? (
-            <div className="flex items-center justify-center h-full text-muted-foreground">
-              Loading YAML...
-            </div>
-          ) : error ? (
+          {error ? (
             <div className="flex items-center justify-center h-full text-destructive p-4 text-center">
               {error}
             </div>
@@ -132,7 +111,7 @@ export function YAMLEditorModal({ open, onClose }: Props) {
           <Button
             id="save-config-yaml-edit-btn"
             onClick={handleSave}
-            disabled={saving || fetching}
+            disabled={saving}
             variant="primary"
             size="sm"
           >

--- a/frontend/src/components/results/ResultsTabs.tsx
+++ b/frontend/src/components/results/ResultsTabs.tsx
@@ -30,6 +30,8 @@ export function ResultsTabs() {
   const theme = useThemeStore((s) => s.theme);
   const activeTab = useResultsTabStore((s) => s.activeTab);
   const setActiveTab = useResultsTabStore((s) => s.setActiveTab);
+  /** Resolved tab for UI: explicit choice, else Sankey when results exist, else Plots. */
+  const displayTab = activeTab ?? (results ? "Sankey" : "Plots");
   const [plugins, setPlugins] = useState<PluginMeta[]>([]);
   const [pluginData, setPluginData] = useState<Record<string, PluginRenderData>>({});
   const [pluginLoading, setPluginLoading] = useState<Record<string, boolean>>({});
@@ -45,11 +47,6 @@ export function ResultsTabs() {
       .then(setPlugins)
       .catch(() => setPlugins([]));
   }, [results, progress]);
-
-  // Switch to Sankey automatically when simulation results arrive.
-  useEffect(() => {
-    if (results) setActiveTab("Sankey");
-  }, [results]);
 
   // If the error clears while viewing the Error tab, move back to a safe tab.
   useEffect(() => {
@@ -130,7 +127,7 @@ export function ResultsTabs() {
             onClick={() => setActiveTab(tab)}
             variant="tab"
             size="tab"
-            data-active={activeTab === tab}
+            data-active={displayTab === tab}
           >
             {tab}
           </Button>
@@ -138,23 +135,23 @@ export function ResultsTabs() {
       </div>
 
       <div className="p-4">
-        {activeTab === "Plots" && data && <PlotsTab data={data} />}
-        {activeTab === "Sankey" && results && (
+        {displayTab === "Plots" && data && <PlotsTab data={data} />}
+        {displayTab === "Sankey" && results && (
           <Suspense fallback={<p className="text-sm text-muted-foreground">Loading...</p>}>
             <SankeyTab results={results} />
           </Suspense>
         )}
-        {activeTab === "Thermo" && results && (
+        {displayTab === "Thermo" && results && (
           <Suspense fallback={<p className="text-sm text-muted-foreground">Loading...</p>}>
             <ThermoReportTab results={results} />
           </Suspense>
         )}
-        {activeTab === "Summary" && results && <SummaryTab results={results} />}
-        {activeTab === ERROR_TAB_LABEL && <ErrorTab error={error} />}
+        {displayTab === "Summary" && results && <SummaryTab results={results} />}
+        {displayTab === ERROR_TAB_LABEL && <ErrorTab error={error} />}
 
         {/* Dynamic plugin tabs */}
         {plugins.map((plugin) => {
-          if (activeTab !== plugin.label) return null;
+          if (displayTab !== plugin.label) return null;
           const pData = pluginData[plugin.id];
           const loading = pluginLoading[plugin.id];
           if (loading) {

--- a/frontend/src/stores/resultsTabStore.ts
+++ b/frontend/src/stores/resultsTabStore.ts
@@ -1,11 +1,12 @@
 import { create } from "zustand";
 
 interface ResultsTabState {
-  activeTab: string;
+  /** null = no explicit choice: show Plots while streaming, Sankey once final results exist. */
+  activeTab: string | null;
   setActiveTab: (tab: string) => void;
 }
 
 export const useResultsTabStore = create<ResultsTabState>((set) => ({
-  activeTab: "Plots",
+  activeTab: null,
   setActiveTab: (tab) => set({ activeTab: tab }),
 }));

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -399,3 +399,301 @@ class TestSimulationRoutes:
         assert resp.json()["detail"] == "time_step must be > 0"
         assert worker_called is False
         simulation_routes._simulations.clear()
+
+
+# ---------------------------------------------------------------------------
+# POST /api/configs/sync
+# ---------------------------------------------------------------------------
+
+_SYNC_YAML = (
+    "phases:\n"
+    "  gas:\n"
+    "    mechanism: gri30.yaml\n"
+    "network:\n"
+    "  - id: inlet\n"
+    "    Reservoir:\n"
+    "      temperature: 298.15 K\n"
+    "      pressure: 1 atm\n"
+    "      composition: CH4:1\n"
+    "  - id: pfr\n"
+    "    IdealGasReactor:\n"
+    "      volume: 0.001\n"
+    "  - id: feed\n"
+    "    MassFlowController:\n"
+    "      mass_flow_rate: 10 kg/h\n"
+    "    source: inlet\n"
+    "    target: pfr\n"
+)
+
+_SYNC_CONFIG = {
+    "nodes": [
+        {
+            "id": "inlet",
+            "type": "Reservoir",
+            "properties": {
+                "temperature": 298.15,
+                "pressure": 101325.0,
+                "composition": "CH4:1",
+            },
+        },
+        {"id": "pfr", "type": "IdealGasReactor", "properties": {"volume": 0.001}},
+    ],
+    "connections": [
+        {
+            "id": "feed",
+            "type": "MassFlowController",
+            "source": "inlet",
+            "target": "pfr",
+            "properties": {"mass_flow_rate": 10 / 3600},
+        },
+    ],
+}
+
+
+class TestSyncConfigRoute:
+    @pytest.mark.asyncio
+    async def test_sync_returns_merged_yaml_with_units_preserved(self):
+        """Assert /api/configs/sync returns 200 with original unit strings.
+
+        Checks that 'yaml' contains '1 atm', '298.15 K', 'kg/h' verbatim
+        and that 'warnings' is an empty list when no values changed.
+        """
+        async with _make_client() as client:
+            resp = await client.post(
+                "/api/configs/sync",
+                json={"config": _SYNC_CONFIG, "original_yaml": _SYNC_YAML},
+            )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "yaml" in body
+        assert body["warnings"] == []
+        # Original unit strings preserved
+        assert "1 atm" in body["yaml"]
+        assert "298.15 K" in body["yaml"]
+        assert "kg/h" in body["yaml"]
+
+    @pytest.mark.asyncio
+    async def test_sync_updates_changed_pressure_in_original_unit(self):
+        """Assert doubled pressure appears as '2 atm', not as a bare SI float.
+
+        Original has 'pressure: 1 atm'; config sets pressure to 202650 Pa.
+        Merged YAML must contain '2 atm' and not '202650'.
+        """
+        config = {
+            "nodes": [
+                {
+                    "id": "inlet",
+                    "type": "Reservoir",
+                    "properties": {
+                        "temperature": 298.15,
+                        "pressure": 202650.0,
+                        "composition": "CH4:1",
+                    },
+                },
+                {
+                    "id": "pfr",
+                    "type": "IdealGasReactor",
+                    "properties": {"volume": 0.001},
+                },
+            ],
+            "connections": [
+                {
+                    "id": "feed",
+                    "type": "MassFlowController",
+                    "source": "inlet",
+                    "target": "pfr",
+                    "properties": {"mass_flow_rate": 10 / 3600},
+                },
+            ],
+        }
+        async with _make_client() as client:
+            resp = await client.post(
+                "/api/configs/sync",
+                json={"config": config, "original_yaml": _SYNC_YAML},
+            )
+        assert resp.status_code == 200
+        yaml_out = resp.json()["yaml"]
+        assert "2 atm" in yaml_out
+        assert "202650" not in yaml_out
+
+    @pytest.mark.asyncio
+    async def test_sync_filters_synthesized_nodes(self):
+        """Assert synthesized nodes are absent from the merged YAML.
+
+        Config contains pfr_ambient with __synthesized=True.
+        Response YAML must not contain 'pfr_ambient'.
+        """
+        config = {
+            "nodes": [
+                {
+                    "id": "inlet",
+                    "type": "Reservoir",
+                    "properties": {
+                        "temperature": 298.15,
+                        "pressure": 101325.0,
+                        "composition": "CH4:1",
+                    },
+                },
+                {
+                    "id": "pfr",
+                    "type": "IdealGasReactor",
+                    "properties": {"volume": 0.001},
+                },
+                {
+                    "id": "pfr_ambient",
+                    "type": "Reservoir",
+                    "properties": {"temperature": 298.15},
+                    "__synthesized": True,
+                },
+            ],
+            "connections": [
+                {
+                    "id": "feed",
+                    "type": "MassFlowController",
+                    "source": "inlet",
+                    "target": "pfr",
+                    "properties": {"mass_flow_rate": 10 / 3600},
+                },
+            ],
+        }
+        async with _make_client() as client:
+            resp = await client.post(
+                "/api/configs/sync",
+                json={"config": config, "original_yaml": _SYNC_YAML},
+            )
+        assert resp.status_code == 200
+        assert "pfr_ambient" not in resp.json()["yaml"]
+
+    @pytest.mark.asyncio
+    async def test_sync_keeps_gui_added_node(self):
+        """Assert GUI-added node (no __synthesized flag) appears in merged YAML.
+
+        Config adds 'new_gui_node' which is absent from original_yaml.
+        Response YAML must contain 'new_gui_node'.
+        """
+        config = {
+            "nodes": [
+                {
+                    "id": "inlet",
+                    "type": "Reservoir",
+                    "properties": {
+                        "temperature": 298.15,
+                        "pressure": 101325.0,
+                        "composition": "CH4:1",
+                    },
+                },
+                {
+                    "id": "pfr",
+                    "type": "IdealGasReactor",
+                    "properties": {"volume": 0.001},
+                },
+                {
+                    "id": "new_gui_node",
+                    "type": "IdealGasReactor",
+                    "properties": {"volume": 0.002},
+                },
+            ],
+            "connections": [
+                {
+                    "id": "feed",
+                    "type": "MassFlowController",
+                    "source": "inlet",
+                    "target": "pfr",
+                    "properties": {"mass_flow_rate": 10 / 3600},
+                },
+            ],
+        }
+        async with _make_client() as client:
+            resp = await client.post(
+                "/api/configs/sync",
+                json={"config": config, "original_yaml": _SYNC_YAML},
+            )
+        assert resp.status_code == 200
+        assert "new_gui_node" in resp.json()["yaml"]
+
+    @pytest.mark.asyncio
+    async def test_sync_returns_422_on_inline_ports(self):
+        """Assert inline port shortcuts in original_yaml return HTTP 422.
+
+        YAML with 'inlet:' on a node triggers the inline-port guard.
+        Response detail must mention 'inline'.
+        """
+        yaml_with_ports = (
+            "phases:\n  gas:\n    mechanism: gri30.yaml\n"
+            "network:\n"
+            "  - id: tube\n"
+            "    DesignPFR:\n"
+            "      length: 1.0\n"
+            "      inlet:\n"
+            "        from: feed\n"
+            "        mass_flow_rate: 0.001\n"
+        )
+        config = {
+            "nodes": [
+                {"id": "tube", "type": "DesignPFR", "properties": {"length": 1.0}}
+            ],
+            "connections": [],
+        }
+        async with _make_client() as client:
+            resp = await client.post(
+                "/api/configs/sync",
+                json={"config": config, "original_yaml": yaml_with_ports},
+            )
+        assert resp.status_code == 422
+        assert "inline" in resp.json()["detail"].lower()
+
+    @pytest.mark.asyncio
+    async def test_sync_returns_422_on_shape_conflict(self):
+        """Assert network: -> stages: shape change returns HTTP 422.
+
+        Original uses network:; config has a non-default group implying stages:.
+        Response detail must mention 'shape'.
+        """
+        config_with_stages = {
+            "nodes": [
+                {
+                    **{
+                        "id": "inlet",
+                        "type": "Reservoir",
+                        "properties": {
+                            "temperature": 298.15,
+                            "pressure": 101325.0,
+                            "composition": "CH4:1",
+                        },
+                    },
+                    "group": "s1",
+                },
+            ],
+            "connections": [],
+            "groups": {
+                "s1": {
+                    "mechanism": "gri30.yaml",
+                    "solve": "equilibrate",
+                    "stage_order": 0,
+                },
+            },
+        }
+        async with _make_client() as client:
+            resp = await client.post(
+                "/api/configs/sync",
+                json={"config": config_with_stages, "original_yaml": _SYNC_YAML},
+            )
+        assert resp.status_code == 422
+        assert "shape" in resp.json()["detail"].lower()
+
+    @pytest.mark.asyncio
+    async def test_sync_returns_422_on_invalid_original_yaml(self):
+        """Assert malformed original_yaml returns a non-200 status.
+
+        An unclosed bracket causes a YAML parse error.
+        Response status must be 422 or 500.
+        """
+        async with _make_client() as client:
+            resp = await client.post(
+                "/api/configs/sync",
+                json={
+                    "config": _SYNC_CONFIG,
+                    "original_yaml": "invalid: yaml: [unclosed bracket",
+                },
+            )
+        assert resp.status_code in (422, 500)

--- a/tests/test_yaml_comment_system.py
+++ b/tests/test_yaml_comment_system.py
@@ -533,5 +533,320 @@ nodes:
         assert loaded_data["nodes"][0]["IdealGasReactor"]["temperature"] == 1000.0
 
 
+class TestMergeConfigIntoYaml:
+    """Tests for merge_config_into_yaml: full sync pipeline semantics."""
+
+    def _make_config(self, nodes, connections=None):
+        """Build a minimal NormalizedConfig-shaped dict."""
+        return {
+            "nodes": nodes,
+            "connections": connections or [],
+        }
+
+    def _node(self, nid, kind, props):
+        return {"id": nid, "type": kind, "properties": props}
+
+    def _conn(self, cid, kind, source, target, props=None):
+        return {
+            "id": cid,
+            "type": kind,
+            "source": source,
+            "target": target,
+            "properties": props or {},
+        }
+
+    def test_merge_preserves_header_and_inline_comments(self):
+        """Asserts that header comments and EOL comments survive a no-op merge.
+
+        The original YAML has a # header comment and inline # comments on
+        temperature and pressure values. After merge_config_into_yaml with
+        the same values, those comment strings are present in the output.
+        """
+        from boulder.config import merge_config_into_yaml
+
+        yaml = (
+            "# Header comment\n"
+            "phases:\n"
+            "  gas:\n"
+            "    mechanism: gri30.yaml\n"
+            "network:\n"
+            "  - id: inlet\n"
+            "    Reservoir:\n"
+            "      temperature: 300.0  # K\n"
+            "      pressure: 101325.0  # Pa\n"
+        )
+        config = self._make_config(
+            [
+                self._node(
+                    "inlet", "Reservoir", {"temperature": 300.0, "pressure": 101325.0}
+                ),
+            ]
+        )
+        result, warnings = merge_config_into_yaml(config, yaml)
+        assert "# Header comment" in result
+        assert "# K" in result
+        assert "# Pa" in result
+
+    def test_merge_drops_synthesized_satellites(self):
+        """Asserts that nodes/connections tagged __synthesized=True are absent from output.
+
+        Config contains two nodes: one authored (inlet) and one synthesized
+        (pfr_ambient). The merged YAML must not contain 'pfr_ambient'.
+        """
+        from boulder.config import merge_config_into_yaml
+
+        yaml = (
+            "phases:\n  gas:\n    mechanism: gri30.yaml\n"
+            "network:\n"
+            "  - id: inlet\n"
+            "    Reservoir:\n"
+            "      temperature: 300.0\n"
+        )
+        config = self._make_config(
+            [
+                self._node("inlet", "Reservoir", {"temperature": 300.0}),
+                {
+                    **self._node("pfr_ambient", "Reservoir", {"temperature": 298.15}),
+                    "__synthesized": True,
+                },
+            ]
+        )
+        result, _ = merge_config_into_yaml(config, yaml)
+        assert "pfr_ambient" not in result
+        assert "inlet" in result
+
+    def test_merge_appends_new_user_node(self):
+        """Asserts that a GUI-added node (not in originalYaml, no __synthesized) is appended.
+
+        Original has 'inlet'; config adds 'reactor1'. Output must contain both.
+        """
+        from boulder.config import merge_config_into_yaml
+
+        yaml = (
+            "phases:\n  gas:\n    mechanism: gri30.yaml\n"
+            "network:\n"
+            "  - id: inlet\n"
+            "    Reservoir:\n"
+            "      temperature: 300.0\n"
+        )
+        config = self._make_config(
+            [
+                self._node("inlet", "Reservoir", {"temperature": 300.0}),
+                self._node("reactor1", "IdealGasReactor", {"volume": 0.001}),
+            ]
+        )
+        result, _ = merge_config_into_yaml(config, yaml)
+        assert "inlet" in result
+        assert "reactor1" in result
+        assert "IdealGasReactor" in result
+
+    def test_merge_removes_deleted_node(self):
+        """Asserts that a node absent from config is removed from the merged YAML.
+
+        Original has 'inlet' and 'r2'; config omits 'r2'. Output must not contain 'r2'.
+        """
+        from boulder.config import merge_config_into_yaml
+
+        yaml = (
+            "phases:\n  gas:\n    mechanism: gri30.yaml\n"
+            "network:\n"
+            "  - id: inlet\n"
+            "    Reservoir:\n"
+            "      temperature: 300.0\n"
+            "  - id: r2\n"
+            "    IdealGasReactor:\n"
+            "      volume: 0.001\n"
+        )
+        config = self._make_config(
+            [
+                self._node("inlet", "Reservoir", {"temperature": 300.0}),
+            ]
+        )
+        result, _ = merge_config_into_yaml(config, yaml)
+        assert "inlet" in result
+        assert "r2" not in result
+
+    def test_merge_adds_new_property_on_existing_node(self):
+        """Asserts that a property added via the GUI appears in the merged YAML.
+
+        Original Reservoir has only temperature. Config adds composition.
+        Output must contain 'composition'.
+        """
+        from boulder.config import merge_config_into_yaml
+
+        yaml = (
+            "phases:\n  gas:\n    mechanism: gri30.yaml\n"
+            "network:\n"
+            "  - id: inlet\n"
+            "    Reservoir:\n"
+            "      temperature: 300.0\n"
+        )
+        config = self._make_config(
+            [
+                self._node(
+                    "inlet",
+                    "Reservoir",
+                    {
+                        "temperature": 300.0,
+                        "composition": "CH4:1",
+                    },
+                ),
+            ]
+        )
+        result, _ = merge_config_into_yaml(config, yaml)
+        assert "composition" in result
+        assert "CH4:1" in result
+
+    def test_merge_removes_deleted_property_from_component_block(self):
+        """Asserts that a property removed via the GUI is absent from the merged YAML.
+
+        Original Reservoir has temperature and composition. Config drops composition.
+        Output must not contain 'composition'.
+        """
+        from boulder.config import merge_config_into_yaml
+
+        yaml = (
+            "phases:\n  gas:\n    mechanism: gri30.yaml\n"
+            "network:\n"
+            "  - id: inlet\n"
+            "    Reservoir:\n"
+            "      temperature: 300.0\n"
+            '      composition: "CH4:1"\n'
+        )
+        config = self._make_config(
+            [
+                self._node("inlet", "Reservoir", {"temperature": 300.0}),
+            ]
+        )
+        result, _ = merge_config_into_yaml(config, yaml)
+        assert "temperature" in result
+        assert "composition" not in result
+
+    def test_merge_handles_type_change(self):
+        """Asserts that changing a node's type removes the old kind key and adds the new one.
+
+        Original has IdealGasReactor; config has same id with
+        IdealGasConstPressureReactor. Output must contain only the new kind key.
+        """
+        from boulder.config import merge_config_into_yaml
+
+        yaml = (
+            "phases:\n  gas:\n    mechanism: gri30.yaml\n"
+            "network:\n"
+            "  - id: r1\n"
+            "    IdealGasReactor:\n"
+            "      volume: 0.001\n"
+        )
+        config = self._make_config(
+            [
+                self._node("r1", "IdealGasConstPressureReactor", {"volume": 0.001}),
+            ]
+        )
+        result, _ = merge_config_into_yaml(config, yaml)
+        assert "IdealGasConstPressureReactor" in result
+        assert "IdealGasReactor:" not in result
+
+    def test_merge_multi_stage_preserves_stages_shape(self):
+        """Asserts that a staged original YAML keeps its stages: shape after merge.
+
+        Original YAML uses stages: + a per-stage list. Merged output must still
+        contain 'stages:' and NOT introduce a top-level 'network:' key.
+        """
+        from boulder.config import merge_config_into_yaml
+
+        yaml = (
+            "phases:\n  gas:\n    mechanism: gri30.yaml\n"
+            "stages:\n"
+            "  s1:\n"
+            "    mechanism: gri30.yaml\n"
+            "    solve: equilibrate\n"
+            "s1:\n"
+            "  - id: inlet\n"
+            "    Reservoir:\n"
+            "      temperature: 300.0\n"
+        )
+        # Build a config that produces a staged STONE output.
+        config = {
+            "nodes": [
+                {
+                    **self._node("inlet", "Reservoir", {"temperature": 300.0}),
+                    "group": "s1",
+                },
+            ],
+            "connections": [],
+            "groups": {
+                "s1": {
+                    "mechanism": "gri30.yaml",
+                    "solve": "equilibrate",
+                    "stage_order": 0,
+                },
+            },
+        }
+        result, _ = merge_config_into_yaml(config, yaml)
+        assert "stages:" in result
+        assert "network:" not in result
+
+    def test_merge_raises_on_inline_ports(self):
+        """Asserts that a YAML with inline port shortcuts raises ValueError.
+
+        Inline ports (inlet: on a node) are not supported by live sync.
+        merge_config_into_yaml must raise ValueError with an explanatory message.
+        """
+        from boulder.config import merge_config_into_yaml
+
+        yaml = (
+            "phases:\n  gas:\n    mechanism: gri30.yaml\n"
+            "network:\n"
+            "  - id: tube\n"
+            "    DesignPFR:\n"
+            "      length: 1.0\n"
+            "      inlet:\n"
+            "        from: feed\n"
+            "        mass_flow_rate: 0.001\n"
+        )
+        config = self._make_config(
+            [
+                self._node("feed", "Reservoir", {"temperature": 300.0}),
+                self._node("tube", "DesignPFR", {"length": 1.0}),
+            ]
+        )
+        with pytest.raises(ValueError, match="[Ii]nline port"):
+            merge_config_into_yaml(config, yaml)
+
+    def test_merge_raises_on_shape_conflict(self):
+        """Asserts that switching from network: to stages: raises ValueError.
+
+        Original YAML uses network:; the config has a non-default group
+        implying stages:. merge_config_into_yaml must raise ValueError.
+        """
+        from boulder.config import merge_config_into_yaml
+
+        yaml = (
+            "phases:\n  gas:\n    mechanism: gri30.yaml\n"
+            "network:\n"
+            "  - id: inlet\n"
+            "    Reservoir:\n"
+            "      temperature: 300.0\n"
+        )
+        config = {
+            "nodes": [
+                {
+                    **self._node("inlet", "Reservoir", {"temperature": 300.0}),
+                    "group": "s1",
+                },
+            ],
+            "connections": [],
+            "groups": {
+                "s1": {
+                    "mechanism": "gri30.yaml",
+                    "solve": "equilibrate",
+                    "stage_order": 0,
+                },
+            },
+        }
+        with pytest.raises(ValueError, match="[Ss]hape conflict"):
+            merge_config_into_yaml(config, yaml)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/test_yaml_unit_map.py
+++ b/tests/test_yaml_unit_map.py
@@ -1,0 +1,236 @@
+"""Tests for boulder/yaml_unit_map.py.
+
+Covers build_unit_map and apply_unit_map_inplace: unit-bearing scalar
+detection, verbatim preservation when unchanged, Pint inverse conversion
+when values differ, and correct handling of offset units (degC/degF).
+"""
+
+import math
+
+import pytest
+
+from boulder.config import load_yaml_string_with_comments
+from boulder.yaml_unit_map import apply_unit_map_inplace, build_unit_map
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _load(yaml_str: str):
+    return load_yaml_string_with_comments(yaml_str)
+
+
+def _dump(tree) -> str:
+    from boulder.config import yaml_to_string_with_comments
+
+    return yaml_to_string_with_comments(tree)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestBuildUnitMap:
+    def test_records_temperature_pressure_flow(self):
+        """Asserts that temperature, pressure, and mass_flow_rate with unit strings
+        are all recorded in the unit_map with correct original text and SI value.
+
+        Checks:
+        - ("inlet", ("Reservoir", "temperature")) -> text "298.15 K", si ~298.15
+        - ("inlet", ("Reservoir", "pressure")) -> text "1 atm", si ~101325
+        - ("feed_to_pfr", ("MassFlowController", "mass_flow_rate")) -> text "10 kg/h",
+          si ~0.002777...
+        """
+        yaml = (
+            "network:\n"
+            "  - id: inlet\n"
+            "    Reservoir:\n"
+            "      temperature: 298.15 K\n"
+            "      pressure: 1 atm\n"
+            "  - id: feed_to_pfr\n"
+            "    MassFlowController:\n"
+            "      mass_flow_rate: 10 kg/h\n"
+            "    source: inlet\n"
+            "    target: pfr\n"
+        )
+        tree = _load(yaml)
+        umap = build_unit_map(tree)
+
+        temp_key = ("inlet", ("Reservoir", "temperature"))
+        assert temp_key in umap, "temperature entry missing"
+        orig_text, _, si_val, _ = umap[temp_key]
+        assert orig_text == "298.15 K"
+        assert math.isclose(si_val, 298.15, rel_tol=1e-6)
+
+        press_key = ("inlet", ("Reservoir", "pressure"))
+        assert press_key in umap, "pressure entry missing"
+        orig_text, _, si_val, _ = umap[press_key]
+        assert orig_text == "1 atm"
+        assert math.isclose(si_val, 101325.0, rel_tol=1e-3)
+
+        flow_key = ("feed_to_pfr", ("MassFlowController", "mass_flow_rate"))
+        assert flow_key in umap, "mass_flow_rate entry missing"
+        orig_text, _, si_val, _ = umap[flow_key]
+        assert orig_text == "10 kg/h"
+        assert math.isclose(si_val, 10 / 3600, rel_tol=1e-6)
+
+    def test_ignores_bare_numbers(self):
+        """Asserts that plain numeric values (no unit string) are not recorded.
+
+        temperature: 300.0 with no unit should not appear in the unit_map.
+        """
+        yaml = (
+            "network:\n"
+            "  - id: r1\n"
+            "    Reservoir:\n"
+            "      temperature: 300.0\n"
+            "      pressure: 101325\n"
+        )
+        tree = _load(yaml)
+        umap = build_unit_map(tree)
+        assert ("r1", ("Reservoir", "temperature")) not in umap
+        assert ("r1", ("Reservoir", "pressure")) not in umap
+
+    def test_ignores_non_unit_strings(self):
+        """Asserts that plain string values like composition are not recorded."""
+        yaml = (
+            "network:\n"
+            '  - id: r1\n'
+            '    Reservoir:\n'
+            '      composition: "CH4:1"\n'
+        )
+        tree = _load(yaml)
+        umap = build_unit_map(tree)
+        assert len(umap) == 0
+
+
+class TestApplyUnitMapInplace:
+    def test_preserves_unchanged_value_verbatim(self):
+        """Asserts that when the SI value matches the original, the original text
+        is restored verbatim (no reformatting of scientific notation etc.).
+
+        Original: pressure: 1 atm (SI = 101325 Pa). Config pressure = 101325.
+        Output YAML must contain '1 atm'.
+        """
+        yaml = (
+            "network:\n"
+            "  - id: inlet\n"
+            "    Reservoir:\n"
+            "      pressure: 1 atm\n"
+        )
+        tree = _load(yaml)
+        umap = build_unit_map(tree)
+        config = {
+            "nodes": [{"id": "inlet", "type": "Reservoir",
+                       "properties": {"pressure": 101325.0}}],
+            "connections": [],
+        }
+        warnings = apply_unit_map_inplace(tree, umap, config)
+        out = _dump(tree)
+        assert "1 atm" in out
+        assert warnings == []
+
+    def test_converts_changed_pressure_to_original_unit(self):
+        """Asserts that pressure doubled from 1 atm to 2 atm (202650 Pa in config)
+        is written as '2 atm' in the merged YAML, not as a bare SI float.
+        """
+        yaml = (
+            "network:\n"
+            "  - id: inlet\n"
+            "    Reservoir:\n"
+            "      pressure: 1 atm\n"
+        )
+        tree = _load(yaml)
+        umap = build_unit_map(tree)
+        config = {
+            "nodes": [{"id": "inlet", "type": "Reservoir",
+                       "properties": {"pressure": 202650.0}}],
+            "connections": [],
+        }
+        apply_unit_map_inplace(tree, umap, config)
+        out = _dump(tree)
+        assert "2 atm" in out
+        assert "202650" not in out
+
+    def test_handles_kg_per_hour(self):
+        """Asserts that mass_flow_rate with original unit kg/h is correctly
+        round-tripped. Original 10 kg/h changed to 5 kg/h (half the SI value).
+
+        Output must contain '5 kg/h' (or equivalent with :g formatting).
+        """
+        yaml = (
+            "network:\n"
+            "  - id: mfc\n"
+            "    MassFlowController:\n"
+            "      mass_flow_rate: 10 kg/h\n"
+            "    source: a\n"
+            "    target: b\n"
+        )
+        tree = _load(yaml)
+        umap = build_unit_map(tree)
+        half_si = 5 / 3600  # 5 kg/h in kg/s
+        config = {
+            "nodes": [],
+            "connections": [{"id": "mfc", "type": "MassFlowController",
+                              "source": "a", "target": "b",
+                              "properties": {"mass_flow_rate": half_si}}],
+        }
+        apply_unit_map_inplace(tree, umap, config)
+        out = _dump(tree)
+        assert "kg/h" in out
+        assert "5" in out
+
+    def test_handles_celsius_without_offset_error(self):
+        """Asserts that temperature in degC round-trips correctly without raising
+        Pint's OffsetUnitCalculusError.
+
+        Original: 500 degC (773.15 K). Config changed to 673.15 K (400 degC).
+        Output must contain '400' and 'degC'; no exception raised.
+        """
+        yaml = (
+            "network:\n"
+            "  - id: r1\n"
+            "    Reservoir:\n"
+            "      temperature: 500 degC\n"
+        )
+        tree = _load(yaml)
+        umap = build_unit_map(tree)
+        config = {
+            "nodes": [{"id": "r1", "type": "Reservoir",
+                       "properties": {"temperature": 673.15}}],  # 400 °C
+            "connections": [],
+        }
+        warnings = apply_unit_map_inplace(tree, umap, config)
+        out = _dump(tree)
+        assert "degC" in out
+        assert "400" in out
+        assert warnings == []
+
+    def test_emits_warning_on_pint_failure_and_leaves_si(self):
+        """Asserts that when Pint cannot back-convert (malformed unit 'xyzzy'),
+        a warning string is returned and the scalar is left as a bare SI float.
+        """
+        from boulder.yaml_unit_map import UnitMap
+
+        yaml = (
+            "network:\n"
+            "  - id: r1\n"
+            "    Reservoir:\n"
+            "      pressure: 1 atm\n"
+        )
+        tree = _load(yaml)
+        # Inject a fake unit_map entry with a bad unit that Pint can't use.
+        umap: UnitMap = {
+            ("r1", ("Reservoir", "pressure")): ("1 xyzzy", "xyzzy", 101325.0, str),
+        }
+        config = {
+            "nodes": [{"id": "r1", "type": "Reservoir",
+                       "properties": {"pressure": 202650.0}}],
+            "connections": [],
+        }
+        warnings = apply_unit_map_inplace(tree, umap, config)
+        assert len(warnings) == 1
+        assert "xyzzy" in warnings[0] or "back-conversion" in warnings[0].lower()


### PR DESCRIPTION

- [x] Fixes composite unfold collision (child reactors created from parent nodes) when saving from the YAML modal or re-parsing after sync: `validate_config` drops `__synthesized`, so the merge path now derives synthesized IDs by re-normalizing the original YAML and diffing against authored list IDs.
- [x] Merged output no longer injects top-level keys that were absent on disk (e.g. empty `settings` / `output` from `convert_to_stone_format`).
- [x] Property merge skips normalization-only defaults (e.g. propagated `pressure`) while still adding GUI-only properties that differ from a fresh normalize of the original file.
- [x] Network list order follows the original YAML; GUI-added nodes/connections are appended at the end.
- [x] Dump uses sequence indentation inferred from the source file so list layout matches the on-disk style.

Note that Units can be freely modified from within the YAML text file (GUI editor window) and it reflects/converts immediatly . 