### PR TITLE
Ask for confirmation before deleting nodes

### DIFF
--- a/frontend/src/components/modals/ConfirmDeleteNodeModal.tsx
+++ b/frontend/src/components/modals/ConfirmDeleteNodeModal.tsx
@@ -1,0 +1,51 @@
+import { Button } from "@/components/ui/Button";
+
+interface Props {
+  open: boolean;
+  nodeId: string;
+  nodeType: string;
+  onClose: () => void;
+  onConfirm: () => void;
+}
+
+export function ConfirmDeleteNodeModal({
+  open,
+  nodeId,
+  nodeType,
+  onClose,
+  onConfirm,
+}: Props) {
+  if (!open) return null;
+
+  return (
+    <div
+      id="confirm-delete-node-modal"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div className="w-full max-w-md bg-card border border-border rounded-lg shadow-lg p-6 space-y-4">
+        <h2 className="text-lg font-semibold text-foreground">Delete node?</h2>
+        <p className="text-sm text-muted-foreground">
+          Delete <span className="font-mono text-foreground">{nodeId}</span>
+          {nodeType ? (
+            <>
+              {" "}
+              (<span className="text-foreground">{nodeType}</span>)
+            </>
+          ) : null}
+          ? Connected flow devices will also be removed. This cannot be undone.
+        </p>
+        <div className="flex justify-end gap-2 pt-2">
+          <Button id="cancel-delete-node" onClick={onClose} variant="secondary" size="sm">
+            Cancel
+          </Button>
+          <Button id="confirm-delete-node" onClick={onConfirm} variant="destructive" size="sm">
+            Delete
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/panels/PropertiesPanel.test.tsx
+++ b/frontend/src/components/panels/PropertiesPanel.test.tsx
@@ -1,0 +1,145 @@
+/**
+ * Vitest unit tests for PropertiesPanel delete confirmation.
+ *
+ * Asserts:
+ * - Clicking Delete on a node opens the confirmation modal instead of deleting immediately.
+ * - Cancel closes the modal without calling removeNode.
+ * - Confirm calls removeNode, clears selection, and closes the modal.
+ * - Clicking Delete on a connection deletes immediately without showing the modal.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { PropertiesPanel } from "./PropertiesPanel";
+
+vi.mock("sonner", () => ({
+  toast: { info: vi.fn(), success: vi.fn() },
+}));
+
+const mockRemoveNode = vi.fn();
+const mockRemoveConnection = vi.fn();
+const mockClearSelection = vi.fn();
+let mockSelectedElement: {
+  type: "node" | "edge";
+  data: Record<string, unknown>;
+} | null = null;
+let mockConfig = {
+  nodes: [
+    {
+      id: "reactor_1",
+      type: "IdealGasReactor",
+      properties: { temperature: 1273.15, pressure: 101325 },
+    },
+  ],
+  connections: [
+    {
+      id: "mfc_1",
+      type: "MassFlowController",
+      source: "reactor_1",
+      target: "reactor_2",
+      properties: { mdot: 0.001 },
+    },
+  ],
+};
+
+vi.mock("@/stores/selectionStore", () => ({
+  useSelectionStore: (selector: (s: unknown) => unknown) => {
+    const store = {
+      selectedElement: mockSelectedElement,
+      clearSelection: mockClearSelection,
+    };
+    return selector(store);
+  },
+}));
+
+vi.mock("@/stores/configStore", () => ({
+  useConfigStore: (selector: (s: unknown) => unknown) => {
+    const store = {
+      config: mockConfig,
+      updateNode: vi.fn(),
+      updateConnection: vi.fn(),
+      removeNode: mockRemoveNode,
+      removeConnection: mockRemoveConnection,
+    };
+    return selector(store);
+  },
+}));
+
+describe("PropertiesPanel delete confirmation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSelectedElement = {
+      type: "node",
+      data: { id: "reactor_1", type: "IdealGasReactor" },
+    };
+    mockConfig = {
+      nodes: [
+        {
+          id: "reactor_1",
+          type: "IdealGasReactor",
+          properties: { temperature: 1273.15, pressure: 101325 },
+        },
+      ],
+      connections: [
+        {
+          id: "mfc_1",
+          type: "MassFlowController",
+          source: "reactor_1",
+          target: "reactor_2",
+          properties: { mdot: 0.001 },
+        },
+      ],
+    };
+  });
+
+  it("opens confirmation modal when deleting a node", () => {
+    render(<PropertiesPanel />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+
+    expect(screen.getByText("Delete node?")).toBeInTheDocument();
+    expect(mockRemoveNode).not.toHaveBeenCalled();
+  });
+
+  it("does not delete a node when Cancel is clicked", () => {
+    render(<PropertiesPanel />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(screen.queryByText("Delete node?")).not.toBeInTheDocument();
+    expect(mockRemoveNode).not.toHaveBeenCalled();
+  });
+
+  it("deletes a node when Delete is confirmed", () => {
+    render(<PropertiesPanel />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+    fireEvent.click(document.getElementById("confirm-delete-node")!);
+
+    expect(mockRemoveNode).toHaveBeenCalledWith("reactor_1");
+    expect(mockClearSelection).toHaveBeenCalled();
+    expect(screen.queryByText("Delete node?")).not.toBeInTheDocument();
+  });
+
+  it("deletes a connection immediately without confirmation", () => {
+    mockSelectedElement = {
+      type: "edge",
+      data: {
+        id: "mfc_1",
+        type: "MassFlowController",
+        source: "reactor_1",
+        target: "reactor_2",
+      },
+    };
+
+    render(<PropertiesPanel />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+
+    expect(screen.queryByText("Delete node?")).not.toBeInTheDocument();
+    expect(mockRemoveConnection).toHaveBeenCalledWith("mfc_1");
+    expect(mockClearSelection).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/panels/PropertiesPanel.tsx
+++ b/frontend/src/components/panels/PropertiesPanel.tsx
@@ -3,6 +3,7 @@ import { useSelectionStore } from "@/stores/selectionStore";
 import { useConfigStore } from "@/stores/configStore";
 import { kelvinToCelsius, celsiusToKelvin, formatNumber, labelWithUnit } from "@/lib/units";
 import { Button } from "@/components/ui/Button";
+import { ConfirmDeleteNodeModal } from "@/components/modals/ConfirmDeleteNodeModal";
 import { toast } from "sonner";
 
 export function PropertiesPanel() {
@@ -12,8 +13,10 @@ export function PropertiesPanel() {
   const updateConnection = useConfigStore((s) => s.updateConnection);
   const removeNode = useConfigStore((s) => s.removeNode);
   const removeConnection = useConfigStore((s) => s.removeConnection);
+  const clearSelection = useSelectionStore((s) => s.clearSelection);
   const [isEditing, setIsEditing] = useState(false);
   const [editValues, setEditValues] = useState<Record<string, string>>({});
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
 
   if (!selectedElement) {
     return (
@@ -77,9 +80,20 @@ export function PropertiesPanel() {
     toast.success("Properties saved");
   };
 
-  const handleDelete = () => {
-    if (isNode) removeNode(id);
-    else removeConnection(id);
+  const handleDeleteClick = () => {
+    if (isNode) {
+      setShowDeleteConfirm(true);
+      return;
+    }
+    removeConnection(id);
+    clearSelection();
+    toast.info(`Deleted ${id}`);
+  };
+
+  const handleConfirmDeleteNode = () => {
+    removeNode(id);
+    clearSelection();
+    setShowDeleteConfirm(false);
     toast.info(`Deleted ${id}`);
   };
 
@@ -101,7 +115,13 @@ export function PropertiesPanel() {
                 Save
               </Button>
             )}
-            <Button onClick={handleDelete} variant="destructive" size="sm" className="text-xs">
+            <Button
+              id="delete-element"
+              onClick={handleDeleteClick}
+              variant="destructive"
+              size="sm"
+              className="text-xs"
+            >
               Delete
             </Button>
           </div>
@@ -254,6 +274,16 @@ export function PropertiesPanel() {
           {" → "}
           <span>Target: {String("target" in entity ? entity.target : "N/A")}</span>
         </div>
+      )}
+
+      {isNode && (
+        <ConfirmDeleteNodeModal
+          open={showDeleteConfirm}
+          nodeId={id}
+          nodeType={entityType}
+          onClose={() => setShowDeleteConfirm(false)}
+          onConfirm={handleConfirmDeleteNode}
+        />
       )}
     </div>
   );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a confirmation step before deleting nodes from the Properties panel. Clicking **Delete** on a reactor or reservoir now opens a modal with **Cancel** and **Delete** actions instead of removing the node immediately.

- New `ConfirmDeleteNodeModal` follows the same overlay pattern as other Boulder modals.
- The modal names the node id and type, and notes that connected flow devices will also be removed.
- **Cancel** closes the modal with no changes.
- Graph selection is cleared after a successful delete (nodes and connections).
- MassFlowController / connection deletes are unchanged (still immediate).

## Screenshots

Properties panel with a selected node and the **Delete** button:

[Properties panel with Delete button for a selected reactor node](https://cursor.com/agents/bc-52067be3-9baf-479c-9c77-030d0e82b4ad/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fdelete-node-properties-panel.png)

Confirmation modal after clicking **Delete** (with **Cancel** and **Delete**):

[Delete node confirmation modal with Cancel and Delete actions](https://cursor.com/agents/bc-52067be3-9baf-479c-9c77-030d0e82b4ad/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fdelete-node-confirmation-modal.png)

## Test plan

- [x] Unit tests: modal opens on node delete, Cancel aborts, Confirm deletes, connections delete without modal
- [x] `npm run type-check`
- [x] `npm run build`

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-52067be3-9baf-479c-9c77-030d0e82b4ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-52067be3-9baf-479c-9c77-030d0e82b4ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

