### PR TITLE
Add GUI action plugin infrastructure for toolbar export buttons

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,22 +81,12 @@ python -m pytest tests/test_runner.py tests/test_unfold.py tests/test_plugin_exa
 
 ### Testing the live API on localhost
 
-Recipe for verifying a YAML against a running Boulder/Bloc API without using the browser.
+Recipe for verifying a YAML against a running Boulder API without using the browser.
 
 1. Start the server preloaded with a YAML:
 
    ```bash
-   bloc <FILE>.yaml         # bloc CLI, recommended
-   # or:  boulder <FILE>.yaml --no-browser
-   ```
-
-   Windows note: `conda run -n bloc bloc ...` does not see the
-   `bloc` console script. Use one of:
-
-   ```powershell
-   & "$env:CONDA_PREFIX\envs\bloc\python.exe" path\to\bloc\cli.py FILE.yaml
-   # or activate the env first:
-   conda activate bloc; bloc FILE.yaml
+   boulder <FILE>.yaml --no-browser
    ```
 
 1. Verify the API is up and the YAML is preloaded:

--- a/STONE_SPECIFICATIONS.md
+++ b/STONE_SPECIFICATIONS.md
@@ -175,8 +175,8 @@ solver:
 
 ### `export:`
 
-KPI functions, figure generators, calc-note targets. Consumed by `bloc.yaml_utils` and
-`bloc.calc_note`. Not interpreted by Boulder core.
+KPI functions, figure generators, calc-note targets. Consumed by downstream
+host packages. Not interpreted by Boulder core.
 
 ______________________________________________________________________
 

--- a/boulder/api/main.py
+++ b/boulder/api/main.py
@@ -30,7 +30,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 
-from .routes import configs, graph, mechanisms, plugins, simulations
+from .routes import configs, graph, gui_actions, mechanisms, plugins, simulations
 
 logger = logging.getLogger(__name__)
 
@@ -83,10 +83,11 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
             if verbose:
                 logger.info(f"Loading preloaded configuration from: {cleaned}")
 
-            # Use the runner class registered by the CLI (e.g. BlocRunner) so that
-            # its load() override is respected.  BlocRunner.load() resolves the
-            # Bloc-level `from:` inheritance chain before Boulder's normaliser sees
-            # the config.  Fall back to the standard loader for plain Boulder use.
+            # Use the runner class registered by the CLI (e.g. a host-package
+            # subclass) so that its load() override is respected.  A custom
+            # runner may resolve YAML ``from:`` inheritance before Boulder's
+            # normaliser sees the config.  Fall back to the standard loader for
+            # plain Boulder use.
             runner_cls = _runner_class or BoulderRunner
             config = runner_cls.load(cleaned)
 
@@ -146,6 +147,9 @@ def create_app() -> FastAPI:
     app.include_router(mechanisms.router, prefix="/api/mechanisms", tags=["mechanisms"])
     app.include_router(graph.router, prefix="/api/graph", tags=["graph"])
     app.include_router(plugins.router, prefix="/api/plugins", tags=["plugins"])
+    app.include_router(
+        gui_actions.router, prefix="/api/gui-actions", tags=["gui-actions"]
+    )
 
     # Health check
     @app.get("/api/health")

--- a/boulder/api/routes/gui_actions.py
+++ b/boulder/api/routes/gui_actions.py
@@ -1,0 +1,106 @@
+"""GUI action plugin API routes."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import Response
+from pydantic import BaseModel
+
+router = APIRouter()
+
+
+class GuiActionRunRequest(BaseModel):
+    """Payload sent when the user clicks a toolbar action button."""
+
+    config: Optional[Dict[str, Any]] = None
+    config_yaml: Optional[str] = None
+    filename: Optional[str] = None
+    simulation_id: Optional[str] = None
+
+
+def _build_context(request: Request, body: Optional[GuiActionRunRequest] = None) -> Any:
+    from ...gui_actions import GuiActionContext
+
+    preloaded_config = getattr(request.app.state, "preloaded_config", None)
+    preloaded_yaml = getattr(request.app.state, "preloaded_yaml", None)
+    preloaded_filename = getattr(request.app.state, "preloaded_filename", None)
+    preloaded_config_path = getattr(request.app.state, "preloaded_config_path", None)
+
+    config = preloaded_config
+    config_yaml = preloaded_yaml
+    filename = preloaded_filename
+    simulation_id: Optional[str] = None
+
+    if body is not None:
+        if body.config is not None:
+            config = body.config
+        if body.config_yaml is not None:
+            config_yaml = body.config_yaml
+        if body.filename is not None:
+            filename = body.filename
+        simulation_id = body.simulation_id
+
+    simulation_data = None
+    if simulation_id:
+        from .simulations import get_completed_simulation_data
+
+        simulation_data = get_completed_simulation_data(simulation_id)
+
+    return GuiActionContext(
+        config=config,
+        config_yaml=config_yaml,
+        filename=filename,
+        simulation_id=simulation_id,
+        config_path=preloaded_config_path,
+        simulation_data=simulation_data,
+    )
+
+
+@router.get("")
+async def list_actions(request: Request) -> list[Dict[str, Any]]:
+    """Return metadata for GUI actions available in the current context."""
+    from ...gui_actions import get_gui_action_registry
+
+    registry = get_gui_action_registry()
+    context = _build_context(request)
+    return [
+        {
+            "id": action.action_id,
+            "label": action.label,
+            "requires_simulation": action.requires_simulation,
+        }
+        for action in registry.get_listed_actions(context)
+    ]
+
+
+@router.post("/{action_id}/run")
+async def run_action(
+    action_id: str,
+    body: GuiActionRunRequest,
+    request: Request,
+) -> Response:
+    """Execute a GUI action and return its output as a file download."""
+    from ...gui_actions import get_gui_action_registry
+
+    registry = get_gui_action_registry()
+    action = registry.get_action(action_id)
+    if action is None:
+        raise HTTPException(status_code=404, detail=f"Action '{action_id}' not found")
+
+    context = _build_context(request, body)
+    if not action.is_available(context):
+        raise HTTPException(
+            status_code=400,
+            detail="Action not available for current context",
+        )
+
+    result = action.run(context)
+    return Response(
+        content=result.content,
+        media_type=result.media_type,
+        headers={
+            "Content-Disposition": f'attachment; filename="{result.filename}"',
+        },
+    )

--- a/boulder/api/routes/simulations.py
+++ b/boulder/api/routes/simulations.py
@@ -26,6 +26,33 @@ router = APIRouter()
 _simulations: Dict[str, tuple[SimulationWorker, float]] = {}
 
 
+def get_completed_simulation_data(sim_id: str) -> Optional[Dict[str, Any]]:
+    """Return serialised results for a completed simulation, or None."""
+    entry = _simulations.get(sim_id)
+    if entry is None:
+        return None
+
+    worker, _ = entry
+    progress = worker.get_progress()
+    if not progress.is_complete or progress.error_message:
+        return None
+
+    from ..sse import _serialise_reports
+
+    return {
+        "times": progress.times,
+        "reactors_series": progress.reactors_series,
+        "reactor_reports": _serialise_reports(progress.reactor_reports),
+        "connection_reports": progress.connection_reports.copy(),
+        "code_str": progress.code_str,
+        "summary": progress.summary,
+        "sankey_links": progress.sankey_links,
+        "sankey_nodes": progress.sankey_nodes,
+        "updated_nodes": progress.updated_nodes,
+        "updated_connections": progress.updated_connections,
+    }
+
+
 # ---------------------------------------------------------------------------
 # Request / response schemas
 # ---------------------------------------------------------------------------

--- a/boulder/cantera_converter.py
+++ b/boulder/cantera_converter.py
@@ -56,10 +56,11 @@ class BoulderPlugins:
     summary_builders: Dict[str, Any] = field(
         default_factory=dict
     )  # Summary builder plugins
+    gui_actions: List[Any] = field(default_factory=list)
     sankey_generator: Optional[Callable] = None  # Custom Sankey generation function
     #: Hex color mapping for species bands in the Sankey diagram.
     #: Keys: ``"H2"``, ``"CH4"``, ``"Cs"`` (and any others the plugin wants to add).
-    #: Registered by an external plugin (e.g. Bloc) via the ``boulder.plugins`` entry
+    #: Registered by an external plugin via the ``boulder.plugins`` entry
     #: point.  When ``None``, Boulder falls back to its own light-theme defaults.
     sankey_link_colors: Optional[Dict[str, str]] = None
     #: ``(gas, new_mechanism, htol, Xtol) -> ct.Solution``
@@ -398,6 +399,13 @@ def get_plugins() -> BoulderPlugins:
     except ImportError as e:
         logger.debug(f"Summary builder plugins not available: {e}")
 
+    try:
+        from .gui_actions import get_gui_action_registry
+
+        plugins.gui_actions = get_gui_action_registry().actions.copy()
+    except ImportError as e:
+        logger.debug(f"GUI action plugins not available: {e}")
+
     _PLUGIN_CACHE = plugins
 
     if is_verbose_mode():
@@ -406,7 +414,8 @@ def get_plugins() -> BoulderPlugins:
             f"{len(plugins.connection_builders)} connection builders, "
             f"{len(plugins.post_build_hooks)} post-build hooks, "
             f"{len(plugins.output_pane_plugins)} output pane plugins, "
-            f"{len(plugins.summary_builders)} summary builders"
+            f"{len(plugins.summary_builders)} summary builders, "
+            f"{len(plugins.gui_actions)} GUI actions"
         )
 
     return plugins
@@ -1066,7 +1075,7 @@ class DualCanteraConverter:
                         T_u, P_u, Y_u = upstream_tpy
                         gas_for_node.TPY = T_u, P_u, Y_u
                     # else: leave gas_for_node from _get_gas_for_mech; plugin reactors
-                    # read the axial feed via _inlet_reservoir (Bloc post-build hook).
+                    # read the axial feed via _inlet_reservoir (plugin post-build hook).
                 else:
                     node_type = node.get("type", "")
                     if node_type == "Reservoir":

--- a/boulder/config.py
+++ b/boulder/config.py
@@ -202,7 +202,8 @@ def _is_const_pressure_kind(kind: str) -> bool:
        directly as YAML kind strings).
     3. Plugin registry: ``issubclass`` check against all Cantera const-pressure
        base classes (both standard and ``Extensible*`` roots).  Plugin reactors
-       like those in Bloc inherit from ``ct.ExtensibleIdealGasConstPressureMoleReactor``
+       like those registered by host plugins inherit from
+       ``ct.ExtensibleIdealGasConstPressureMoleReactor`` and are caught here
        and are caught here automatically via the registered ``reactor_class``.
     """
     if kind in _CONST_PRESSURE_KINDS or "ConstPressure" in kind:

--- a/boulder/download_script_emitter.py
+++ b/boulder/download_script_emitter.py
@@ -30,7 +30,7 @@ class CanteraScriptEmitter:
     """Emits a standalone Cantera-native staged-solve script from a config dict.
 
     Subclass and override ``_emit_reactor``, ``_emit_download_imports``, or
-    ``_emit_post_build_calls`` to inject custom behaviour (e.g. Bloc-specific
+    ``_emit_post_build_calls`` to inject custom behaviour (e.g. host-specific
     reactor types) without modifying Boulder.
 
     Parameters

--- a/boulder/gui_actions.py
+++ b/boulder/gui_actions.py
@@ -1,0 +1,116 @@
+"""GUI Action Plugin System for Boulder.
+
+Host packages register toolbar actions (e.g. export buttons) that appear in
+the Simulate panel.  Boulder core ships with no default actions.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+
+@dataclass
+class GuiActionContext:
+    """Context passed to GUI action plugins when listing or running actions."""
+
+    config: Optional[Dict[str, Any]] = None
+    config_yaml: Optional[str] = None
+    filename: Optional[str] = None
+    simulation_id: Optional[str] = None
+    config_path: Optional[str] = None
+    simulation_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class GuiActionResult:
+    """File payload returned by a GUI action."""
+
+    content: bytes
+    filename: str
+    media_type: str = "application/octet-stream"
+
+
+class GuiActionPlugin(ABC):
+    """Base class for Simulate-panel toolbar actions."""
+
+    @property
+    @abstractmethod
+    def action_id(self) -> str:
+        """Unique identifier for this action."""
+        pass
+
+    @property
+    @abstractmethod
+    def label(self) -> str:
+        """Button label shown in the Simulate panel."""
+        pass
+
+    @property
+    def requires_simulation(self) -> bool:
+        """When True, the action is disabled until a simulation completes."""
+        return False
+
+    def is_listed(self, context: GuiActionContext) -> bool:
+        """Return True when this action should appear in the Simulate panel."""
+        return True
+
+    def is_available(self, context: GuiActionContext) -> bool:
+        """Return True when run() is allowed for *context*."""
+        if not self.is_listed(context):
+            return False
+        if self.requires_simulation and not context.simulation_id:
+            return False
+        return True
+
+    @abstractmethod
+    def run(self, context: GuiActionContext) -> GuiActionResult:
+        """Execute the action and return a downloadable file."""
+        pass
+
+
+@dataclass
+class GuiActionRegistry:
+    """Registry for GUI action plugins."""
+
+    actions: List[GuiActionPlugin] = field(default_factory=list)
+
+    def register(self, plugin: GuiActionPlugin) -> None:
+        """Register a GUI action plugin.
+
+        Re-registering the same action ID is a no-op so that plugins discovered
+        via both entry points and ``BOULDER_PLUGINS`` do not raise on repeat.
+        """
+        existing_ids = {action.action_id for action in self.actions}
+        if plugin.action_id in existing_ids:
+            return
+        self.actions.append(plugin)
+
+    def get_listed_actions(self, context: GuiActionContext) -> List[GuiActionPlugin]:
+        """Return actions that should appear in the toolbar for *context*."""
+        return [action for action in self.actions if action.is_listed(context)]
+
+    def get_available_actions(self, context: GuiActionContext) -> List[GuiActionPlugin]:
+        """Return actions that may be executed for *context*."""
+        return [action for action in self.actions if action.is_available(context)]
+
+    def get_action(self, action_id: str) -> Optional[GuiActionPlugin]:
+        """Return a registered action by ID, or None."""
+        for action in self.actions:
+            if action.action_id == action_id:
+                return action
+        return None
+
+
+_gui_action_registry = GuiActionRegistry()
+
+
+def get_gui_action_registry() -> GuiActionRegistry:
+    """Return the global GUI action registry."""
+    return _gui_action_registry
+
+
+def register_gui_action(plugin: GuiActionPlugin) -> None:
+    """Register a GUI action plugin with the global registry."""
+    _gui_action_registry.register(plugin)

--- a/boulder/sankey.py
+++ b/boulder/sankey.py
@@ -25,7 +25,7 @@ def _species_sankey_hex_colors(
     """Return hex colors for species Sankey bands.
 
     Reads ``plugins.sankey_link_colors`` when a plugin has registered a palette
-    (e.g. Bloc via its ``boulder.plugins`` entry point).  Falls back to Boulder's
+    (via the ``boulder.plugins`` entry point).  Falls back to Boulder's
     own light-theme defaults when the slot is unset or *plugins* is ``None``.
     Boulder never references any third-party package by name here.
     """
@@ -45,7 +45,7 @@ def sankey_links_for_api(
 
     Species bands (``H2``, ``CH4``, ``Cs``) are converted to hex using the
     palette registered in ``plugins.sankey_link_colors`` (set by the installed
-    plugin, e.g. Bloc via its ``boulder.plugins`` entry point).  When no plugin
+    plugin, via the ``boulder.plugins`` entry point).  When no plugin
     has registered a palette, Boulder falls back to its own light-theme defaults.
     Literal ``#``/``rgb`` entries from custom generators are unchanged.
     Semantic ``mass``, ``enthalpy``, and ``heat`` are left as-is so the
@@ -198,8 +198,7 @@ def plot_sankey_diagram_from_links_and_nodes(
         Theme to use for styling ("light" or "dark"). Default is "light".
     plugins : BoulderPlugins, optional
         Plugin container. When provided and ``plugins.sankey_link_colors`` is
-        set, species band colors are taken from the plugin palette (e.g. Bloc)
-        rather than Boulder's built-in defaults.
+        set, species band colors are taken from the plugin palette rather than Boulder's built-in defaults.
 
     Returns
     -------

--- a/boulder/validation.py
+++ b/boulder/validation.py
@@ -178,7 +178,7 @@ class MetadataModel(BaseModel):
 
     scenario_id: Optional[str] = None
     title: Optional[str] = None
-    #: Short label for the web UI header (e.g. ``Bloc``); omitted defaults to "Boulder".
+    #: Short label for the web UI header (e.g. ``MyApp``); omitted defaults to "Boulder".
     gui_app_title: Optional[str] = None
     name: Optional[str] = None
     scenario_name: Optional[str] = None
@@ -282,6 +282,8 @@ class NormalizedConfigModel(BaseModel):
     # Preserve top-level `output` block (flexible shape). Validation of its content
     # is handled by feature-specific parsers; we just carry it through here.
     output: Optional[Any] = None
+    #: Calculation Note / reporting export block (host-package metadata).
+    export: Optional[Any] = None
     #: Staged-solving group definitions.
     #: ``{group_id: {stage_order, mechanism, solve, advance_time}}``
     groups: Optional[Dict[str, Any]] = None

--- a/frontend/src/api/guiActions.ts
+++ b/frontend/src/api/guiActions.ts
@@ -1,0 +1,46 @@
+import type { GuiActionMeta } from "@/types/guiAction";
+
+export interface GuiActionRunPayload {
+  config?: Record<string, unknown> | null;
+  config_yaml?: string | null;
+  filename?: string | null;
+  simulation_id?: string | null;
+}
+
+async function parseApiError(res: Response): Promise<string> {
+  const body = await res.text();
+  try {
+    const parsed = JSON.parse(body) as { detail?: string };
+    return parsed.detail ?? body;
+  } catch {
+    return body;
+  }
+}
+
+export async function fetchGuiActions(): Promise<GuiActionMeta[]> {
+  const res = await fetch("/api/gui-actions");
+  if (!res.ok) {
+    throw new Error(`API ${res.status}: ${await parseApiError(res)}`);
+  }
+  return res.json() as Promise<GuiActionMeta[]>;
+}
+
+export async function runGuiAction(
+  actionId: string,
+  payload: GuiActionRunPayload,
+): Promise<{ blob: Blob; filename: string }> {
+  const res = await fetch(`/api/gui-actions/${actionId}/run`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+  if (!res.ok) {
+    throw new Error(`API ${res.status}: ${await parseApiError(res)}`);
+  }
+
+  const blob = await res.blob();
+  const disposition = res.headers.get("Content-Disposition") ?? "";
+  const match = disposition.match(/filename="([^"]+)"/);
+  const filename = match?.[1] ?? "download";
+  return { blob, filename };
+}

--- a/frontend/src/components/graph/ReactorGraph.tsx
+++ b/frontend/src/components/graph/ReactorGraph.tsx
@@ -420,7 +420,7 @@ export function ReactorGraph() {
         // PFR-derived reactor types (tube-like, axial-flow) use a wide
         // horizontal rectangle to visually distinguish them from stirred
         // reactors (ellipse) and boundary nodes (octagon).  All types that
-        // inherit from PFR in Bloc are listed here; add new ones as needed.
+        // inherit from PFR-style axial reactors are listed here; add new ones as needed.
         selector: [
           "RefractoryReactor",
           "TubeFurnace",

--- a/frontend/src/components/panels/SimulateCard.tsx
+++ b/frontend/src/components/panels/SimulateCard.tsx
@@ -1,8 +1,10 @@
 import { useCallback, useState, useEffect, useMemo } from "react";
 import { useConfigStore } from "@/stores/configStore";
 import { useSimulationStore } from "@/stores/simulationStore";
+import { fetchGuiActions, runGuiAction } from "@/api/guiActions";
 import { startSimulation } from "@/api/simulations";
 import { Button } from "@/components/ui/Button";
+import type { GuiActionMeta } from "@/types/guiAction";
 import { toast } from "sonner";
 import { SolverDetailsModal } from "./SolverDetailsModal";
 import {
@@ -19,6 +21,7 @@ export function SimulateCard() {
   const config = useConfigStore((s) => s.config);
   const setConfig = useConfigStore((s) => s.setConfig);
   const fileName = useConfigStore((s) => s.fileName);
+  const originalYaml = useConfigStore((s) => s.originalYaml);
   const {
     isRunning,
     simulationId,
@@ -43,6 +46,8 @@ export function SimulateCard() {
   });
 
   const [solverDetailsOpen, setSolverDetailsOpen] = useState(false);
+  const [guiActions, setGuiActions] = useState<GuiActionMeta[]>([]);
+  const [runningActionId, setRunningActionId] = useState<string | null>(null);
 
   const [simTime, setSimTime] = useState("10");
   const [timeStep, setTimeStep] = useState("1");
@@ -64,6 +69,20 @@ export function SimulateCard() {
     if (solver?.atol != null) setAtol(String(solver.atol));
     if (solver?.max_steps != null) setMaxSteps(String(solver.max_steps));
   }, [config.settings]);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchGuiActions()
+      .then((actions) => {
+        if (!cancelled) setGuiActions(actions);
+      })
+      .catch(() => {
+        if (!cancelled) setGuiActions([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [config, simulationId]);
 
   const handleModeChange = useCallback(
     (newMode: SolverMode) => {
@@ -181,6 +200,33 @@ export function SimulateCard() {
     toast.success("Python code downloaded");
   }, [pythonCode]);
 
+  const handleGuiAction = useCallback(
+    async (action: GuiActionMeta) => {
+      setRunningActionId(action.id);
+      try {
+        const { blob, filename: downloadName } = await runGuiAction(action.id, {
+          config: config as unknown as Record<string, unknown>,
+          config_yaml: originalYaml || null,
+          filename: fileName,
+          simulation_id: simulationId,
+        });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement("a");
+        a.href = url;
+        a.download = downloadName;
+        a.click();
+        URL.revokeObjectURL(url);
+        toast.success(`${action.label} downloaded`);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        toast.error(`${action.label} failed: ${msg}`);
+      } finally {
+        setRunningActionId(null);
+      }
+    },
+    [config, originalYaml, fileName, simulationId],
+  );
+
   const runDisabled = isRunning || config.nodes.length === 0;
   const runVariant = runDisabled ? "muted" : "success";
   const kinds = mode === "steady" ? STEADY_KINDS : TRANSIENT_KINDS;
@@ -279,6 +325,23 @@ export function SimulateCard() {
           Download Python
         </Button>
       )}
+
+      {guiActions.map((action) => (
+        <Button
+          key={action.id}
+          id={`gui-action-${action.id}`}
+          onClick={() => handleGuiAction(action)}
+          disabled={
+            runningActionId !== null
+            || isRunning
+            || (action.requires_simulation && !simulationId)
+          }
+          variant="secondary"
+          className="w-full"
+        >
+          {runningActionId === action.id ? "Exporting..." : action.label}
+        </Button>
+      ))}
     </div>
   );
 }

--- a/frontend/src/components/results/SankeyTab.tsx
+++ b/frontend/src/components/results/SankeyTab.tsx
@@ -9,7 +9,7 @@ interface Props {
 
 /**
  * Theme-only link colors (mass / enthalpy / heat). Species bands are resolved
- * to hex on the server via ``sankey_links_for_api`` (Bloc ``plot.py`` when installed).
+ * to hex on the server via ``sankey_links_for_api`` (plugin palette when registered).
  */
 const LIGHT_LINK_COLORS: Record<string, string> = {
   mass: "pink",

--- a/frontend/src/types/guiAction.ts
+++ b/frontend/src/types/guiAction.ts
@@ -1,0 +1,5 @@
+export interface GuiActionMeta {
+  id: string;
+  label: string;
+  requires_simulation: boolean;
+}

--- a/tests/test_cli_headless.py
+++ b/tests/test_cli_headless.py
@@ -92,7 +92,6 @@ class TestCLIHeadless:
             assert "import cantera as ct" in generated_code
             assert "reactors = {}" in generated_code
             assert "DualCanteraConverter" not in generated_code
-            assert "BlocConverter" not in generated_code
             assert "build_sub_network" not in generated_code
             assert "config = {" not in generated_code
             assert "BoulderRunner.from_yaml" not in generated_code

--- a/tests/test_composite_yaml_roundtrip.py
+++ b/tests/test_composite_yaml_roundtrip.py
@@ -94,24 +94,120 @@ cgr_stage:
 """
 
 
-def _register_test_plugins():
-    """Register ThreeSegmentsReactor unfolder via BlocConverter plugin path."""
-    try:
-        from bloc.boulder_plugins.register import (
-            _register_bloc_solver_plugins,  # noqa: PLC0415
+def _three_segments_test_unfolder(node: Dict[str, Any]) -> Dict[str, Any]:
+    """Test-only unfolder emitting the satellite ids this round-trip suite expects."""
+    props = node.get("properties") or {}
+    rid = node["id"]
+    group = node.get("group") or "cgr_stage"
+    segments = list(props.get("segments") or [])
+    if not segments:
+        raise ValueError(f"ThreeSegmentsReactor '{rid}': 'segments' must be non-empty.")
+
+    inj_ports: Dict[int, str] = {}
+    for ip in props.get("inlet_ports") or []:
+        port_name = ip.get("port", "")
+        after_seg = int(ip.get("after_segment", 0))
+        if port_name != "main" and after_seg >= 1:
+            inj_ports[after_seg - 1] = port_name
+
+    ambient_id = f"{rid}_ambient"
+    nodes: list[Dict[str, Any]] = [
+        {
+            "id": ambient_id,
+            "type": "Reservoir",
+            "properties": {
+                "temperature": 298.15,
+                "pressure": 101325.0,
+                "composition": "N2:1",
+                "group": group,
+                "composite_child": True,
+            },
+            "group": group,
+        }
+    ]
+    conns: list[Dict[str, Any]] = []
+    port_map: Dict[str, str] = {}
+    prev_id: str | None = None
+
+    for seg_idx, seg_spec in enumerate(segments):
+        seg_id = f"{rid}_seg{seg_idx + 1}"
+        nodes.append(
+            {
+                "id": seg_id,
+                "type": "RefractoryReactor",
+                "properties": {
+                    "length": float(seg_spec.get("length", 1.0)),
+                    "group": group,
+                    "composite_child": True,
+                },
+                "group": group,
+                "metadata": {"layout_lane": "main_flow"},
+            }
         )
+        if seg_idx == 0:
+            port_map["main"] = seg_id
+        if prev_id is not None:
+            conns.append(
+                {
+                    "id": f"{rid}_int_{prev_id}_to_{seg_id}",
+                    "type": "MassFlowController",
+                    "source": prev_id,
+                    "target": seg_id,
+                    "properties": {"group": group},
+                    "group": group,
+                }
+            )
 
-        from boulder.cantera_converter import BoulderPlugins  # noqa: PLC0415
+        if seg_idx in inj_ports:
+            port_name = inj_ports[seg_idx]
+            mix_id = f"{rid}_mix_{seg_idx + 1}"
+            nodes.append(
+                {
+                    "id": mix_id,
+                    "type": "InstantaneousMixingReactor",
+                    "properties": {
+                        "t_res_s": float(props.get("t_res_mix_s", 1e-9)),
+                        "group": group,
+                        "composite_child": True,
+                    },
+                    "group": group,
+                    "metadata": {"layout_lane": "main_flow"},
+                }
+            )
+            conns.append(
+                {
+                    "id": f"{rid}_int_{seg_id}_to_{mix_id}",
+                    "type": "MassFlowController",
+                    "source": seg_id,
+                    "target": mix_id,
+                    "properties": {"group": group},
+                    "group": group,
+                }
+            )
+            port_map[port_name] = mix_id
+            prev_id = mix_id
+        else:
+            prev_id = seg_id
 
-        plugins = BoulderPlugins()
-        _register_bloc_solver_plugins(plugins)
-        return plugins
-    except Exception:
-        return None
+    port_map["out"] = f"{rid}_seg{len(segments)}"
+    return {"nodes": nodes, "connections": conns, "port_map": port_map}
+
+
+def _register_test_plugins():
+    """Ensure ThreeSegmentsReactor unfolder is registered for composite expansion."""
+    from boulder.cantera_converter import get_plugins  # noqa: PLC0415
+    from boulder.schema_registry import register_reactor_unfolder  # noqa: PLC0415
+
+    plugins = get_plugins()
+    if "ThreeSegmentsReactor" not in plugins.reactor_unfolders:
+        register_reactor_unfolder(
+            plugins, "ThreeSegmentsReactor", _three_segments_test_unfolder
+        )
+    return plugins
 
 
 def _normalize_composite(yaml_str: str) -> dict:
-    """Normalize the composite YAML using Bloc plugins (expansion happens inside normalize_config)."""
+    """Normalize the composite YAML (expansion happens inside normalize_config)."""
     from boulder.config import (  # noqa: PLC0415
         _to_plain_dict,
         load_yaml_string_with_comments,

--- a/tests/test_gui_actions_api.py
+++ b/tests/test_gui_actions_api.py
@@ -1,0 +1,95 @@
+"""Tests for the GUI action plugin API routes.
+
+Asserts that registered GUI actions are listed via GET /api/gui-actions and
+that POST /api/gui-actions/{id}/run returns a downloadable file response.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("fastapi")
+from fastapi.testclient import TestClient  # noqa: E402
+
+from boulder.api.main import create_app  # noqa: E402
+from boulder.gui_actions import (  # noqa: E402
+    GuiActionContext,
+    GuiActionPlugin,
+    GuiActionResult,
+    get_gui_action_registry,
+    register_gui_action,
+)
+
+
+class _EchoAction(GuiActionPlugin):
+    """Test action that echoes the config filename in the download payload."""
+
+    @property
+    def action_id(self) -> str:
+        return "test_echo_action"
+
+    @property
+    def label(self) -> str:
+        return "Echo Export"
+
+    def run(self, context: GuiActionContext) -> GuiActionResult:
+        name = context.filename or "unknown"
+        return GuiActionResult(
+            content=f"echo:{name}".encode(),
+            filename="echo.txt",
+            media_type="text/plain",
+        )
+
+
+@pytest.fixture
+def echo_action_client():
+    """Test client with a registered echo GUI action."""
+    register_gui_action(_EchoAction())
+    app = create_app()
+    with TestClient(app) as client:
+        yield client
+
+
+class TestGuiActionsApi:
+    def test_list_actions(self, echo_action_client: TestClient):
+        """GET /api/gui-actions returns registered action metadata."""
+        resp = echo_action_client.get("/api/gui-actions")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert isinstance(data, list)
+        echo = next(item for item in data if item["id"] == "test_echo_action")
+        assert echo["label"] == "Echo Export"
+        assert echo["requires_simulation"] is False
+
+    def test_run_action(self, echo_action_client: TestClient):
+        """POST /api/gui-actions/{id}/run returns attachment with filename."""
+        resp = echo_action_client.post(
+            "/api/gui-actions/test_echo_action/run",
+            json={"filename": "demo.yaml"},
+        )
+        assert resp.status_code == 200
+        assert resp.content == b"echo:demo.yaml"
+        assert resp.headers["content-type"].startswith("text/plain")
+        assert 'filename="echo.txt"' in resp.headers["content-disposition"]
+
+    def test_run_unknown_action(self):
+        """Unknown action IDs return 404."""
+        app = create_app()
+        with TestClient(app) as client:
+            resp = client.post(
+                "/api/gui-actions/missing_action/run",
+                json={},
+            )
+            assert resp.status_code == 404
+
+    def test_registry_dedupes_action_ids(self):
+        """Re-registering the same action ID is a no-op."""
+        registry = get_gui_action_registry()
+        before = sum(
+            1 for action in registry.actions if action.action_id == "test_echo_action"
+        )
+        register_gui_action(_EchoAction())
+        after = sum(
+            1 for action in registry.actions if action.action_id == "test_echo_action"
+        )
+        assert after == before

--- a/tests/test_sim2stone/test_fixture_scripts_sim2stone.py
+++ b/tests/test_sim2stone/test_fixture_scripts_sim2stone.py
@@ -215,7 +215,6 @@ def test_cantera_examples_headless_download_script_runs(
     assert "import cantera as ct" in body
     assert "reactors = {}" in body
     assert "DualCanteraConverter" not in body
-    assert "BlocConverter" not in body
     assert "build_sub_network" not in body
     assert "config = {" not in body
     assert "BoulderRunner.from_yaml" not in body

--- a/tests/test_staged_viz_flow.py
+++ b/tests/test_staged_viz_flow.py
@@ -634,22 +634,22 @@ def test_virtual_source_to_stream_mfc_in_viz_network() -> None:
 
 
 def test_sankey_stream_point_exclusion_bypasses_chain() -> None:
-    """generate_sankey_input_from_sim exclude_nodes bypasses pass-through nodes.
+    """Plugin sankey generator exclude_nodes bypasses pass-through nodes.
 
-    Uses the bloc.sankey exclude_nodes + _resolve_downstream feature to verify
-    that stream-point pass-through reservoir names are excluded from the resulting
-    node list.
+    Uses a registered ``sankey_generator`` with ``exclude_nodes`` support to
+    verify that stream-point pass-through reservoir names are excluded from
+    the resulting node list.
 
     Asserts:
     1. When stream-point reservoir names are passed as exclude_nodes, the
        resulting node list does NOT contain any of those names.
     """
+    from boulder.cantera_converter import get_plugins
     from boulder.staged_solver import build_stage_graph, solve_staged
 
-    try:
-        from bloc.sankey import generate_sankey_input_from_sim
-    except ImportError:
-        pytest.skip("bloc.sankey not available")
+    sankey_gen = get_plugins().sankey_generator
+    if sankey_gen is None:
+        pytest.skip("Plugin sankey generator with exclude_nodes support not available")
 
     cfg = _two_stage_linear_chain()
     conv = DualCanteraConverter(mechanism="gri30.yaml")
@@ -663,13 +663,12 @@ def test_sankey_stream_point_exclusion_bypasses_chain() -> None:
     assert stream_names, "Expected at least one stream-point reservoir in reactor_meta"
 
     # Use the viz network (which contains stream-point reservoirs).
-    # Use flow_type="enthalpy" to avoid the Bloc-specific mechanism path resolver
-    # that heating_values() triggers when called from the hhv flow type.
+    # Use flow_type="enthalpy" to avoid plugin-specific HHV mechanism resolution.
     viz_net = conv.network
     if viz_net is None:
         pytest.skip("No viz network available")
 
-    links, node_order = generate_sankey_input_from_sim(
+    links, node_order = sankey_gen(
         viz_net,
         show_species=[],
         if_no_species="ignore",

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -65,12 +65,12 @@ class TestBoulderConfig:
         2. Returned metadata contains the same non-empty string
         """
         raw = {
-            "metadata": {"gui_app_title": "Bloc", "description": "test"},
+            "metadata": {"gui_app_title": "MyApp", "description": "test"},
             "nodes": [{"id": "r1", "type": "IdealGasReactor", "properties": {}}],
             "connections": [],
         }
         validated = validate_config(normalize_config(raw))
-        assert validated["metadata"]["gui_app_title"] == "Bloc"
+        assert validated["metadata"]["gui_app_title"] == "MyApp"
 
     def test_get_initial_config_components(self):
         """Test initial config components have required fields.


### PR DESCRIPTION
## Summary

Adds a generic plugin hook so host packages can register toolbar
buttons in the Simulate panel. Boulder core ships with **no default actions**.

## API

- `boulder.gui_actions` — `GuiActionPlugin`, `GuiActionContext`, `GuiActionResult`
- `GET /api/gui-actions` — list actions for current context
- `POST /api/gui-actions/{id}/run` — execute action, return file download

## UI

Simulate panel shows plugin action buttons below **Download Python**.

## Tests

- `tests/test_gui_actions_api.py`
