### PR TITLE
Wait for server port before opening browser in CLI

### DIFF
--- a/boulder/cli.py
+++ b/boulder/cli.py
@@ -47,6 +47,53 @@ def find_available_port(host: str, start_port: int, max_attempts: int = 10) -> i
     )
 
 
+def wait_for_port(
+    host: str,
+    port: int,
+    *,
+    timeout: float = 30.0,
+    poll_interval: float = 0.25,
+) -> bool:
+    """Return True once *port* is bound (server listening), False on timeout."""
+    import time
+
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if is_port_in_use(host, port):
+            return True
+        time.sleep(poll_interval)
+    return False
+
+
+def schedule_browser_open(
+    url: str,
+    host: str,
+    port: int,
+    *,
+    timeout: float = 30.0,
+    poll_interval: float = 0.25,
+    verbose: bool = False,
+) -> None:
+    """Open *url* in a background thread once *host*:*port* is listening."""
+    import threading
+
+    def _open_when_ready() -> None:
+        if verbose:
+            print(f"⏳ Waiting for server at {url}...")
+        ready = wait_for_port(host, port, timeout=timeout, poll_interval=poll_interval)
+        if verbose:
+            if ready:
+                print(f"🌐 Opening browser at {url}")
+            else:
+                print(f"⚠️  Timed out waiting for {url}; opening browser anyway")
+        try:
+            webbrowser.open(url)
+        except Exception:
+            pass
+
+    threading.Thread(target=_open_when_ready, daemon=True).start()
+
+
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     dev_epilog = (
         "Developers:\n"
@@ -518,23 +565,14 @@ def main(argv: list[str] | None = None, *, runner_class=None) -> None:
 
         print("⚙️  Starting backend server...")
 
-        # Open browser to Vite dev server after waiting for it to be ready
+        # Open browser to Vite dev server once its port is bound
         if not args.no_open:
-            import time
-
-            def open_browser_delayed():
-                # Wait longer for Vite to fully start
-                print("⏳ Waiting for Vite dev server to be ready...")
-                time.sleep(5)  # Increased delay for Vite to fully start
-                vite_url = "http://localhost:5173"
-                print(f"🌐 Opening browser at {vite_url}")
-                try:
-                    webbrowser.open(vite_url)
-                except Exception:
-                    pass
-
-            browser_thread = threading.Thread(target=open_browser_delayed, daemon=True)
-            browser_thread.start()
+            schedule_browser_open(
+                "http://localhost:5173",
+                "127.0.0.1",
+                5173,
+                verbose=True,
+            )
 
         # Continue to start backend below (disable opening backend URL)
         args.no_open = True
@@ -663,11 +701,12 @@ def main(argv: list[str] | None = None, *, runner_class=None) -> None:
 
     url = f"http://{args.host}:{args.port}"
     if not args.no_open:
-        # Open browser slightly before server starts; browser will retry the connection
-        try:
-            webbrowser.open(url)
-        except Exception:
-            pass
+        schedule_browser_open(
+            url,
+            args.host,
+            args.port,
+            verbose=args.verbose,
+        )
 
     if args.verbose and args.port != original_port:
         print(f"Boulder server will start on {url} (port changed from {original_port})")

--- a/docs/plans/2026-06-07-wait-for-server-before-browser-open.md
+++ b/docs/plans/2026-06-07-wait-for-server-before-browser-open.md
@@ -1,0 +1,115 @@
+# Wait for Server Before Browser Open — Boulder Implementation Plan
+
+> **For agent:** Use `@executing-plans` task-by-task. Use `@verification-before-completion` before claiming done.
+
+**Goal:** Fix the Boulder CLI opening the browser before uvicorn binds port 8050, which causes Firefox "Unable to connect" on first load.
+
+**Architecture:** Add small port-polling helpers in `boulder/cli.py`, reusing existing `is_port_in_use()`. Start a daemon thread that polls until the backend port is bound, then call `webbrowser.open()`. Apply the same pattern in `--dev` mode for the Vite port (5173) instead of a fixed 5 s sleep.
+
+**Tech Stack:** Python 3, uvicorn, FastAPI, pytest, threading
+
+**Repo:** Boulder (`boulder/boulder/cli.py`)
+
+**Reference:** `sda/dashboard/app.py` — `_wait_and_open()` (poll until port bound, then open browser)
+
+---
+
+## Background
+
+### Root cause
+
+In `boulder/boulder/cli.py` (~664–670), production mode calls `webbrowser.open(url)` **before** `uvicorn.run()`:
+
+```python
+    url = f"http://{args.host}:{args.port}"
+    if not args.no_open:
+        # Open browser slightly before server starts; browser will retry the connection
+        try:
+            webbrowser.open(url)
+        except Exception:
+            pass
+```
+
+The comment assumes the browser will retry. Firefox often does not — you get "Unable to connect" on `127.0.0.1:8050`.
+
+In `--dev` mode (~521–537), a fixed `time.sleep(5)` before opening Vite is brittle (too short on slow machines, wasteful on fast ones).
+
+### Success criteria
+
+1. Browser opens only after the target port is bound (or timeout fallback).
+2. `--no-open` still suppresses browser open.
+3. `--dev` polls port 5173 instead of sleeping 5 s.
+4. New unit tests cover helpers; existing CLI tests pass.
+5. Manual smoke test: `boulder` loads without "Unable to connect".
+
+### Port detection note
+
+`is_port_in_use(host, port)` returns `False` when the port is free, `True` when something is listening. Poll until it returns `True`.
+
+---
+
+## Task 1: Extract port-wait helpers
+
+**Files:**
+- Modify: `boulder/boulder/cli.py` (after `find_available_port`, ~line 47)
+- Create: `boulder/tests/test_cli_browser.py`
+
+**Step 1: Write failing tests**
+
+Create `tests/test_cli_browser.py` with tests for `wait_for_port` and `schedule_browser_open`.
+
+**Step 2: Run tests — expect FAIL**
+
+```bash
+pytest tests/test_cli_browser.py -v
+```
+
+Expected: `ImportError: cannot import name 'wait_for_port'`
+
+**Step 3: Implement helpers in `boulder/cli.py`**
+
+Add `wait_for_port` and `schedule_browser_open` after `find_available_port`.
+
+**Step 4: Run tests — expect PASS**
+
+```bash
+pytest tests/test_cli_browser.py -v
+```
+
+---
+
+## Task 2: Wire production mode
+
+**Files:**
+- Modify: `boulder/boulder/cli.py` (~664–670)
+
+Replace immediate `webbrowser.open()` with `schedule_browser_open()`.
+
+---
+
+## Task 3: Improve `--dev` mode
+
+**Files:**
+- Modify: `boulder/boulder/cli.py` (~521–537)
+
+Replace fixed `time.sleep(5)` with `schedule_browser_open()` polling port 5173.
+
+---
+
+## Task 4: Final verification
+
+```bash
+pytest tests/test_cli_browser.py tests/test_cli_import.py tests/test_cli_headless.py -v
+python -c "from boulder.cli import wait_for_port, schedule_browser_open; print('ok')"
+```
+
+---
+
+## Agent constraints
+
+| Do | Don't |
+|----|-------|
+| Fix only in `boulder/boulder/cli.py` + new tests | Refactor uvicorn to subprocess |
+| Keep `--no-open` behavior | Block `main()` waiting for browser |
+| Use daemon threads | Add HTTP health polling unless port polling fails in practice |
+| Run pytest before claiming done | Commit or push unless explicitly asked |

--- a/docs/plans/2026-06-07-wait-for-server-before-browser-open.md
+++ b/docs/plans/2026-06-07-wait-for-server-before-browser-open.md
@@ -12,7 +12,7 @@
 
 **Reference:** `sda/dashboard/app.py` — `_wait_and_open()` (poll until port bound, then open browser)
 
----
+______________________________________________________________________
 
 ## Background
 
@@ -37,20 +37,21 @@ In `--dev` mode (~521–537), a fixed `time.sleep(5)` before opening Vite is bri
 ### Success criteria
 
 1. Browser opens only after the target port is bound (or timeout fallback).
-2. `--no-open` still suppresses browser open.
-3. `--dev` polls port 5173 instead of sleeping 5 s.
-4. New unit tests cover helpers; existing CLI tests pass.
-5. Manual smoke test: `boulder` loads without "Unable to connect".
+1. `--no-open` still suppresses browser open.
+1. `--dev` polls port 5173 instead of sleeping 5 s.
+1. New unit tests cover helpers; existing CLI tests pass.
+1. Manual smoke test: `boulder` loads without "Unable to connect".
 
 ### Port detection note
 
 `is_port_in_use(host, port)` returns `False` when the port is free, `True` when something is listening. Poll until it returns `True`.
 
----
+______________________________________________________________________
 
 ## Task 1: Extract port-wait helpers
 
 **Files:**
+
 - Modify: `boulder/boulder/cli.py` (after `find_available_port`, ~line 47)
 - Create: `boulder/tests/test_cli_browser.py`
 
@@ -76,25 +77,27 @@ Add `wait_for_port` and `schedule_browser_open` after `find_available_port`.
 pytest tests/test_cli_browser.py -v
 ```
 
----
+______________________________________________________________________
 
 ## Task 2: Wire production mode
 
 **Files:**
+
 - Modify: `boulder/boulder/cli.py` (~664–670)
 
 Replace immediate `webbrowser.open()` with `schedule_browser_open()`.
 
----
+______________________________________________________________________
 
 ## Task 3: Improve `--dev` mode
 
 **Files:**
+
 - Modify: `boulder/boulder/cli.py` (~521–537)
 
 Replace fixed `time.sleep(5)` with `schedule_browser_open()` polling port 5173.
 
----
+______________________________________________________________________
 
 ## Task 4: Final verification
 
@@ -103,7 +106,7 @@ pytest tests/test_cli_browser.py tests/test_cli_import.py tests/test_cli_headles
 python -c "from boulder.cli import wait_for_port, schedule_browser_open; print('ok')"
 ```
 
----
+______________________________________________________________________
 
 ## Agent constraints
 

--- a/tests/test_cli_browser.py
+++ b/tests/test_cli_browser.py
@@ -1,0 +1,125 @@
+"""Tests for CLI browser-open port polling helpers."""
+
+import socket
+import threading
+import time
+
+import pytest
+
+from boulder.cli import schedule_browser_open, wait_for_port
+
+
+def test_wait_for_port_returns_true_when_port_becomes_in_use():
+    """Assert wait_for_port returns True when the target port is listening."""
+    host, port = "127.0.0.1", 0
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.bind((host, port))
+    bound_port = sock.getsockname()[1]
+    sock.listen(1)
+
+    def _release_after_delay():
+        time.sleep(0.2)
+        sock.close()
+
+    threading.Thread(target=_release_after_delay, daemon=True).start()
+    assert wait_for_port(host, bound_port, timeout=2.0, poll_interval=0.05) is True
+
+
+def test_wait_for_port_times_out_when_port_stays_free():
+    """Assert wait_for_port returns False when the port never becomes bound."""
+    host, port = "127.0.0.1", 0
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.bind((host, port))
+    free_port = sock.getsockname()[1]
+    sock.close()
+    assert wait_for_port(host, free_port, timeout=0.3, poll_interval=0.05) is False
+
+
+def test_schedule_browser_open_waits_for_port(monkeypatch):
+    """Assert schedule_browser_open opens the browser once the port is listening."""
+    opened = []
+
+    def fake_open(url):
+        opened.append(url)
+
+    monkeypatch.setattr("boulder.cli.webbrowser.open", fake_open)
+
+    host, port = "127.0.0.1", 0
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.bind((host, port))
+    bound_port = sock.getsockname()[1]
+    sock.listen(1)
+
+    url = f"http://{host}:{bound_port}"
+    schedule_browser_open(url, host, bound_port, timeout=2.0, poll_interval=0.05)
+    time.sleep(0.5)
+    sock.close()
+
+    assert opened == [url]
+
+
+def test_main_uses_schedule_browser_open_not_sync_open(monkeypatch):
+    """Assert production main() schedules browser open instead of opening synchronously."""
+    calls = {"sync_open": 0, "scheduled": 0}
+
+    monkeypatch.setattr(
+        "boulder.cli.webbrowser.open",
+        lambda url: calls.__setitem__("sync_open", calls["sync_open"] + 1),
+    )
+    monkeypatch.setattr(
+        "boulder.cli.schedule_browser_open",
+        lambda url, host, port, **kwargs: calls.__setitem__(
+            "scheduled", calls["scheduled"] + 1
+        ),
+    )
+    monkeypatch.setattr("boulder.cli.is_port_in_use", lambda h, p: False)
+
+    import types
+
+    api_main = types.SimpleNamespace(_converter_class=None, _runner_class=None)
+    monkeypatch.setitem(__import__("sys").modules, "boulder.api.main", api_main)
+
+    import uvicorn
+
+    monkeypatch.setattr(uvicorn, "run", lambda *a, **kw: (_ for _ in ()).throw(SystemExit(0)))
+
+    import boulder.cli as cli
+
+    with pytest.raises(SystemExit):
+        cli.main([])
+
+    assert calls["sync_open"] == 0
+    assert calls["scheduled"] == 1
+
+
+def test_dev_mode_schedules_vite_browser_open(monkeypatch, tmp_path):
+    """Assert --dev mode schedules browser open for the Vite port instead of sleeping."""
+    scheduled = []
+
+    monkeypatch.setattr(
+        "boulder.cli.schedule_browser_open",
+        lambda url, host, port, **kwargs: scheduled.append((url, host, port)),
+    )
+    monkeypatch.setattr("boulder.cli.Path.exists", lambda self: True)
+    monkeypatch.setattr("platform.system", lambda: "Windows")
+
+    def fake_run(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+
+    import types
+
+    api_main = types.SimpleNamespace(_converter_class=None, _runner_class=None)
+    monkeypatch.setitem(__import__("sys").modules, "boulder.api.main", api_main)
+
+    import uvicorn
+
+    monkeypatch.setattr(uvicorn, "run", lambda *a, **kw: (_ for _ in ()).throw(SystemExit(0)))
+
+    import boulder.cli as cli
+
+    with pytest.raises(SystemExit):
+        cli.main(["--dev"])
+
+    assert scheduled == [("http://localhost:5173", "127.0.0.1", 5173)]

--- a/tests/test_cli_browser.py
+++ b/tests/test_cli_browser.py
@@ -81,7 +81,9 @@ def test_main_uses_schedule_browser_open_not_sync_open(monkeypatch):
 
     import uvicorn
 
-    monkeypatch.setattr(uvicorn, "run", lambda *a, **kw: (_ for _ in ()).throw(SystemExit(0)))
+    monkeypatch.setattr(
+        uvicorn, "run", lambda *a, **kw: (_ for _ in ()).throw(SystemExit(0))
+    )
 
     import boulder.cli as cli
 
@@ -115,7 +117,9 @@ def test_dev_mode_schedules_vite_browser_open(monkeypatch, tmp_path):
 
     import uvicorn
 
-    monkeypatch.setattr(uvicorn, "run", lambda *a, **kw: (_ for _ in ()).throw(SystemExit(0)))
+    monkeypatch.setattr(
+        uvicorn, "run", lambda *a, **kw: (_ for _ in ()).throw(SystemExit(0))
+    )
 
     import boulder.cli as cli
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the Boulder CLI opening the browser before uvicorn binds port 8050, which caused Firefox "Unable to connect" on first load.

## Changes

- Add `wait_for_port()` and `schedule_browser_open()` helpers in `boulder/cli.py` that poll until the target port is listening, then open the browser in a daemon thread.
- **Production mode:** replace synchronous `webbrowser.open()` (called before `uvicorn.run()`) with scheduled port polling on the backend port.
- **`--dev` mode:** replace fixed `time.sleep(5)` with port polling on `127.0.0.1:5173`.
- Add `tests/test_cli_browser.py` with unit tests for helpers and wiring.
- Add implementation plan at `docs/plans/2026-06-07-wait-for-server-before-browser-open.md`.

## Behavior

| Mode | Before | After |
|------|--------|-------|
| Default | Browser opens before server binds | Browser opens after port is bound |
| `--dev` | Fixed 5 s sleep for Vite | Polls port 5173 |
| `--no-open` | Unchanged | Still suppresses browser open |
| Timeout | N/A | Opens browser anyway with warning (verbose mode) |

## Testing

```bash
pytest tests/test_cli_browser.py tests/test_cli_import.py tests/test_cli_headless.py -v
```

All 12 tests pass. Health check with `boulder --no-open --verbose` returns 200 on `/api/health`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fc6f1313-3349-478e-bbb7-0cfb6aa0dc52"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fc6f1313-3349-478e-bbb7-0cfb6aa0dc52"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

