### PR TITLE
Set Sankey node colors to match Cytoscape graph

### DIFF
--- a/frontend/src/components/results/SankeyTab.test.tsx
+++ b/frontend/src/components/results/SankeyTab.test.tsx
@@ -1,0 +1,78 @@
+/**
+ * Vitest unit tests for SankeyTab.
+ *
+ * Asserts:
+ * - Sankey node bars use Cytoscape temperature colors, not Plotly defaults.
+ */
+
+import { render } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { temperatureToNodeColor } from "@/lib/cytoscapeNodeColor";
+import type { SimulationResults } from "@/types/simulation";
+import { SankeyTab } from "./SankeyTab";
+
+interface SankeyNodeTrace {
+  label?: string[];
+  color?: string[];
+}
+
+interface SankeyPlotTrace {
+  type?: string;
+  node?: SankeyNodeTrace;
+}
+
+interface PlotProps {
+  data: SankeyPlotTrace[];
+}
+
+const plotCalls = vi.hoisted(() => [] as PlotProps[]);
+
+vi.mock("react-plotly.js", () => ({
+  default: (props: PlotProps) => {
+    plotCalls.push(props);
+    return <div data-testid="plot" />;
+  },
+}));
+
+vi.mock("@/stores/themeStore", () => ({
+  useThemeStore: (selector: (state: { theme: "light" }) => unknown) =>
+    selector({ theme: "light" }),
+}));
+
+const baseResults: SimulationResults = {
+  is_running: false,
+  is_complete: true,
+  times: [0],
+  reactors_series: {},
+  sankey_nodes: ["feed", "reactor", "outlet"],
+  sankey_links: {
+    source: [0, 1],
+    target: [1, 2],
+    value: [1, 1],
+    color: ["mass", "mass"],
+    label: ["mass", "mass"],
+  },
+  reactor_reports: {
+    feed: { T: 300 },
+    reactor: { T: 1500 },
+    outlet: { T: 1200 },
+  },
+};
+
+describe("SankeyTab", () => {
+  beforeEach(() => {
+    plotCalls.length = 0;
+  });
+
+  it("sets node colors from reactor temperatures matching the Cytoscape scale", () => {
+    render(<SankeyTab results={baseResults} />);
+
+    const node = plotCalls[0].data[0].node;
+    expect(node?.color).toEqual([
+      temperatureToNodeColor(300, "light"),
+      temperatureToNodeColor(1500, "light"),
+      temperatureToNodeColor(1200, "light"),
+    ]);
+  });
+});

--- a/frontend/src/components/results/SankeyTab.tsx
+++ b/frontend/src/components/results/SankeyTab.tsx
@@ -1,4 +1,5 @@
 import Plot from "react-plotly.js";
+import { mapSankeyNodeColors } from "@/lib/cytoscapeNodeColor";
 import { useThemeStore } from "@/stores/themeStore";
 import type { SimulationResults } from "@/types/simulation";
 
@@ -71,6 +72,13 @@ export function SankeyTab({ results }: Props) {
   if (linkLabels) linkTrace.label = linkLabels;
   if (linkColors) linkTrace.color = linkColors;
 
+  const nodeColors = mapSankeyNodeColors(
+    results.sankey_nodes,
+    results.reactor_reports as Record<string, unknown> | undefined,
+    results.updated_nodes,
+    theme,
+  );
+
   return (
     <Plot
       data={[
@@ -78,6 +86,7 @@ export function SankeyTab({ results }: Props) {
           type: "sankey" as const,
           node: {
             label: results.sankey_nodes,
+            color: nodeColors,
             pad: 15,
             thickness: 20,
           },

--- a/frontend/src/lib/cytoscapeNodeColor.test.ts
+++ b/frontend/src/lib/cytoscapeNodeColor.test.ts
@@ -1,0 +1,32 @@
+/**
+ * Vitest unit tests for cytoscapeNodeColor helpers.
+ *
+ * Asserts:
+ * - Cold and hot ends of the scale match Cytoscape stylesheet endpoints.
+ * - Missing reactor reports fall back to the cold-end default.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  CYTOSCAPE_TEMP_MAX_K,
+  CYTOSCAPE_TEMP_MIN_K,
+  mapSankeyNodeColors,
+  temperatureToNodeColor,
+} from "./cytoscapeNodeColor";
+
+describe("cytoscapeNodeColor", () => {
+  it("maps cold and hot temperatures to Cytoscape light-theme endpoints", () => {
+    expect(temperatureToNodeColor(CYTOSCAPE_TEMP_MIN_K, "light")).toBe("#00bfff");
+    expect(temperatureToNodeColor(CYTOSCAPE_TEMP_MAX_K, "light")).toBe("#ff6347");
+  });
+
+  it("maps cold and hot temperatures to Cytoscape dark-theme endpoints", () => {
+    expect(temperatureToNodeColor(CYTOSCAPE_TEMP_MIN_K, "dark")).toBe("#4a90e2");
+    expect(temperatureToNodeColor(CYTOSCAPE_TEMP_MAX_K, "dark")).toBe("#e94b3c");
+  });
+
+  it("uses the cold-end color when no temperature is available for a node", () => {
+    const colors = mapSankeyNodeColors(["unknown"], undefined, undefined, "light");
+    expect(colors).toEqual([temperatureToNodeColor(CYTOSCAPE_TEMP_MIN_K, "light")]);
+  });
+});

--- a/frontend/src/lib/cytoscapeNodeColor.ts
+++ b/frontend/src/lib/cytoscapeNodeColor.ts
@@ -1,0 +1,81 @@
+/** Cytoscape node fill scale (matches ``boulder/styles.py`` and ``ReactorGraph``). */
+export const CYTOSCAPE_TEMP_MIN_K = 300;
+export const CYTOSCAPE_TEMP_MAX_K = 2273;
+
+type Theme = "light" | "dark";
+
+const NODE_COLORS: Record<Theme, { low: string; high: string }> = {
+  light: { low: "#00bfff", high: "#ff6347" },
+  dark: { low: "#4A90E2", high: "#E94B3C" },
+};
+
+function hexToRgb(hex: string): [number, number, number] {
+  const h = hex.replace("#", "");
+  const n = parseInt(h, 16);
+  return [(n >> 16) & 255, (n >> 8) & 255, n & 255];
+}
+
+function rgbToHex(r: number, g: number, b: number): string {
+  return `#${[r, g, b]
+    .map((c) => Math.round(c).toString(16).padStart(2, "0"))
+    .join("")}`;
+}
+
+function lerpHex(a: string, b: string, t: number): string {
+  const ta = hexToRgb(a);
+  const tb = hexToRgb(b);
+  const u = Math.max(0, Math.min(1, t));
+  return rgbToHex(
+    ta[0] + (tb[0] - ta[0]) * u,
+    ta[1] + (tb[1] - ta[1]) * u,
+    ta[2] + (tb[2] - ta[2]) * u,
+  );
+}
+
+/** Match Cytoscape ``mapData(temperature, 300, 2273, low, high)`` node fill. */
+export function temperatureToNodeColor(tempK: number, theme: Theme): string {
+  const { low, high } = NODE_COLORS[theme];
+  const span = CYTOSCAPE_TEMP_MAX_K - CYTOSCAPE_TEMP_MIN_K;
+  const t = (tempK - CYTOSCAPE_TEMP_MIN_K) / span;
+  return lerpHex(low, high, t);
+}
+
+interface ReactorReport {
+  T?: number;
+}
+
+interface UpdatedNode {
+  id: string;
+  properties?: Record<string, unknown>;
+}
+
+/** Resolve post-solve temperature [K] for a reactor id, else cold-end default. */
+export function resolveNodeTemperatureK(
+  nodeId: string,
+  reactorReports?: Record<string, unknown>,
+  updatedNodes?: UpdatedNode[] | null,
+): number {
+  const report = reactorReports?.[nodeId] as ReactorReport | undefined;
+  if (typeof report?.T === "number") return report.T;
+
+  const updated = updatedNodes?.find((n) => n.id === nodeId);
+  const propT = updated?.properties?.temperature;
+  if (typeof propT === "number") return propT;
+
+  return CYTOSCAPE_TEMP_MIN_K;
+}
+
+/** One Plotly Sankey node color per label, aligned with the Cytoscape graph. */
+export function mapSankeyNodeColors(
+  nodeLabels: string[],
+  reactorReports: Record<string, unknown> | undefined,
+  updatedNodes: UpdatedNode[] | null | undefined,
+  theme: Theme,
+): string[] {
+  return nodeLabels.map((label) =>
+    temperatureToNodeColor(
+      resolveNodeTemperatureK(label, reactorReports, updatedNodes),
+      theme,
+    ),
+  );
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sankey node bars no longer use Plotly's default per-node palette (green, blue, pink, etc.). Each bar is colored from the corresponding reactor temperature using the same 300–2273 K scale as the Cytoscape reactor graph (`deepskyblue` → `tomato` in light mode, `#4A90E2` → `#E94B3C` in dark mode).

## Changes

- Add `frontend/src/lib/cytoscapeNodeColor.ts` with shared temperature→color mapping aligned with `boulder/styles.py` and `ReactorGraph.tsx`.
- Set `node.color` in `SankeyTab.tsx` from `reactor_reports` (falling back to `updated_nodes.properties.temperature`, then the cold-end default).
- Add unit tests for the color helper and Sankey tab wiring.

## Testing

```bash
cd frontend && npx vitest run src/components/results/SankeyTab.test.tsx src/lib/cytoscapeNodeColor.test.ts
npm run build
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-811b3e00-58ed-40dd-a1e6-2ed1d00b0cf0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-811b3e00-58ed-40dd-a1e6-2ed1d00b0cf0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

