### PR TITLE
Cache results 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -551,6 +551,8 @@ __pycache__/
 alembic/versions/*.pyc
 *.png
 /configs/.boulder-cache
+# On-disk simulation result cache (sidecar next to any YAML)
+.boulder-cache/
 piston.csv
 configs/cantera_examples/nanosecond_pulse_discharge_stone.yaml
 configs/cantera_examples/combustor_stone.yaml

--- a/boulder/api/main.py
+++ b/boulder/api/main.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import logging
 import os
+import time
 from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import AsyncGenerator
@@ -72,6 +73,8 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     app.state.preloaded_yaml = None
     app.state.preloaded_filename = None
     app.state.preloaded_config_path = None  # full path for script generation
+    app.state.preloaded_result = None
+    app.state.preloaded_fingerprint = None
 
     if env_config_path and env_config_path.strip():
         try:
@@ -107,6 +110,60 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
             app.state.preloaded_config_path = str(actual_yaml_path)
 
             logger.info(f"Preloaded configuration: {app.state.preloaded_filename}")
+
+            # Attempt to load a matching cache entry for the preloaded config.
+            try:
+                from ..result_cache import (
+                    cache_dir_for,
+                    compute_fingerprint,
+                    find_result_by_config_snapshot,
+                    load_result,
+                )
+
+                cache_root = cache_dir_for(str(actual_yaml_path))
+                if cache_root is not None:
+                    mechanism = None
+                    phases = validated.get("phases", {})
+                    if isinstance(phases, dict):
+                        gas = phases.get("gas", {})
+                        if isinstance(gas, dict):
+                            mechanism = gas.get("mechanism")
+                    fingerprint = compute_fingerprint(validated, mechanism=mechanism)
+                    cached = load_result(cache_root, fingerprint)
+                    # If direct lookup misses, scan entries for one whose
+                    # config_snapshot fingerprint matches the startup fingerprint.
+                    # This handles legacy entries where pre-build and startup
+                    # fingerprints diverged due to type normalisation differences.
+                    if cached is None:
+                        cached = find_result_by_config_snapshot(
+                            cache_root, fingerprint, mechanism=mechanism
+                        )
+                    app.state.preloaded_result = cached
+                    app.state.preloaded_fingerprint = fingerprint if cached else None
+                    if cached:
+                        meta = cached.get("meta", {})
+                        created = meta.get("created_at", 0.0)
+                        logger.info(
+                            "Loaded cached simulation result for %s "
+                            "(created %.0f s ago, fingerprint %s…)",
+                            app.state.preloaded_filename,
+                            time.time() - created,
+                            fingerprint[:12],
+                        )
+                    else:
+                        logger.info(
+                            "No valid cache entry found for preloaded config "
+                            "(fingerprint %s…). Run the simulation to populate the cache.",
+                            fingerprint[:12],
+                        )
+                else:
+                    app.state.preloaded_result = None
+                    app.state.preloaded_fingerprint = None
+            except Exception as cache_err:
+                logger.warning("Cache load at startup failed: %s", cache_err)
+                app.state.preloaded_result = None
+                app.state.preloaded_fingerprint = None
+
         except Exception as e:
             logger.error(f"Failed to load preloaded configuration: {e}")
 

--- a/boulder/api/main.py
+++ b/boulder/api/main.py
@@ -115,40 +115,43 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
             try:
                 from ..result_cache import (
                     cache_dir_for,
-                    compute_fingerprint,
-                    find_result_by_config_snapshot,
-                    load_result,
+                    lookup_cached_result,
+                    resolve_mechanism_for_fingerprint,
                 )
 
                 cache_root = cache_dir_for(str(actual_yaml_path))
                 if cache_root is not None:
-                    mechanism = None
-                    phases = validated.get("phases", {})
-                    if isinstance(phases, dict):
-                        gas = phases.get("gas", {})
-                        if isinstance(gas, dict):
-                            mechanism = gas.get("mechanism")
-                    fingerprint = compute_fingerprint(validated, mechanism=mechanism)
-                    cached = load_result(cache_root, fingerprint)
-                    # If direct lookup misses, scan entries for one whose
-                    # config_snapshot fingerprint matches the startup fingerprint.
-                    # This handles legacy entries where pre-build and startup
-                    # fingerprints diverged due to type normalisation differences.
+                    converter_cls = getattr(app.state, "converter_class", None)
+                    mechanism = resolve_mechanism_for_fingerprint(
+                        validated, converter_class=converter_cls
+                    )
+                    fingerprint, cached = lookup_cached_result(
+                        cache_root,
+                        validated,
+                        mechanism=mechanism,
+                    )
                     if cached is None:
+                        from ..result_cache import find_result_by_config_snapshot
+
                         cached = find_result_by_config_snapshot(
                             cache_root, fingerprint, mechanism=mechanism
                         )
                     app.state.preloaded_result = cached
-                    app.state.preloaded_fingerprint = fingerprint if cached else None
+                    # Use the *actual* cache-entry fingerprint (directory name) so
+                    # that artifacts_dir_for() resolves correctly in export actions.
+                    app.state.preloaded_fingerprint = (
+                        cached.get("fingerprint") if cached else None
+                    )
                     if cached:
                         meta = cached.get("meta", {})
                         created = meta.get("created_at", 0.0)
+                        actual_fp = cached.get("fingerprint", fingerprint)
                         logger.info(
                             "Loaded cached simulation result for %s "
                             "(created %.0f s ago, fingerprint %s…)",
                             app.state.preloaded_filename,
                             time.time() - created,
-                            fingerprint[:12],
+                            actual_fp[:12],
                         )
                     else:
                         logger.info(

--- a/boulder/api/main.py
+++ b/boulder/api/main.py
@@ -121,16 +121,15 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
 
                 cache_root = cache_dir_for(str(actual_yaml_path))
                 if cache_root is not None:
-                    converter_cls = getattr(app.state, "converter_class", None)
                     mechanism = resolve_mechanism_for_fingerprint(
-                        validated, converter_class=converter_cls
+                        validated, converter_class=app.state.converter_class
                     )
                     fingerprint, cached = lookup_cached_result(
                         cache_root,
                         validated,
                         mechanism=mechanism,
                     )
-                    if cached is None:
+                    if cached is None and fingerprint is not None:
                         from ..result_cache import find_result_by_config_snapshot
 
                         cached = find_result_by_config_snapshot(
@@ -145,7 +144,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
                     if cached:
                         meta = cached.get("meta", {})
                         created = meta.get("created_at", 0.0)
-                        actual_fp = cached.get("fingerprint", fingerprint)
+                        actual_fp = str(cached.get("fingerprint") or fingerprint or "")
                         logger.info(
                             "Loaded cached simulation result for %s "
                             "(created %.0f s ago, fingerprint %s…)",
@@ -153,7 +152,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
                             time.time() - created,
                             actual_fp[:12],
                         )
-                    else:
+                    elif fingerprint is not None:
                         logger.info(
                             "No valid cache entry found for preloaded config "
                             "(fingerprint %s…). Run the simulation to populate the cache.",

--- a/boulder/api/routes/gui_actions.py
+++ b/boulder/api/routes/gui_actions.py
@@ -48,6 +48,14 @@ def _build_context(request: Request, body: Optional[GuiActionRunRequest] = None)
 
         simulation_data = get_completed_simulation_data(simulation_id)
 
+    preloaded_result = getattr(request.app.state, "preloaded_result", None)
+    preloaded_fingerprint = getattr(request.app.state, "preloaded_fingerprint", None)
+    has_cached_result = preloaded_result is not None
+    # Expose the fingerprint even when preloaded_result is not yet set (e.g.
+    # contributors are still writing artifacts).  Actions that can poll for
+    # bundle readiness use the fingerprint to locate the cache entry directory.
+    cache_fingerprint = preloaded_fingerprint
+
     return GuiActionContext(
         config=config,
         config_yaml=config_yaml,
@@ -55,12 +63,19 @@ def _build_context(request: Request, body: Optional[GuiActionRunRequest] = None)
         simulation_id=simulation_id,
         config_path=preloaded_config_path,
         simulation_data=simulation_data,
+        has_cached_result=has_cached_result,
+        cache_fingerprint=cache_fingerprint,
     )
 
 
 @router.get("")
 async def list_actions(request: Request) -> list[Dict[str, Any]]:
-    """Return metadata for GUI actions available in the current context."""
+    """Return metadata for GUI actions available in the current context.
+
+    Each entry includes ``is_available`` so the frontend can disable the
+    button when the server knows the action cannot run yet (e.g. no cache
+    and no completed simulation).
+    """
     from ...gui_actions import get_gui_action_registry
 
     registry = get_gui_action_registry()
@@ -70,6 +85,7 @@ async def list_actions(request: Request) -> list[Dict[str, Any]]:
             "id": action.action_id,
             "label": action.label,
             "requires_simulation": action.requires_simulation,
+            "is_available": action.is_available(context),
         }
         for action in registry.get_listed_actions(context)
     ]
@@ -96,7 +112,11 @@ async def run_action(
             detail="Action not available for current context",
         )
 
-    result = action.run(context)
+    try:
+        result = action.run(context)
+    except (ValueError, RuntimeError, FileNotFoundError) as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
     return Response(
         content=result.content,
         media_type=result.media_type,

--- a/boulder/api/routes/gui_actions.py
+++ b/boulder/api/routes/gui_actions.py
@@ -22,6 +22,11 @@ class GuiActionRunRequest(BaseModel):
 
 def _build_context(request: Request, body: Optional[GuiActionRunRequest] = None) -> Any:
     from ...gui_actions import GuiActionContext
+    from ...result_cache import (
+        cache_dir_for,
+        lookup_cached_result,
+        resolve_mechanism_for_fingerprint,
+    )
 
     preloaded_config = getattr(request.app.state, "preloaded_config", None)
     preloaded_yaml = getattr(request.app.state, "preloaded_yaml", None)
@@ -51,10 +56,22 @@ def _build_context(request: Request, body: Optional[GuiActionRunRequest] = None)
     preloaded_result = getattr(request.app.state, "preloaded_result", None)
     preloaded_fingerprint = getattr(request.app.state, "preloaded_fingerprint", None)
     has_cached_result = preloaded_result is not None
-    # Expose the fingerprint even when preloaded_result is not yet set (e.g.
-    # contributors are still writing artifacts).  Actions that can poll for
-    # bundle readiness use the fingerprint to locate the cache entry directory.
     cache_fingerprint = preloaded_fingerprint
+
+    if body is not None and body.config is not None and isinstance(config, dict):
+        converter_cls = getattr(request.app.state, "converter_class", None)
+        mechanism = resolve_mechanism_for_fingerprint(
+            config, converter_class=converter_cls
+        )
+        cache_root = cache_dir_for(preloaded_config_path)
+        fingerprint, cached = lookup_cached_result(
+            cache_root,
+            dict(config),
+            mechanism=mechanism,
+            preloaded_result=preloaded_result,
+        )
+        cache_fingerprint = fingerprint
+        has_cached_result = cached is not None
 
     return GuiActionContext(
         config=config,

--- a/boulder/api/routes/simulations.py
+++ b/boulder/api/routes/simulations.py
@@ -153,9 +153,14 @@ async def start_simulation(
             grid["stop"] = simulation_time
             grid["dt"] = time_step
 
-        # Create a fresh worker for this simulation
+        # Create a fresh worker for this simulation.
+        # Pass app.state so the worker can update preloaded_result after the
+        # solve completes without requiring a server restart.
         worker = SimulationWorker()
-        worker.start_simulation(converter, config, simulation_time, time_step)
+        worker.start_simulation(
+            converter, config, simulation_time, time_step,
+            app_state=request.app.state,
+        )
         _simulations[sim_id] = (worker, time.time())
 
         return {"simulation_id": sim_id}
@@ -256,6 +261,129 @@ async def stop_simulation(sim_id: str) -> Dict[str, Any]:
     # Remove the worker from the dictionary to free memory
     del _simulations[sim_id]
     return {"stopped": True, "simulation_id": sim_id}
+
+
+@router.post("/check-cache")
+async def check_simulation_cache(
+    body: StartSimulationRequest,
+    request: Request,
+) -> Dict[str, Any]:
+    """Check whether a cached result exists for the submitted config.
+
+    Computes the fingerprint from ``body.config`` (exactly as the simulation
+    worker would) and returns the matching entry when found.
+
+    Returns ``{"cached": true, "result": {...}, "fingerprint": "...", "meta": {...}}``
+    or ``{"cached": false}``.
+    """
+    from ...result_cache import cache_dir_for, compute_fingerprint, load_result_flexible
+
+    config = dict(body.config)
+    mechanism = body.mechanism
+    if not mechanism:
+        phases = config.get("phases", {})
+        if isinstance(phases, dict):
+            gas = phases.get("gas", {})
+            if isinstance(gas, dict):
+                mechanism = gas.get("mechanism")
+
+    config_path = getattr(request.app.state, "preloaded_config_path", None)
+    cache_root = cache_dir_for(config_path)
+    if cache_root is None:
+        return {"cached": False}
+
+    fingerprint = compute_fingerprint(config, mechanism=mechanism or None)
+    # Use flexible lookup: if a direct hit is absent, follow any alias file
+    # written for the post-build fingerprint during the last solve.
+    cached = load_result_flexible(cache_root, fingerprint)
+
+    if cached is None:
+        # Fallback: compare the incoming config fingerprint against the
+        # post-build config_snapshot stored in the server's preloaded result.
+        # This handles existing cache entries that were written before alias
+        # files were introduced, as well as any server restart where the
+        # preloaded_result is already loaded from disk.
+        preloaded = getattr(request.app.state, "preloaded_result", None)
+        if preloaded is not None:
+            snapshot = preloaded.get("config_snapshot") or {}
+            if snapshot:
+                snapshot_fp = compute_fingerprint(
+                    snapshot, mechanism=mechanism or None
+                )
+                if snapshot_fp == fingerprint:
+                    cached = preloaded
+
+    if cached is None:
+        return {"cached": False}
+
+    meta = cached.get("meta", {})
+    return {
+        "cached": True,
+        "fingerprint": fingerprint,
+        "result": cached.get("gui_payload", {}),
+        "config_snapshot": cached.get("config_snapshot", {}),
+        "meta": meta,
+    }
+
+
+@router.get("/cached")
+async def get_cached_result(request: Request) -> Dict[str, Any]:
+    """Return the cached simulation result for the preloaded configuration.
+
+    Returns ``{"cached": true, "result": {...}, "meta": {...}, "fingerprint": "..."}``
+    when a valid cache entry exists for the preloaded config fingerprint, or
+    ``{"cached": false}`` otherwise.
+    """
+    cached = getattr(request.app.state, "preloaded_result", None)
+    fingerprint = getattr(request.app.state, "preloaded_fingerprint", None)
+    if cached is None:
+        return {"cached": False}
+
+    meta = cached.get("meta", {})
+    return {
+        "cached": True,
+        "fingerprint": fingerprint,
+        "result": cached.get("gui_payload", {}),
+        "config_snapshot": cached.get("config_snapshot", {}),
+        "meta": meta,
+    }
+
+
+@router.get("/cached/artifacts/{artifact_name}")
+async def get_cached_artifact(
+    artifact_name: str,
+    request: Request,
+) -> Any:
+    """Serve a file from the cached artifacts directory.
+
+    Used by contributor plugins (e.g. Bloc) to fetch package-specific
+    artifacts they wrote during a previous solve.
+    """
+    from fastapi.responses import FileResponse
+
+    cached = getattr(request.app.state, "preloaded_result", None)
+    if cached is None:
+        raise HTTPException(status_code=404, detail="No cached result available")
+
+    artifacts_dir = cached.get("artifacts_dir")
+    if artifacts_dir is None:
+        raise HTTPException(status_code=404, detail="No artifacts directory in cache")
+
+    from pathlib import Path as _Path
+
+    artifact_path = _Path(artifacts_dir) / artifact_name
+    if not artifact_path.is_file():
+        raise HTTPException(
+            status_code=404,
+            detail=f"Artifact '{artifact_name}' not found in cache",
+        )
+    # Safety: ensure the resolved path stays inside the artifacts directory
+    try:
+        artifact_path.resolve().relative_to(_Path(artifacts_dir).resolve())
+    except ValueError:
+        raise HTTPException(status_code=403, detail="Path traversal denied")
+
+    return FileResponse(str(artifact_path))
 
 
 @router.post("/cleanup")

--- a/boulder/api/routes/simulations.py
+++ b/boulder/api/routes/simulations.py
@@ -158,7 +158,10 @@ async def start_simulation(
         # solve completes without requiring a server restart.
         worker = SimulationWorker()
         worker.start_simulation(
-            converter, config, simulation_time, time_step,
+            converter,
+            config,
+            simulation_time,
+            time_step,
             app_state=request.app.state,
         )
         _simulations[sim_id] = (worker, time.time())
@@ -276,42 +279,32 @@ async def check_simulation_cache(
     Returns ``{"cached": true, "result": {...}, "fingerprint": "...", "meta": {...}}``
     or ``{"cached": false}``.
     """
-    from ...result_cache import cache_dir_for, compute_fingerprint, load_result_flexible
+    from ...result_cache import (
+        cache_dir_for,
+        lookup_cached_result,
+        resolve_mechanism_for_fingerprint,
+    )
 
     config = dict(body.config)
-    mechanism = body.mechanism
-    if not mechanism:
-        phases = config.get("phases", {})
-        if isinstance(phases, dict):
-            gas = phases.get("gas", {})
-            if isinstance(gas, dict):
-                mechanism = gas.get("mechanism")
+    converter_cls = getattr(request.app.state, "converter_class", None)
+    mechanism = resolve_mechanism_for_fingerprint(
+        config,
+        converter_class=converter_cls,
+        body_mechanism=body.mechanism,
+    )
 
     config_path = getattr(request.app.state, "preloaded_config_path", None)
     cache_root = cache_dir_for(config_path)
     if cache_root is None:
         return {"cached": False}
 
-    fingerprint = compute_fingerprint(config, mechanism=mechanism or None)
-    # Use flexible lookup: if a direct hit is absent, follow any alias file
-    # written for the post-build fingerprint during the last solve.
-    cached = load_result_flexible(cache_root, fingerprint)
-
-    if cached is None:
-        # Fallback: compare the incoming config fingerprint against the
-        # post-build config_snapshot stored in the server's preloaded result.
-        # This handles existing cache entries that were written before alias
-        # files were introduced, as well as any server restart where the
-        # preloaded_result is already loaded from disk.
-        preloaded = getattr(request.app.state, "preloaded_result", None)
-        if preloaded is not None:
-            snapshot = preloaded.get("config_snapshot") or {}
-            if snapshot:
-                snapshot_fp = compute_fingerprint(
-                    snapshot, mechanism=mechanism or None
-                )
-                if snapshot_fp == fingerprint:
-                    cached = preloaded
+    preloaded = getattr(request.app.state, "preloaded_result", None)
+    fingerprint, cached = lookup_cached_result(
+        cache_root,
+        config,
+        mechanism=mechanism,
+        preloaded_result=preloaded,
+    )
 
     if cached is None:
         return {"cached": False}

--- a/boulder/cantera_converter.py
+++ b/boulder/cantera_converter.py
@@ -410,7 +410,9 @@ def get_plugins() -> BoulderPlugins:
     try:
         from .result_cache import get_cache_contributor_registry
 
-        plugins.cache_contributors = get_cache_contributor_registry().contributors.copy()
+        plugins.cache_contributors = (
+            get_cache_contributor_registry().contributors.copy()
+        )
     except ImportError as e:
         logger.debug(f"Cache contributor plugins not available: {e}")
 

--- a/boulder/cantera_converter.py
+++ b/boulder/cantera_converter.py
@@ -57,6 +57,7 @@ class BoulderPlugins:
         default_factory=dict
     )  # Summary builder plugins
     gui_actions: List[Any] = field(default_factory=list)
+    cache_contributors: List[Any] = field(default_factory=list)
     sankey_generator: Optional[Callable] = None  # Custom Sankey generation function
     #: Hex color mapping for species bands in the Sankey diagram.
     #: Keys: ``"H2"``, ``"CH4"``, ``"Cs"`` (and any others the plugin wants to add).
@@ -406,6 +407,13 @@ def get_plugins() -> BoulderPlugins:
     except ImportError as e:
         logger.debug(f"GUI action plugins not available: {e}")
 
+    try:
+        from .result_cache import get_cache_contributor_registry
+
+        plugins.cache_contributors = get_cache_contributor_registry().contributors.copy()
+    except ImportError as e:
+        logger.debug(f"Cache contributor plugins not available: {e}")
+
     _PLUGIN_CACHE = plugins
 
     if is_verbose_mode():
@@ -415,7 +423,8 @@ def get_plugins() -> BoulderPlugins:
             f"{len(plugins.post_build_hooks)} post-build hooks, "
             f"{len(plugins.output_pane_plugins)} output pane plugins, "
             f"{len(plugins.summary_builders)} summary builders, "
-            f"{len(plugins.gui_actions)} GUI actions"
+            f"{len(plugins.gui_actions)} GUI actions, "
+            f"{len(plugins.cache_contributors)} cache contributors"
         )
 
     return plugins

--- a/boulder/gui_actions.py
+++ b/boulder/gui_actions.py
@@ -21,6 +21,10 @@ class GuiActionContext:
     simulation_id: Optional[str] = None
     config_path: Optional[str] = None
     simulation_data: Optional[Dict[str, Any]] = None
+    #: True when a valid on-disk cache entry exists for the current config.
+    has_cached_result: bool = False
+    #: Fingerprint hex of the cached entry, or None when no cache is available.
+    cache_fingerprint: Optional[str] = None
 
 
 @dataclass

--- a/boulder/result_cache.py
+++ b/boulder/result_cache.py
@@ -225,8 +225,10 @@ def _package_install_dir(package: str) -> Optional[Path]:
         for entry in dist.files or []:
             if entry.name == "__init__.py":
                 loc = entry.locate()
-                if loc is not None and loc.is_file():
-                    return loc.parent
+                if loc is not None:
+                    loc_path = Path(loc)
+                    if loc_path.is_file():
+                        return loc_path.parent
         mod = importlib.import_module(package)
         mod_file = getattr(mod, "__file__", None)
         if mod_file:

--- a/boulder/result_cache.py
+++ b/boulder/result_cache.py
@@ -30,7 +30,9 @@ SHA-256 hex of canonical sorted-key JSON of:
 
 * normalized config (nodes, connections, settings, phases)
 * mechanism identity (content hash for local files; name+cantera-version for builtins)
-* package versions: boulder, cantera
+* package source identity (git HEAD + dirty token for editable installs)
+* cantera version
+* per-plugin source identity from ``BOULDER_PLUGINS``
 * ``BOULDER_PLUGINS`` env var
 * ``CACHE_VERSION`` integer
 
@@ -45,6 +47,7 @@ import json
 import logging
 import os
 import shutil
+import subprocess
 import tempfile
 import time
 from abc import ABC, abstractmethod
@@ -137,14 +140,7 @@ def _mechanism_identity(mechanism: Optional[str]) -> str:
 
 
 def _package_version(package: str) -> str:
-    """Return the base (major.minor.patch) version of *package*, or 'unknown'.
-
-    Development-install suffixes (``.dev*``, ``+local``, ``.dirty``) are
-    stripped so that cache entries survive code edits within the same release
-    series.  :data:`CACHE_VERSION` is the authoritative discriminator for
-    schema-breaking changes; a version bump (e.g. 0.5.4 → 0.5.5) still
-    produces a different fingerprint and invalidates old entries.
-    """
+    """Return the base (major.minor.patch) version of *package*, or 'unknown'."""
     try:
         import re
         from importlib.metadata import version
@@ -154,6 +150,211 @@ def _package_version(package: str) -> str:
         return m.group(1) if m else raw
     except Exception:
         return "unknown"
+
+
+def _ignore_code_changes() -> bool:
+    """Return True when ``BOULDER_CACHE_IGNORE_CODE`` disables git-based identity."""
+    return os.environ.get("BOULDER_CACHE_IGNORE_CODE", "").strip().lower() in (
+        "1",
+        "true",
+        "yes",
+    )
+
+
+def _find_git_root(start: Path) -> Optional[Path]:
+    """Walk parents of *start* looking for a ``.git`` directory."""
+    current = start.resolve()
+    for parent in [current, *current.parents]:
+        if (parent / ".git").exists():
+            return parent
+    return None
+
+
+def _git_head(repo_dir: Path) -> Optional[str]:
+    """Return ``git rev-parse HEAD`` for *repo_dir*, or None."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=repo_dir,
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+        if result.returncode == 0:
+            return result.stdout.strip()
+    except (OSError, subprocess.SubprocessError):
+        pass
+    return None
+
+
+def _git_dirty_token(repo_dir: Path) -> Optional[str]:
+    """Return a short hash when the work tree has uncommitted or untracked changes."""
+    try:
+        status = subprocess.run(
+            ["git", "status", "--porcelain"],
+            cwd=repo_dir,
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+        diff = subprocess.run(
+            ["git", "diff", "HEAD"],
+            cwd=repo_dir,
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+        combined = (status.stdout or "") + (diff.stdout or "")
+        if not combined.strip():
+            return None
+        return hashlib.sha256(combined.encode()).hexdigest()[:12]
+    except (OSError, subprocess.SubprocessError):
+        return None
+
+
+def _package_install_dir(package: str) -> Optional[Path]:
+    """Return the on-disk directory for *package*, when discoverable."""
+    try:
+        import importlib
+        from importlib.metadata import distribution
+
+        dist = distribution(package)
+        for entry in dist.files or []:
+            if entry.name == "__init__.py":
+                loc = entry.locate()
+                if loc is not None and loc.is_file():
+                    return loc.parent
+        mod = importlib.import_module(package)
+        mod_file = getattr(mod, "__file__", None)
+        if mod_file:
+            return Path(mod_file).parent
+    except Exception:
+        pass
+    return None
+
+
+def _source_identity(package: str) -> str:
+    """Return a stable identity string for *package* source code.
+
+    When the install lives inside a git work tree, uses ``HEAD`` plus a dirty
+    token derived from ``git diff`` and ``git status``.  Falls back to the
+    stripped package version for wheel installs or when git is unavailable.
+
+    Set ``BOULDER_CACHE_IGNORE_CODE=1`` to restore version-only identity.
+    """
+    if _ignore_code_changes():
+        return _package_version(package)
+
+    install_dir = _package_install_dir(package)
+    if install_dir is None:
+        return _package_version(package)
+
+    git_root = _find_git_root(install_dir)
+    if git_root is None:
+        return _package_version(package)
+
+    head = _git_head(git_root)
+    if head is None:
+        return _package_version(package)
+
+    dirty = _git_dirty_token(git_root)
+    if dirty:
+        return f"git:{head[:12]}+dirty:{dirty}"
+    return f"git:{head[:12]}"
+
+
+def _plugins_source_identity() -> Dict[str, str]:
+    """Return source-identity strings for each top-level ``BOULDER_PLUGINS`` package."""
+    plugins_env = os.environ.get("BOULDER_PLUGINS", "").strip()
+    if not plugins_env:
+        return {}
+
+    identities: Dict[str, str] = {}
+    for entry in plugins_env.split(","):
+        module_name = entry.strip()
+        if not module_name:
+            continue
+        root_pkg = module_name.split(".")[0]
+        if root_pkg in identities:
+            continue
+        try:
+            import importlib
+
+            mod = importlib.import_module(module_name)
+            pkg_name = (mod.__package__ or module_name).split(".")[0]
+            identities[pkg_name] = _source_identity(pkg_name)
+        except ImportError:
+            identities[root_pkg] = _source_identity(root_pkg)
+    return identities
+
+
+def mechanism_from_config(
+    config: Dict[str, Any],
+    body_mechanism: Optional[str] = None,
+) -> str:
+    """Extract the mechanism string from *config* or an explicit POST override."""
+    if body_mechanism:
+        return body_mechanism
+    phases = config.get("phases", {})
+    if isinstance(phases, dict):
+        gas = phases.get("gas", {})
+        if isinstance(gas, dict):
+            mechanism = gas.get("mechanism")
+            if mechanism:
+                return str(mechanism)
+    return "gri30.yaml"
+
+
+def resolve_mechanism_for_fingerprint(
+    config: Dict[str, Any],
+    converter_class: Any = None,
+    body_mechanism: Optional[str] = None,
+) -> str:
+    """Resolve the mechanism string used for cache fingerprinting.
+
+    Applies :meth:`~boulder.cantera_converter.DualCanteraConverter.resolve_mechanism`
+    from *converter_class* when provided, without constructing a full converter
+    (avoids loading Cantera during cache lookups).
+    """
+    raw = mechanism_from_config(config, body_mechanism=body_mechanism)
+    if converter_class is None:
+        return raw
+    try:
+        instance = object.__new__(converter_class)
+        return converter_class.resolve_mechanism(instance, raw)
+    except Exception:
+        return raw
+
+
+def lookup_cached_result(
+    cache_root: Optional[Path],
+    config: Dict[str, Any],
+    mechanism: Optional[str] = None,
+    preloaded_result: Optional[Dict[str, Any]] = None,
+) -> tuple[Optional[str], Optional[Dict[str, Any]]]:
+    """Compute a fingerprint and load a matching cache entry when present.
+
+    Returns
+    -------
+    tuple
+        ``(fingerprint, cached_entry)``.  *fingerprint* is always computed
+        when *cache_root* is set; *cached_entry* is ``None`` on a miss.
+    """
+    if cache_root is None:
+        return None, None
+
+    fingerprint = compute_fingerprint(config, mechanism=mechanism)
+    cached = load_result_flexible(cache_root, fingerprint)
+    if cached is None and preloaded_result is not None:
+        snapshot = preloaded_result.get("config_snapshot") or {}
+        if snapshot:
+            snapshot_fp = compute_fingerprint(snapshot, mechanism=mechanism)
+            if snapshot_fp == fingerprint:
+                cached = preloaded_result
+    return fingerprint, cached
 
 
 def compute_fingerprint(
@@ -182,8 +383,9 @@ def compute_fingerprint(
         "cache_version": CACHE_VERSION,
         "config": _coerce(config),
         "mechanism": _mechanism_identity(mechanism),
-        "boulder_version": _package_version("boulder"),
+        "boulder_source": _source_identity("boulder"),
         "cantera_version": _package_version("cantera"),
+        "plugins_source": _plugins_source_identity(),
         "boulder_plugins": os.environ.get("BOULDER_PLUGINS", ""),
     }
     if extra:
@@ -385,7 +587,9 @@ def save_alias(cache_root: Path, alias_fp: str, canonical_fp: str) -> None:
     logger.debug("Cache alias written: %s → %s", alias_fp[:12], canonical_fp[:12])
 
 
-def load_result_flexible(cache_root: Path, fingerprint: str) -> Optional[Dict[str, Any]]:
+def load_result_flexible(
+    cache_root: Path, fingerprint: str
+) -> Optional[Dict[str, Any]]:
     """Load a cached result, following alias files when needed.
 
     Tries the direct entry first; if absent, checks for a
@@ -450,9 +654,7 @@ def find_result_by_config_snapshot(
             result_data = json.loads(
                 (entry_dir / "result.json").read_text(encoding="utf-8")
             )
-            meta = json.loads(
-                (entry_dir / "meta.json").read_text(encoding="utf-8")
-            )
+            meta = json.loads((entry_dir / "meta.json").read_text(encoding="utf-8"))
             if meta.get("cache_version") != CACHE_VERSION:
                 continue
             snapshot = result_data.get("config_snapshot") or {}
@@ -479,6 +681,23 @@ def clear_cache(cache_root: Path) -> None:
     logger.info("Cache cleared: %s", cache_root)
 
 
+def _prune_orphan_aliases(cache_root: Path) -> None:
+    """Remove alias files whose canonical cache entry no longer exists."""
+    if not cache_root.exists():
+        return
+    for alias_file in cache_root.iterdir():
+        if not alias_file.is_file() or not alias_file.name.startswith("_alias_"):
+            continue
+        try:
+            canonical_fp = alias_file.read_text(encoding="utf-8").strip()
+            target_dir = _entry_dir(cache_root, canonical_fp)
+            if not (target_dir / "COMPLETE").exists():
+                alias_file.unlink(missing_ok=True)
+                logger.debug("Pruned orphan cache alias: %s", alias_file.name[:20])
+        except OSError:
+            continue
+
+
 def _prune_cache(cache_root: Path) -> None:
     """Remove oldest cache entries when count exceeds :data:`MAX_CACHE_ENTRIES`."""
     entries = [
@@ -486,12 +705,12 @@ def _prune_cache(cache_root: Path) -> None:
         for d in cache_root.iterdir()
         if d.is_dir() and not d.name.startswith("_tmp_") and (d / "COMPLETE").exists()
     ]
-    if len(entries) <= MAX_CACHE_ENTRIES:
-        return
-    entries.sort(key=lambda d: (d / "COMPLETE").stat().st_mtime)
-    for old in entries[: len(entries) - MAX_CACHE_ENTRIES]:
-        shutil.rmtree(old, ignore_errors=True)
-        logger.debug("Pruned cache entry: %s", old.name[:12])
+    if len(entries) > MAX_CACHE_ENTRIES:
+        entries.sort(key=lambda d: (d / "COMPLETE").stat().st_mtime)
+        for old in entries[: len(entries) - MAX_CACHE_ENTRIES]:
+            shutil.rmtree(old, ignore_errors=True)
+            logger.debug("Pruned cache entry: %s", old.name[:12])
+    _prune_orphan_aliases(cache_root)
 
 
 # ---------------------------------------------------------------------------

--- a/boulder/result_cache.py
+++ b/boulder/result_cache.py
@@ -1,0 +1,605 @@
+"""On-disk cache of the last simulation result.
+
+Boulder stores the GUI results payload (times, reactor series, reports,
+Sankey, summary, updated nodes/connections) to a fingerprinted directory
+next to the loaded YAML file.  On startup, if the preloaded config
+fingerprint matches a cache entry, Boulder loads it and sends it to the
+frontend immediately so outputs are visible without re-running.
+
+Host packages (e.g. Bloc) register :class:`CacheContributorPlugin`
+implementations.  After each successful GUI solve, Boulder calls every
+registered contributor so they can write package-specific artifacts
+(e.g. a calc-note bundle JSON + figure PNGs) into the same cache entry.
+The contributor receives the solved ``converter`` so it can access
+live network objects.
+
+Cache layout
+------------
+::
+
+    <yaml_dir>/.boulder-cache/         (or $BOULDER_CACHE_DIR)
+        <fingerprint>/
+            result.json                GUI payload + config snapshot
+            meta.json                  created_at, versions, fingerprint inputs
+            COMPLETE                   marker written last (atomic write guard)
+            artifacts/                 contributor-written files
+
+Fingerprint
+-----------
+SHA-256 hex of canonical sorted-key JSON of:
+
+* normalized config (nodes, connections, settings, phases)
+* mechanism identity (content hash for local files; name+cantera-version for builtins)
+* package versions: boulder, cantera
+* ``BOULDER_PLUGINS`` env var
+* ``CACHE_VERSION`` integer
+
+:data:`CACHE_VERSION` must be bumped whenever the ``result.json``
+or ``meta.json`` schema changes.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import shutil
+import tempfile
+import time
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from datetime import date, datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+#: Bump when result.json / meta.json schema changes to auto-invalidate old entries.
+CACHE_VERSION: int = 1
+
+#: Keep at most this many cache entries per cache directory (oldest pruned first).
+MAX_CACHE_ENTRIES: int = 5
+
+
+# ---------------------------------------------------------------------------
+# JSON coercion helpers
+# ---------------------------------------------------------------------------
+
+
+def _coerce(obj: Any) -> Any:
+    """Recursively coerce *obj* to JSON-native types.
+
+    Handles numpy scalars/arrays, Path objects, tuples, and datetime objects.
+
+    Integer-valued floats (e.g. ``0.0``, ``1.0``) are normalised to ``int``
+    so that a value that starts as ``0.0`` in a Pydantic-validated config
+    produces the same fingerprint as ``0`` after a JavaScript JSON round-trip
+    (``JSON.stringify`` drops the ``.0`` for whole-number floats).
+    """
+    if obj is None or isinstance(obj, (bool, str)):
+        return obj
+    if isinstance(obj, float):
+        # Normalise integer-valued floats (0.0 → 0, 1.0 → 1) to produce
+        # stable fingerprints across Python↔JavaScript JSON round-trips.
+        if obj.is_integer():
+            return int(obj)
+        return obj
+    if isinstance(obj, int):
+        return obj
+    # numpy scalar
+    if hasattr(obj, "item"):
+        return obj.item()
+    # numpy array or other array-like with tolist()
+    if hasattr(obj, "tolist"):
+        return _coerce(obj.tolist())
+    if isinstance(obj, Path):
+        return str(obj)
+    # datetime/date objects (e.g. from YAML date fields like 2026-03-26)
+    if isinstance(obj, (datetime, date)):
+        return obj.isoformat()
+    if isinstance(obj, dict):
+        return {str(k): _coerce(v) for k, v in obj.items()}
+    if isinstance(obj, (list, tuple)):
+        return [_coerce(v) for v in obj]
+    return obj
+
+
+# ---------------------------------------------------------------------------
+# Fingerprinting
+# ---------------------------------------------------------------------------
+
+
+def _mechanism_identity(mechanism: Optional[str]) -> str:
+    """Return a stable string identifying the mechanism for hashing.
+
+    For a local file path: sha256 of the file content.
+    For a built-in Cantera mechanism name (no path separator, ends with .yaml
+    or .cti, or is a known format): ``"builtin:<name>@cantera-<version>"``.
+    Falls back to the bare name if unresolvable.
+    """
+    if not mechanism:
+        return "builtin:gri30.yaml"
+
+    p = Path(mechanism)
+    if p.is_file():
+        digest = hashlib.sha256(p.read_bytes()).hexdigest()[:16]
+        return f"file:{p.name}@{digest}"
+
+    # Not a local file — treat as built-in
+    try:
+        import cantera as ct  # type: ignore
+
+        ct_version = getattr(ct, "__version__", "unknown")
+    except ImportError:
+        ct_version = "unknown"
+    return f"builtin:{mechanism}@cantera-{ct_version}"
+
+
+def _package_version(package: str) -> str:
+    """Return the base (major.minor.patch) version of *package*, or 'unknown'.
+
+    Development-install suffixes (``.dev*``, ``+local``, ``.dirty``) are
+    stripped so that cache entries survive code edits within the same release
+    series.  :data:`CACHE_VERSION` is the authoritative discriminator for
+    schema-breaking changes; a version bump (e.g. 0.5.4 → 0.5.5) still
+    produces a different fingerprint and invalidates old entries.
+    """
+    try:
+        import re
+        from importlib.metadata import version
+
+        raw = version(package)
+        m = re.match(r"^(\d+\.\d+\.\d+)", raw)
+        return m.group(1) if m else raw
+    except Exception:
+        return "unknown"
+
+
+def compute_fingerprint(
+    config: Dict[str, Any],
+    mechanism: Optional[str] = None,
+    extra: Optional[Dict[str, Any]] = None,
+) -> str:
+    """Compute a cache fingerprint (sha256 hex) for *config*.
+
+    Parameters
+    ----------
+    config:
+        Fully normalised simulation config dict (nodes/connections/settings/phases).
+    mechanism:
+        Mechanism string from the POST body or resolved from config.
+    extra:
+        Additional key/value pairs included verbatim in the hash (e.g.
+        ``{"simulation_time": 10.0, "time_step": 1.0}``).
+
+    Returns
+    -------
+    str
+        64-character hex digest.
+    """
+    key: Dict[str, Any] = {
+        "cache_version": CACHE_VERSION,
+        "config": _coerce(config),
+        "mechanism": _mechanism_identity(mechanism),
+        "boulder_version": _package_version("boulder"),
+        "cantera_version": _package_version("cantera"),
+        "boulder_plugins": os.environ.get("BOULDER_PLUGINS", ""),
+    }
+    if extra:
+        key["extra"] = _coerce(extra)
+
+    canonical = json.dumps(key, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode()).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Cache directory resolution
+# ---------------------------------------------------------------------------
+
+
+def cache_dir_for(config_path: Optional[str]) -> Optional[Path]:
+    """Return the cache directory for *config_path*.
+
+    Respects ``$BOULDER_CACHE_DIR`` override.  Returns ``None`` when neither
+    the override nor a valid config path is available.
+    """
+    override = os.environ.get("BOULDER_CACHE_DIR", "").strip()
+    if override:
+        return Path(override)
+    if config_path:
+        return Path(config_path).parent / ".boulder-cache"
+    return None
+
+
+def _entry_dir(cache_root: Path, fingerprint: str) -> Path:
+    return cache_root / fingerprint
+
+
+# ---------------------------------------------------------------------------
+# Save / load
+# ---------------------------------------------------------------------------
+
+
+def save_result(
+    cache_root: Path,
+    fingerprint: str,
+    gui_payload: Dict[str, Any],
+    config_snapshot: Dict[str, Any],
+    mechanism: Optional[str] = None,
+    meta_extra: Optional[Dict[str, Any]] = None,
+) -> Path:
+    """Atomically persist the GUI payload and config snapshot to disk.
+
+    Creates ``<cache_root>/<fingerprint>/result.json``,
+    ``meta.json``, and the ``COMPLETE`` marker.  Prunes old entries to keep
+    at most :data:`MAX_CACHE_ENTRIES`.
+
+    Parameters
+    ----------
+    cache_root:
+        Root cache directory (``<yaml_dir>/.boulder-cache`` or override).
+    fingerprint:
+        Hex digest from :func:`compute_fingerprint`.
+    gui_payload:
+        The complete GUI results dict (times, reactor_reports, etc.).
+    config_snapshot:
+        Post-solve config dict (post stream-point enrichment).
+    mechanism:
+        Mechanism string for meta logging.
+    meta_extra:
+        Additional fields written into ``meta.json`` (e.g. contributor names).
+
+    Returns
+    -------
+    Path
+        The cache entry directory.
+    """
+    cache_root.mkdir(parents=True, exist_ok=True)
+    entry = _entry_dir(cache_root, fingerprint)
+    artifacts_dir = entry / "artifacts"
+
+    # Use a temp dir inside the cache root for atomic replacement
+    tmp_dir = Path(tempfile.mkdtemp(dir=cache_root, prefix="_tmp_"))
+    try:
+        (tmp_dir / "artifacts").mkdir()
+
+        result_data = {
+            "gui_payload": _coerce(gui_payload),
+            "config_snapshot": _coerce(config_snapshot),
+        }
+        _write_json(tmp_dir / "result.json", result_data)
+
+        meta: Dict[str, Any] = {
+            "fingerprint": fingerprint,
+            "cache_version": CACHE_VERSION,
+            "created_at": time.time(),
+            "boulder_version": _package_version("boulder"),
+            "cantera_version": _package_version("cantera"),
+            "mechanism": mechanism or "",
+        }
+        if meta_extra:
+            meta.update(_coerce(meta_extra))
+        _write_json(tmp_dir / "meta.json", meta)
+
+        # Not yet COMPLETE — move into place first
+        if entry.exists():
+            shutil.rmtree(entry)
+        shutil.move(str(tmp_dir), str(entry))
+        artifacts_dir = entry / "artifacts"
+        artifacts_dir.mkdir(exist_ok=True)
+
+    except Exception:
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+        raise
+
+    # Write COMPLETE marker atomically
+    _write_complete_marker(entry)
+
+    _prune_cache(cache_root)
+    logger.info("Cache entry written: %s/%s", cache_root.name, fingerprint[:12])
+    return entry
+
+
+def _write_json(path: Path, data: Any) -> None:
+    """Write *data* as JSON to *path* atomically via temp file + rename."""
+    tmp = path.with_suffix(".tmp")
+    tmp.write_text(json.dumps(data, indent=2, ensure_ascii=False), encoding="utf-8")
+    tmp.replace(path)
+
+
+def _write_complete_marker(entry: Path) -> None:
+    """Write the COMPLETE marker atomically."""
+    marker = entry / "COMPLETE"
+    tmp = entry / "COMPLETE.tmp"
+    tmp.write_text(str(time.time()), encoding="utf-8")
+    tmp.replace(marker)
+
+
+def load_result(
+    cache_root: Path,
+    fingerprint: str,
+) -> Optional[Dict[str, Any]]:
+    """Load a cached result entry.
+
+    Returns ``None`` when the entry does not exist, is incomplete
+    (missing COMPLETE marker), or cannot be parsed.
+
+    Returns
+    -------
+    dict or None
+        Keys: ``"gui_payload"``, ``"config_snapshot"``, ``"meta"``,
+        ``"artifacts_dir"`` (Path), ``"fingerprint"`` (str).
+    """
+    entry = _entry_dir(cache_root, fingerprint)
+    if not (entry / "COMPLETE").exists():
+        return None
+    try:
+        result_data = json.loads((entry / "result.json").read_text(encoding="utf-8"))
+        meta = json.loads((entry / "meta.json").read_text(encoding="utf-8"))
+        if meta.get("cache_version") != CACHE_VERSION:
+            logger.debug("Cache entry version mismatch, ignoring: %s", fingerprint[:12])
+            return None
+        return {
+            "fingerprint": fingerprint,
+            "gui_payload": result_data.get("gui_payload", {}),
+            "config_snapshot": result_data.get("config_snapshot", {}),
+            "meta": meta,
+            "artifacts_dir": entry / "artifacts",
+        }
+    except (OSError, json.JSONDecodeError, KeyError) as exc:
+        logger.debug("Failed to load cache entry %s: %s", fingerprint[:12], exc)
+        return None
+
+
+def artifacts_dir_for(cache_root: Path, fingerprint: str) -> Optional[Path]:
+    """Return the artifacts directory for a valid cache entry, or None."""
+    entry = _entry_dir(cache_root, fingerprint)
+    if not (entry / "COMPLETE").exists():
+        return None
+    return entry / "artifacts"
+
+
+# ---------------------------------------------------------------------------
+# Alias support (pre-build ↔ post-build fingerprint mapping)
+# ---------------------------------------------------------------------------
+
+
+def _alias_path(cache_root: Path, alias_fp: str) -> Path:
+    """Return the path for an alias file mapping *alias_fp* to a canonical entry."""
+    return cache_root / f"_alias_{alias_fp}"
+
+
+def save_alias(cache_root: Path, alias_fp: str, canonical_fp: str) -> None:
+    """Write an alias file mapping *alias_fp* → *canonical_fp*.
+
+    Used to map post-build fingerprints to the pre-build (canonical) cache
+    entry so that :func:`load_result_flexible` finds hits regardless of
+    whether the caller provides a pre-build or post-build fingerprint.
+    """
+    cache_root.mkdir(parents=True, exist_ok=True)
+    alias_file = _alias_path(cache_root, alias_fp)
+    tmp = alias_file.with_suffix(".tmp")
+    tmp.write_text(canonical_fp, encoding="utf-8")
+    tmp.replace(alias_file)
+    logger.debug("Cache alias written: %s → %s", alias_fp[:12], canonical_fp[:12])
+
+
+def load_result_flexible(cache_root: Path, fingerprint: str) -> Optional[Dict[str, Any]]:
+    """Load a cached result, following alias files when needed.
+
+    Tries the direct entry first; if absent, checks for a
+    ``_alias_<fingerprint>`` file written when a post-build fingerprint
+    was aliased to the canonical (pre-build) cache entry.
+
+    Returns
+    -------
+    dict or None
+        Same structure as :func:`load_result`.
+    """
+    result = load_result(cache_root, fingerprint)
+    if result is not None:
+        return result
+    alias_file = _alias_path(cache_root, fingerprint)
+    if alias_file.is_file():
+        try:
+            canonical_fp = alias_file.read_text(encoding="utf-8").strip()
+            return load_result(cache_root, canonical_fp)
+        except OSError:
+            return None
+    return None
+
+
+def find_result_by_config_snapshot(
+    cache_root: Path,
+    fingerprint: str,
+    mechanism: Optional[str] = None,
+) -> Optional[Dict[str, Any]]:
+    """Scan cache entries for one whose ``config_snapshot`` fingerprint matches.
+
+    This bridges the gap when the startup fingerprint (from the pre-build
+    validated config) differs from the key under which the entry was stored
+    (worker's pre-build fingerprint), but the POST-build ``config_snapshot``
+    happens to match the startup fingerprint.  This occurs because of minor
+    type differences (e.g. ``0.0`` float vs ``0`` int after JSON round-trips)
+    that the ``_coerce`` normaliser now eliminates, so new entries will hash
+    consistently.  The scan is only needed for entries written by older code.
+
+    Parameters
+    ----------
+    cache_root:
+        Root cache directory.
+    fingerprint:
+        The fingerprint to search for in stored ``config_snapshot`` fields.
+    mechanism:
+        Mechanism string used when computing the snapshot fingerprint.
+
+    Returns
+    -------
+    dict or None
+        Same structure as :func:`load_result`, or ``None`` if not found.
+    """
+    if not cache_root.exists():
+        return None
+    for entry_dir in cache_root.iterdir():
+        if not entry_dir.is_dir() or entry_dir.name.startswith("_"):
+            continue
+        if not (entry_dir / "COMPLETE").exists():
+            continue
+        try:
+            result_data = json.loads(
+                (entry_dir / "result.json").read_text(encoding="utf-8")
+            )
+            meta = json.loads(
+                (entry_dir / "meta.json").read_text(encoding="utf-8")
+            )
+            if meta.get("cache_version") != CACHE_VERSION:
+                continue
+            snapshot = result_data.get("config_snapshot") or {}
+            if not snapshot:
+                continue
+            snapshot_fp = compute_fingerprint(snapshot, mechanism=mechanism)
+            if snapshot_fp == fingerprint:
+                return {
+                    "fingerprint": entry_dir.name,
+                    "gui_payload": result_data.get("gui_payload", {}),
+                    "config_snapshot": snapshot,
+                    "meta": meta,
+                    "artifacts_dir": entry_dir / "artifacts",
+                }
+        except (OSError, json.JSONDecodeError, KeyError):
+            continue
+    return None
+
+
+def clear_cache(cache_root: Path) -> None:
+    """Remove all cache entries under *cache_root*."""
+    if cache_root.exists():
+        shutil.rmtree(cache_root)
+    logger.info("Cache cleared: %s", cache_root)
+
+
+def _prune_cache(cache_root: Path) -> None:
+    """Remove oldest cache entries when count exceeds :data:`MAX_CACHE_ENTRIES`."""
+    entries = [
+        d
+        for d in cache_root.iterdir()
+        if d.is_dir() and not d.name.startswith("_tmp_") and (d / "COMPLETE").exists()
+    ]
+    if len(entries) <= MAX_CACHE_ENTRIES:
+        return
+    entries.sort(key=lambda d: (d / "COMPLETE").stat().st_mtime)
+    for old in entries[: len(entries) - MAX_CACHE_ENTRIES]:
+        shutil.rmtree(old, ignore_errors=True)
+        logger.debug("Pruned cache entry: %s", old.name[:12])
+
+
+# ---------------------------------------------------------------------------
+# CacheContributorPlugin — plugin hook for host packages
+# ---------------------------------------------------------------------------
+
+
+class CacheContributorPlugin(ABC):
+    """Plugin that writes package-specific artifacts into a Boulder cache entry.
+
+    Implement this in a host package to persist additional derived data
+    (e.g. calculation-note bundles, figure PNGs) alongside Boulder's GUI
+    payload.  Boulder calls :meth:`contribute` after a successful solve.
+
+    Parameters to :meth:`contribute`
+    ----------------------------------
+    config:
+        Post-solve, fully normalised config dict (post stream-point enrichment).
+    converter:
+        The solved :class:`~boulder.cantera_converter.DualCanteraConverter`
+        instance (gives access to live network objects for stream points, etc.).
+    simulation_result:
+        :class:`~boulder.simulation_result.SimulationResult` built from the
+        converter after the solve.
+    fingerprint:
+        Hex digest identifying this cache entry.
+    artifacts_dir:
+        Directory where the contributor should write its files.  It exists
+        and is writable before :meth:`contribute` is called.
+    """
+
+    @property
+    @abstractmethod
+    def contributor_id(self) -> str:
+        """Unique identifier for this contributor."""
+
+    @abstractmethod
+    def contribute(
+        self,
+        config: Dict[str, Any],
+        converter: Any,
+        simulation_result: Any,
+        fingerprint: str,
+        artifacts_dir: Path,
+    ) -> None:
+        """Write artifacts into *artifacts_dir*.
+
+        Must not raise: failures are logged but must not abort the live solve.
+        Prefer explicit ``except SomeError`` over broad ``except Exception``
+        inside implementations.
+        """
+
+
+@dataclass
+class CacheContributorRegistry:
+    """Registry for cache contributor plugins."""
+
+    contributors: List[CacheContributorPlugin] = field(default_factory=list)
+
+    def register(self, plugin: CacheContributorPlugin) -> None:
+        """Register *plugin*, silently skipping duplicate IDs."""
+        existing = {c.contributor_id for c in self.contributors}
+        if plugin.contributor_id in existing:
+            return
+        self.contributors.append(plugin)
+
+
+_cache_contributor_registry = CacheContributorRegistry()
+
+
+def get_cache_contributor_registry() -> CacheContributorRegistry:
+    """Return the global cache contributor registry."""
+    return _cache_contributor_registry
+
+
+def register_cache_contributor(plugin: CacheContributorPlugin) -> None:
+    """Register a :class:`CacheContributorPlugin` with the global registry."""
+    _cache_contributor_registry.register(plugin)
+
+
+def run_contributors(
+    contributors: List[CacheContributorPlugin],
+    config: Dict[str, Any],
+    converter: Any,
+    simulation_result: Any,
+    fingerprint: str,
+    artifacts_dir: Path,
+) -> None:
+    """Call each contributor, logging but not re-raising on failure."""
+    for contributor in contributors:
+        try:
+            contributor.contribute(
+                config, converter, simulation_result, fingerprint, artifacts_dir
+            )
+            logger.debug(
+                "Cache contributor %s completed for %s",
+                contributor.contributor_id,
+                fingerprint[:12],
+            )
+        except OSError as exc:
+            logger.warning(
+                "Cache contributor %s failed (OSError): %s",
+                contributor.contributor_id,
+                exc,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "Cache contributor %s failed: %s",
+                contributor.contributor_id,
+                exc,
+            )

--- a/boulder/simulation_worker.py
+++ b/boulder/simulation_worker.py
@@ -346,8 +346,13 @@ class SimulationWorker:
             # Persist results to disk cache (best-effort: never aborts the solve).
             # Pass pre_build_config so the fingerprint matches the startup fingerprint.
             self._persist_to_cache(
-                converter, config, results, reactor_reports, connection_reports,
-                code_str, pre_build_config=pre_build_config,
+                converter,
+                config,
+                results,
+                reactor_reports,
+                connection_reports,
+                code_str,
+                pre_build_config=pre_build_config,
             )
 
         except Exception as e:
@@ -392,11 +397,14 @@ class SimulationWorker:
             )
             from .simulation_result import make_simulation_result
 
-            mechanism = getattr(converter, "mechanism", None)
+            mechanism_raw = getattr(converter, "mechanism", None) or "gri30.yaml"
+            mechanism = converter.resolve_mechanism(mechanism_raw)
             config_path = getattr(converter, "_download_config_path", None)
             cache_root = cache_dir_for(config_path)
             if cache_root is None:
-                logger.debug("No cache root available (no config path); skipping cache.")
+                logger.debug(
+                    "No cache root available (no config path); skipping cache."
+                )
                 return
 
             progress = self.get_progress()
@@ -455,7 +463,8 @@ class SimulationWorker:
                 save_alias(cache_root, post_build_fp, fingerprint)
                 logger.debug(
                     "Cache post-build alias written: %s → %s",
-                    post_build_fp[:12], fingerprint[:12],
+                    post_build_fp[:12],
+                    fingerprint[:12],
                 )
 
             artifacts_dir = entry / "artifacts"
@@ -473,7 +482,9 @@ class SimulationWorker:
                         fingerprint[:12],
                     )
                 except Exception as state_exc:  # noqa: BLE001
-                    logger.debug("Could not update app.state (pre-contrib): %s", state_exc)
+                    logger.debug(
+                        "Could not update app.state (pre-contrib): %s", state_exc
+                    )
 
             contributors = getattr(
                 getattr(converter, "plugins", None), "cache_contributors", []

--- a/boulder/simulation_worker.py
+++ b/boulder/simulation_worker.py
@@ -104,6 +104,9 @@ class SimulationWorker:
         self._lock = threading.Lock()
         self._stop_event = threading.Event()
         self._worker_thread: Optional[threading.Thread] = None
+        #: Optional reference to FastAPI app.state; updated with cache result on
+        #: successful solve so GUI actions see the new cache without server restart.
+        self._app_state: Optional[Any] = None
 
     def start_simulation(
         self,
@@ -111,6 +114,7 @@ class SimulationWorker:
         config: Dict[str, Any],
         simulation_time: float = 10.0,
         time_step: float = 1.0,
+        app_state: Optional[Any] = None,
     ) -> None:
         """Start a background simulation."""
         if self._worker_thread and self._worker_thread.is_alive():
@@ -119,6 +123,7 @@ class SimulationWorker:
 
         # Reset state
         self._stop_event.clear()
+        self._app_state = app_state
         with self._lock:
             self.progress = SimulationProgress()
 
@@ -202,6 +207,18 @@ class SimulationWorker:
                 self.progress.n_stages = 0
 
             logger.info("Building Cantera network in background...")
+
+            # Snapshot nodes/connections before build_network mutates the config
+            # in-place (staged solver adds outlet/interface nodes).  The pre-build
+            # snapshot is used for fingerprinting so the startup fingerprint—
+            # computed from the un-enriched validated config—matches the cache entry.
+            import copy as _copy
+
+            pre_build_config: Dict[str, Any] = {
+                **config,
+                "nodes": _copy.deepcopy(config.get("nodes") or []),
+                "connections": _copy.deepcopy(config.get("connections") or []),
+            }
 
             # Callback fired by solve_staged after each stage completes.
             # n_total is passed by the solver on each call, so n_stages stays
@@ -306,6 +323,8 @@ class SimulationWorker:
 
             # Finalize results
             logger.info(f"Simulation completed: {len(results['time'])} time points")
+            reactor_reports = self._generate_reactor_reports(converter, results)
+            connection_reports = self._generate_connection_reports(converter)
             with self._lock:
                 self.progress.times = results["time"]
                 self.progress.reactors_series = results["reactors"]
@@ -315,19 +334,21 @@ class SimulationWorker:
                 # Store Sankey data if present
                 self.progress.sankey_links = results.get("sankey_links")
                 self.progress.sankey_nodes = results.get("sankey_nodes")
-                # Generate reactor reports for thermo analysis
-                self.progress.reactor_reports = self._generate_reactor_reports(
-                    converter, results
-                )
-                self.progress.connection_reports = self._generate_connection_reports(
-                    converter
-                )
+                self.progress.reactor_reports = reactor_reports
+                self.progress.connection_reports = connection_reports
                 self.progress.is_running = False
                 self.progress.is_complete = True
                 self.progress.end_time = time.time()
                 # Carry through final error message if present in results
                 if isinstance(results, dict) and results.get("error_message"):
                     self.progress.error_message = results.get("error_message")
+
+            # Persist results to disk cache (best-effort: never aborts the solve).
+            # Pass pre_build_config so the fingerprint matches the startup fingerprint.
+            self._persist_to_cache(
+                converter, config, results, reactor_reports, connection_reports,
+                code_str, pre_build_config=pre_build_config,
+            )
 
         except Exception as e:
             logger.error(f"Simulation failed: {e}", exc_info=True)
@@ -336,6 +357,141 @@ class SimulationWorker:
                 self.progress.is_running = False
                 self.progress.is_complete = False
                 self.progress.end_time = time.time()
+
+    def _persist_to_cache(
+        self,
+        converter: Any,
+        config: Dict[str, Any],
+        results: Dict[str, Any],
+        reactor_reports: Dict[str, Any],
+        connection_reports: Dict[str, Any],
+        code_str: str,
+        pre_build_config: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Persist GUI payload + SimulationResult to disk cache (best-effort).
+
+        Parameters
+        ----------
+        pre_build_config:
+            Config snapshot taken *before* ``build_network`` enriched it with
+            outlet/interface nodes.  When provided, the fingerprint is computed
+            from this snapshot so it matches the fingerprint computed from the
+            validated config at startup (which is also pre-build).  The
+            post-build ``config`` is still stored as the config_snapshot.
+
+        Failures are logged at WARNING level and never propagate to the caller.
+        """
+        try:
+            from .result_cache import (
+                cache_dir_for,
+                compute_fingerprint,
+                load_result,
+                run_contributors,
+                save_alias,
+                save_result,
+            )
+            from .simulation_result import make_simulation_result
+
+            mechanism = getattr(converter, "mechanism", None)
+            config_path = getattr(converter, "_download_config_path", None)
+            cache_root = cache_dir_for(config_path)
+            if cache_root is None:
+                logger.debug("No cache root available (no config path); skipping cache.")
+                return
+
+            progress = self.get_progress()
+            # Use pre-build snapshot for fingerprinting when available so the hash
+            # matches the startup fingerprint (computed from the un-enriched config).
+            fp_config = pre_build_config if pre_build_config is not None else config
+            fingerprint = compute_fingerprint(fp_config, mechanism=mechanism)
+
+            # Expose the fingerprint immediately so GUI actions can detect this
+            # cache entry before contributors finish writing artifacts.
+            if self._app_state is not None:
+                try:
+                    self._app_state.preloaded_fingerprint = fingerprint
+                except Exception:  # noqa: BLE001
+                    pass
+
+            gui_payload: Dict[str, Any] = {
+                "status": "complete",
+                "is_complete": True,
+                "error_message": None,
+                "times": progress.times,
+                "reactors_series": progress.reactors_series,
+                "reactor_reports": reactor_reports,
+                "connection_reports": connection_reports,
+                "code_str": code_str,
+                "summary": progress.summary,
+                "sankey_links": progress.sankey_links,
+                "sankey_nodes": progress.sankey_nodes,
+                "elapsed_time": progress.get_calculation_time(),
+                "updated_nodes": progress.updated_nodes,
+                "updated_connections": progress.updated_connections,
+            }
+
+            from .api.sse import _serialise_reports
+
+            gui_payload["reactor_reports"] = _serialise_reports(reactor_reports)
+
+            simulation_result = make_simulation_result(converter, config)
+
+            entry = save_result(
+                cache_root=cache_root,
+                fingerprint=fingerprint,
+                gui_payload=gui_payload,
+                config_snapshot=config,
+                mechanism=mechanism,
+            )
+
+            # Write an alias from the post-build fingerprint → canonical entry.
+            # After a solve, the frontend stores the post-build config (with
+            # stream-point nodes added by the staged solver).  On the next
+            # "Run Simulation" click, check-cache fingerprints the post-build
+            # config, which differs from the pre-build fingerprint used here.
+            # The alias lets load_result_flexible find the entry via either key.
+            post_build_fp = compute_fingerprint(config, mechanism=mechanism)
+            if post_build_fp != fingerprint:
+                save_alias(cache_root, post_build_fp, fingerprint)
+                logger.debug(
+                    "Cache post-build alias written: %s → %s",
+                    post_build_fp[:12], fingerprint[:12],
+                )
+
+            artifacts_dir = entry / "artifacts"
+
+            # Update app.state immediately after save_result so the frontend
+            # detects the cache hit and Export can poll for the bundle instead
+            # of triggering a full re-solve.  Contributors write their artifacts
+            # next (potentially slow), but the cache entry is already addressable.
+            cached = load_result(cache_root, fingerprint)
+            if cached is not None and self._app_state is not None:
+                try:
+                    self._app_state.preloaded_result = cached
+                    logger.debug(
+                        "app.state.preloaded_result updated (pre-contributors, %s…)",
+                        fingerprint[:12],
+                    )
+                except Exception as state_exc:  # noqa: BLE001
+                    logger.debug("Could not update app.state (pre-contrib): %s", state_exc)
+
+            contributors = getattr(
+                getattr(converter, "plugins", None), "cache_contributors", []
+            )
+            if contributors:
+                run_contributors(
+                    contributors,
+                    config,
+                    converter,
+                    simulation_result,
+                    fingerprint,
+                    artifacts_dir,
+                )
+
+        except OSError as exc:
+            logger.warning("Cache persistence failed (OSError): %s", exc)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Cache persistence failed: %s", exc)
 
     def _generate_reactor_reports(
         self, converter: Any, results: Dict[str, Any]

--- a/frontend/src/api/resultCache.ts
+++ b/frontend/src/api/resultCache.ts
@@ -1,0 +1,48 @@
+import { apiFetch } from "./client";
+import type { SimulationResults } from "@/types/simulation";
+
+export interface CachedResultMeta {
+  fingerprint: string;
+  cache_version: number;
+  created_at: number;
+  boulder_version: string;
+  cantera_version: string;
+  mechanism: string;
+}
+
+export interface CachedResultResponse {
+  cached: true;
+  fingerprint: string;
+  result: SimulationResults;
+  config_snapshot: Record<string, unknown>;
+  meta: CachedResultMeta;
+}
+
+export interface NoCachedResultResponse {
+  cached: false;
+}
+
+export type CacheCheckResponse = CachedResultResponse | NoCachedResultResponse;
+
+export function fetchCachedResult() {
+  return apiFetch<CacheCheckResponse>("/simulations/cached");
+}
+
+/**
+ * Check whether a cached result exists for the given config.
+ *
+ * Unlike fetchCachedResult (which reads the server-side preloaded fingerprint),
+ * this function submits the *current* in-memory config so the fingerprint is
+ * computed from the same data the worker would hash — ensuring a hit even when
+ * the config was updated by the SSE handler after a previous solve.
+ */
+export function checkSimulationCache(
+  config: Record<string, unknown>,
+  mechanism?: string | null,
+): Promise<CacheCheckResponse> {
+  return apiFetch<CacheCheckResponse>("/simulations/check-cache", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ config, mechanism: mechanism ?? null }),
+  });
+}

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -7,6 +7,7 @@ import { useSimulationSSE } from "@/hooks/useSimulationSSE";
 import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
 import { startSimulation } from "@/api/simulations";
 import { fetchDefaultConfig, fetchPreloadedConfig } from "@/api/configs";
+import { fetchCachedResult } from "@/api/resultCache";
 import { EditNetworkCard } from "@/components/panels/EditNetworkCard";
 import { SimulateCard } from "@/components/panels/SimulateCard";
 import { PropertiesPanel } from "@/components/panels/PropertiesPanel";
@@ -20,7 +21,8 @@ import { toast } from "sonner";
 export function AppShell() {
   const { theme, toggleTheme } = useThemeStore();
   const { config, fileName, setConfig } = useConfigStore();
-  const { isRunning, beginSimulationRun, startSimulation: setStarted, setError } = useSimulationStore();
+  const { isRunning, beginSimulationRun, startSimulation: setStarted, setError, setResults } =
+    useSimulationStore();
   const solverMode = useMemo(() => {
     const solver = (config.settings as Record<string, unknown> | null | undefined)
       ?.solver as Record<string, unknown> | undefined;
@@ -34,22 +36,71 @@ export function AppShell() {
   // Connect SSE stream
   useSimulationSSE();
 
-  // Load preloaded config if available, otherwise load default config on mount
+  // Load preloaded config if available, otherwise load default config on mount.
+  // After a successful preloaded-config fetch, check for a matching cache entry
+  // so outputs are visible immediately without re-running (issue #51).
   useEffect(() => {
     fetchPreloadedConfig()
       .then((resp) => {
         if (resp.preloaded && resp.config) {
           setConfig(resp.config, resp.filename || "config.yaml", resp.yaml);
           toast.success(`Loaded ${resp.filename || "configuration"}`);
+
+          // Try to populate the UI with cached results for this config.
+          return fetchCachedResult().then((cacheResp) => {
+            if (!cacheResp.cached) return;
+
+            const result = cacheResp.result;
+            setResults(result);
+
+            // Sync graph topology: apply updated_nodes / updated_connections
+            // exactly as the SSE complete handler does.
+            if (result.updated_nodes != null && result.updated_connections != null) {
+              const currentConfig = useConfigStore.getState().config;
+              const frontendMeta = new Map<string, Record<string, unknown>>();
+              for (const n of currentConfig.nodes) {
+                const off = (n.metadata as Record<string, unknown> | null)?.layout_offset;
+                if (off !== undefined) frontendMeta.set(n.id, { layout_offset: off });
+              }
+              setConfig({
+                ...currentConfig,
+                nodes: result.updated_nodes.map((n) => {
+                  const extra = frontendMeta.get(n.id);
+                  return {
+                    id: n.id,
+                    type: n.type,
+                    group: n.group ?? null,
+                    properties: n.properties ?? {},
+                    metadata: extra
+                      ? { ...(n.metadata ?? {}), ...extra }
+                      : (n.metadata ?? null),
+                    network_class: n.network_class ?? null,
+                  };
+                }),
+                connections: result.updated_connections.map((c) => ({
+                  id: c.id,
+                  source: c.source,
+                  target: c.target,
+                  type: c.type,
+                  properties: c.properties ?? {},
+                  metadata: c.metadata ?? null,
+                  group: c.group ?? null,
+                  logical: c.logical ?? null,
+                  mechanism_switch: c.mechanism_switch ?? null,
+                })),
+              });
+            }
+
+            const created = cacheResp.meta.created_at;
+            const ageMin = Math.round((Date.now() / 1000 - created) / 60);
+            const ageStr = ageMin < 2 ? "just now" : `${ageMin} min ago`;
+            toast.success(`Loaded cached results from ${ageStr}. Re-run skipped.`);
+          });
         } else {
           // No preloaded config, load default
-          return fetchDefaultConfig();
-        }
-      })
-      .then((resp) => {
-        // Only runs if fetchDefaultConfig was called
-        if (resp) {
-          setConfig(resp.config, "default.yaml", resp.yaml);
+          return fetchDefaultConfig().then((defResp) => {
+            if (defResp) setConfig(defResp.config, "default.yaml", defResp.yaml);
+          });
         }
       })
       .catch(() => {

--- a/frontend/src/components/panels/SimulateCard.tsx
+++ b/frontend/src/components/panels/SimulateCard.tsx
@@ -3,6 +3,7 @@ import { useConfigStore } from "@/stores/configStore";
 import { useSimulationStore } from "@/stores/simulationStore";
 import { fetchGuiActions, runGuiAction } from "@/api/guiActions";
 import { startSimulation } from "@/api/simulations";
+import { checkSimulationCache } from "@/api/resultCache";
 import { Button } from "@/components/ui/Button";
 import type { GuiActionMeta } from "@/types/guiAction";
 import { toast } from "sonner";
@@ -25,10 +26,12 @@ export function SimulateCard() {
   const {
     isRunning,
     simulationId,
+    results,
     pythonCode,
     beginSimulationRun,
     startSimulation: setStarted,
     setError,
+    setResults,
   } = useSimulationStore();
 
   const configSolver = (config.settings as Record<string, unknown> | null | undefined)?.solver as
@@ -70,19 +73,36 @@ export function SimulateCard() {
     if (solver?.max_steps != null) setMaxSteps(String(solver.max_steps));
   }, [config.settings]);
 
+  // Re-fetch whenever config, simulationId, or results change.
+  // After a solve completes (results becomes non-null), the server's cache
+  // is populated and is_available will change for export actions.
+  // A second fetch fires after a short delay to catch the (async) cache write.
   useEffect(() => {
     let cancelled = false;
-    fetchGuiActions()
-      .then((actions) => {
-        if (!cancelled) setGuiActions(actions);
-      })
-      .catch(() => {
-        if (!cancelled) setGuiActions([]);
-      });
+
+    const doFetch = () =>
+      fetchGuiActions()
+        .then((actions) => {
+          if (!cancelled) setGuiActions(actions);
+        })
+        .catch(() => {
+          if (!cancelled) setGuiActions([]);
+        });
+
+    doFetch();
+
+    // When results just arrived, fire a second fetch after the background
+    // cache-write thread has had time to finish (~3 s is conservative).
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    if (results !== null) {
+      timer = setTimeout(doFetch, 3000);
+    }
+
     return () => {
       cancelled = true;
+      if (timer !== undefined) clearTimeout(timer);
     };
-  }, [config, simulationId]);
+  }, [config, simulationId, results]);
 
   const handleModeChange = useCallback(
     (newMode: SolverMode) => {
@@ -173,6 +193,31 @@ export function SimulateCard() {
       toast.error("Add at least one reactor before simulating");
       return;
     }
+
+    // Check whether a cached result already exists for the current config.
+    // This avoids re-running the full simulation when nothing has changed.
+    // Only applies to steady-state mode; transient runs always execute fresh.
+    if (mode === "steady") {
+      try {
+        const cfgRaw = config as unknown as Record<string, unknown>;
+        const phases = cfgRaw.phases as Record<string, unknown> | undefined;
+        const gas = phases?.gas as Record<string, unknown> | undefined;
+        const mechStr = (gas?.mechanism as string | undefined) ?? null;
+
+        const cacheResp = await checkSimulationCache(cfgRaw, mechStr);
+        if (cacheResp.cached) {
+          setResults(cacheResp.result);
+          const created = cacheResp.meta.created_at;
+          const ageMin = Math.round((Date.now() / 1000 - created) / 60);
+          const ageStr = ageMin < 2 ? "just now" : `${ageMin} min ago`;
+          toast.success(`Loaded cached results from ${ageStr}. Re-run skipped.`);
+          return;
+        }
+      } catch {
+        // Cache check failed (no config path, network error, etc.) — proceed normally.
+      }
+    }
+
     beginSimulationRun();
     try {
       const resp = await startSimulation(
@@ -186,7 +231,7 @@ export function SimulateCard() {
       toast.error(`Failed: ${msg}`);
       setError(msg);
     }
-  }, [config, simTime, timeStep, mode, beginSimulationRun, setStarted, setError]);
+  }, [config, simTime, timeStep, mode, beginSimulationRun, setStarted, setError, setResults]);
 
   const handleDownloadPy = useCallback(() => {
     if (!pythonCode) return;
@@ -334,7 +379,7 @@ export function SimulateCard() {
           disabled={
             runningActionId !== null
             || isRunning
-            || (action.requires_simulation && !simulationId)
+            || !action.is_available
           }
           variant="secondary"
           className="w-full"

--- a/frontend/src/hooks/useSimulationSSE.ts
+++ b/frontend/src/hooks/useSimulationSSE.ts
@@ -63,6 +63,9 @@ export function useSimulationSSE() {
                 metadata: extra
                   ? { ...(n.metadata ?? {}), ...extra }
                   : (n.metadata ?? null),
+                // Preserve Pydantic-default fields so the fingerprint computed
+                // from the store matches the one written to cache by the worker.
+                network_class: n.network_class ?? null,
               };
             }),
             connections: data.updated_connections.map((c) => ({
@@ -78,6 +81,7 @@ export function useSimulationSSE() {
               // dropped from the merged YAML.
               group: c.group ?? null,
               logical: c.logical ?? null,
+              mechanism_switch: c.mechanism_switch ?? null,
             })),
           });
         }

--- a/frontend/src/types/guiAction.ts
+++ b/frontend/src/types/guiAction.ts
@@ -2,4 +2,6 @@ export interface GuiActionMeta {
   id: string;
   label: string;
   requires_simulation: boolean;
+  /** True when the server considers this action ready to run right now. */
+  is_available: boolean;
 }

--- a/frontend/src/types/simulation.ts
+++ b/frontend/src/types/simulation.ts
@@ -71,6 +71,8 @@ export interface SimulationResults extends SimulationProgress {
     group?: string | null;
     properties: Record<string, unknown>;
     metadata?: Record<string, unknown> | null;
+    /** Custom ReactorNet subclass dotted-path (Pydantic default: null). */
+    network_class?: string | null;
   }> | null;
   /**
    * Authoritative connection list after the staged-solver build completes.
@@ -88,5 +90,7 @@ export interface SimulationResults extends SimulationProgress {
     group?: string | null;
     /** True for logical (kind-less) inter-stage connections. */
     logical?: boolean | null;
+    /** Per-stage mechanism-switch spec (htol / Xtol thresholds). */
+    mechanism_switch?: Record<string, unknown> | null;
   }> | null;
 }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -306,7 +306,9 @@ class TestSimulationRoutes:
                 self.mechanism = mechanism
 
         class DummyWorker:
-            def start_simulation(self, converter, config, simulation_time, time_step):
+            def start_simulation(
+                self, converter, config, simulation_time, time_step, **kwargs
+            ):
                 captured["simulation_time"] = simulation_time
                 captured["time_step"] = time_step
 
@@ -338,7 +340,9 @@ class TestSimulationRoutes:
                 self.mechanism = mechanism
 
         class DummyWorker:
-            def start_simulation(self, converter, config, simulation_time, time_step):
+            def start_simulation(
+                self, converter, config, simulation_time, time_step, **kwargs
+            ):
                 captured["simulation_time"] = simulation_time
                 captured["time_step"] = time_step
 
@@ -378,7 +382,9 @@ class TestSimulationRoutes:
                 self.mechanism = mechanism
 
         class DummyWorker:
-            def start_simulation(self, converter, config, simulation_time, time_step):
+            def start_simulation(
+                self, converter, config, simulation_time, time_step, **kwargs
+            ):
                 nonlocal worker_called
                 worker_called = True
 
@@ -420,7 +426,9 @@ class TestSimulationRoutes:
                 self.mechanism = mechanism
 
         class DummyWorker:
-            def start_simulation(self, converter, config, simulation_time, time_step):
+            def start_simulation(
+                self, converter, config, simulation_time, time_step, **kwargs
+            ):
                 received_config.update(config)
 
         monkeypatch.setattr(simulation_routes, "DualCanteraConverter", DummyConverter)

--- a/tests/test_gui_actions_api.py
+++ b/tests/test_gui_actions_api.py
@@ -6,6 +6,9 @@ that POST /api/gui-actions/{id}/run returns a downloadable file response.
 
 from __future__ import annotations
 
+import time
+from typing import Any, Dict
+
 import pytest
 
 pytest.importorskip("fastapi")
@@ -19,6 +22,31 @@ from boulder.gui_actions import (  # noqa: E402
     get_gui_action_registry,
     register_gui_action,
 )
+from boulder.result_cache import CACHE_VERSION, save_result  # noqa: E402
+
+SIMPLE_CONFIG: Dict[str, Any] = {
+    "nodes": [{"id": "r1", "type": "IdealGasReactor", "properties": {"T": 1000}}],
+    "connections": [],
+    "settings": {"solver": {"kind": "steady_state"}},
+    "phases": {"gas": {"mechanism": "gri30.yaml"}},
+}
+
+SIMPLE_PAYLOAD: Dict[str, Any] = {
+    "status": "complete",
+    "is_complete": True,
+    "error_message": None,
+    "times": [0.0],
+    "reactors_series": {"r1": {"T": [1000.0], "P": [101325.0], "X": {}}},
+    "reactor_reports": {},
+    "connection_reports": {},
+    "code_str": "# generated",
+    "summary": [],
+    "sankey_links": None,
+    "sankey_nodes": None,
+    "elapsed_time": 1.23,
+    "updated_nodes": None,
+    "updated_connections": None,
+}
 
 
 class _EchoAction(GuiActionPlugin):
@@ -93,3 +121,82 @@ class TestGuiActionsApi:
             1 for action in registry.actions if action.action_id == "test_echo_action"
         )
         assert after == before
+
+
+class TestGuiActionCacheContext:
+    def test_build_context_matches_check_cache(self, tmp_path):
+        """_build_context and check-cache agree on has_cached_result for body.config."""
+        from boulder.api.routes.gui_actions import _build_context
+        from boulder.result_cache import (
+            compute_fingerprint,
+            resolve_mechanism_for_fingerprint,
+        )
+
+        yaml_path = tmp_path / "model.yaml"
+        yaml_path.write_text("nodes: []\n", encoding="utf-8")
+        mechanism = resolve_mechanism_for_fingerprint(SIMPLE_CONFIG)
+        fingerprint = compute_fingerprint(SIMPLE_CONFIG, mechanism=mechanism)
+        save_result(
+            cache_root=tmp_path / ".boulder-cache",
+            fingerprint=fingerprint,
+            gui_payload=SIMPLE_PAYLOAD,
+            config_snapshot=SIMPLE_CONFIG,
+        )
+
+        app = create_app()
+        with TestClient(app) as client:
+            app.state.preloaded_config_path = str(yaml_path)
+            app.state.preloaded_result = None
+            app.state.preloaded_fingerprint = None
+
+            body = {
+                "config": SIMPLE_CONFIG,
+                "mechanism": "gri30.yaml",
+            }
+            cache_resp = client.post("/api/simulations/check-cache", json=body)
+            assert cache_resp.json()["cached"] is True
+
+            from boulder.api.routes.gui_actions import GuiActionRunRequest
+
+            class _Req:
+                app = client.app
+
+            ctx = _build_context(_Req(), GuiActionRunRequest(**body))
+            assert ctx.has_cached_result is True
+            assert ctx.cache_fingerprint is not None
+
+    def test_build_context_rejects_stale_preloaded_fingerprint(self, tmp_path):
+        """Edited body.config must not inherit startup cache state."""
+        from boulder.api.routes.gui_actions import GuiActionRunRequest, _build_context
+
+        yaml_path = tmp_path / "model.yaml"
+        yaml_path.write_text("nodes: []\n", encoding="utf-8")
+        fingerprint = "d" * 64
+        cached = {
+            "fingerprint": fingerprint,
+            "gui_payload": SIMPLE_PAYLOAD,
+            "config_snapshot": SIMPLE_CONFIG,
+            "meta": {"cache_version": CACHE_VERSION, "created_at": time.time()},
+            "artifacts_dir": tmp_path / ".boulder-cache" / fingerprint / "artifacts",
+        }
+
+        edited_config = dict(SIMPLE_CONFIG)
+        edited_config["nodes"] = [
+            {"id": "r2", "type": "IdealGasReactor", "properties": {"T": 2000}}
+        ]
+
+        app = create_app()
+        with TestClient(app) as client:
+            app.state.preloaded_config_path = str(yaml_path)
+            app.state.preloaded_result = cached
+            app.state.preloaded_fingerprint = fingerprint
+
+            class _Req:
+                app = client.app
+
+            ctx = _build_context(
+                _Req(),
+                GuiActionRunRequest(config=edited_config, mechanism="gri30.yaml"),
+            )
+            assert ctx.has_cached_result is False
+            assert ctx.cache_fingerprint is not None

--- a/tests/test_result_cache.py
+++ b/tests/test_result_cache.py
@@ -25,10 +25,15 @@ from boulder.result_cache import (
     CacheContributorPlugin,
     CacheContributorRegistry,
     _entry_dir,
+    _prune_cache,
+    _source_identity,
     cache_dir_for,
     compute_fingerprint,
     load_result,
+    lookup_cached_result,
+    resolve_mechanism_for_fingerprint,
     run_contributors,
+    save_alias,
     save_result,
 )
 
@@ -76,7 +81,9 @@ class TestComputeFingerprint:
     def test_changes_with_config(self):
         """Different configs produce different fingerprints."""
         cfg2 = dict(SIMPLE_CONFIG)
-        cfg2["nodes"] = [{"id": "r2", "type": "IdealGasReactor", "properties": {"T": 2000}}]
+        cfg2["nodes"] = [
+            {"id": "r2", "type": "IdealGasReactor", "properties": {"T": 2000}}
+        ]
         fp1 = compute_fingerprint(SIMPLE_CONFIG)
         fp2 = compute_fingerprint(cfg2)
         assert fp1 != fp2
@@ -260,11 +267,133 @@ class TestPruning:
             time.sleep(0.01)  # ensure mtime ordering
 
         complete_entries = [
-            d
-            for d in tmp_path.iterdir()
-            if d.is_dir() and (d / "COMPLETE").exists()
+            d for d in tmp_path.iterdir() if d.is_dir() and (d / "COMPLETE").exists()
         ]
         assert len(complete_entries) == MAX_CACHE_ENTRIES
+
+
+class TestSourceIdentity:
+    def test_ignore_code_env_uses_package_version(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """BOULDER_CACHE_IGNORE_CODE=1 restores version-only identity."""
+        monkeypatch.setenv("BOULDER_CACHE_IGNORE_CODE", "1")
+        identity = _source_identity("boulder")
+        assert identity.count(".") >= 2 or identity == "unknown"
+
+    def test_dirty_worktree_changes_fingerprint(self, monkeypatch: pytest.MonkeyPatch):
+        """Uncommitted changes produce a different fingerprint than a clean tree."""
+        monkeypatch.delenv("BOULDER_CACHE_IGNORE_CODE", raising=False)
+
+        def fake_source(package: str) -> str:
+            if package == "boulder":
+                return "git:abc123"
+            return "unknown"
+
+        def fake_dirty(package: str) -> str:
+            if package == "boulder":
+                return "git:abc123+dirty:deadbeef1234"
+            return "unknown"
+
+        monkeypatch.setattr("boulder.result_cache._source_identity", fake_source)
+        fp_clean = compute_fingerprint(SIMPLE_CONFIG)
+        monkeypatch.setattr("boulder.result_cache._source_identity", fake_dirty)
+        fp_dirty = compute_fingerprint(SIMPLE_CONFIG)
+        assert fp_clean != fp_dirty
+
+
+class TestResolveMechanismForFingerprint:
+    def test_subclass_override_is_applied(self):
+        """resolve_mechanism_for_fingerprint honours converter subclass overrides."""
+
+        class _RedirectConverter:
+            def resolve_mechanism(self, name: str) -> str:
+                return "/custom/mech.yaml"
+
+        resolved = resolve_mechanism_for_fingerprint(
+            SIMPLE_CONFIG,
+            converter_class=_RedirectConverter,
+        )
+        assert resolved == "/custom/mech.yaml"
+
+    def test_reader_writer_use_same_resolved_mechanism(self):
+        """Fingerprint with resolved mechanism matches worker-style hashing."""
+
+        class _RedirectConverter:
+            def resolve_mechanism(self, name: str) -> str:
+                return "h2o2.yaml"
+
+        mechanism = resolve_mechanism_for_fingerprint(
+            SIMPLE_CONFIG,
+            converter_class=_RedirectConverter,
+        )
+        fp_reader = compute_fingerprint(SIMPLE_CONFIG, mechanism=mechanism)
+        fp_writer = compute_fingerprint(SIMPLE_CONFIG, mechanism="h2o2.yaml")
+        assert fp_reader == fp_writer
+
+
+class TestLookupCachedResult:
+    def test_hit_via_alias(self, tmp_path: Path):
+        """lookup_cached_result follows post-build alias files."""
+        canonical = compute_fingerprint(SIMPLE_CONFIG, mechanism="gri30.yaml")
+        post_build = dict(SIMPLE_CONFIG)
+        post_build["nodes"] = list(SIMPLE_CONFIG["nodes"]) + [
+            {"id": "outlet", "type": "Reservoir", "properties": {}}
+        ]
+        post_fp = compute_fingerprint(post_build, mechanism="gri30.yaml")
+        save_result(
+            cache_root=tmp_path,
+            fingerprint=canonical,
+            gui_payload=SIMPLE_PAYLOAD,
+            config_snapshot=post_build,
+        )
+        save_alias(tmp_path, post_fp, canonical)
+        fingerprint, cached = lookup_cached_result(
+            tmp_path, post_build, mechanism="gri30.yaml"
+        )
+        assert cached is not None
+        assert fingerprint == post_fp
+
+    def test_snapshot_fallback(self, tmp_path: Path):
+        """lookup_cached_result accepts a matching preloaded snapshot."""
+        fingerprint = compute_fingerprint(SIMPLE_CONFIG, mechanism="gri30.yaml")
+        preloaded = {
+            "fingerprint": fingerprint,
+            "gui_payload": SIMPLE_PAYLOAD,
+            "config_snapshot": SIMPLE_CONFIG,
+            "meta": {"cache_version": CACHE_VERSION},
+        }
+        fp, cached = lookup_cached_result(
+            tmp_path,
+            SIMPLE_CONFIG,
+            mechanism="gri30.yaml",
+            preloaded_result=preloaded,
+        )
+        assert fp == fingerprint
+        assert cached is preloaded
+
+
+class TestAliasPruning:
+    def test_orphan_alias_removed_after_entry_pruned(self, tmp_path: Path):
+        """_prune_cache deletes alias files whose canonical entry was removed."""
+        from boulder.result_cache import MAX_CACHE_ENTRIES
+
+        fingerprints = []
+        for i in range(MAX_CACHE_ENTRIES + 2):
+            fp = f"{i:064x}"
+            fingerprints.append(fp)
+            save_result(
+                cache_root=tmp_path,
+                fingerprint=fp,
+                gui_payload=SIMPLE_PAYLOAD,
+                config_snapshot=SIMPLE_CONFIG,
+            )
+            time.sleep(0.01)
+
+        orphan_alias = tmp_path / f"_alias_{'f' * 64}"
+        orphan_alias.write_text(fingerprints[0], encoding="utf-8")
+        _prune_cache(tmp_path)
+        assert not orphan_alias.exists()
 
 
 # ---------------------------------------------------------------------------
@@ -327,7 +456,9 @@ class TestCacheContributorPlugin:
             def contributor_id(self) -> str:
                 return "test_failing"
 
-            def contribute(self, config, converter, simulation_result, fingerprint, artifacts_dir):
+            def contribute(
+                self, config, converter, simulation_result, fingerprint, artifacts_dir
+            ):
                 raise RuntimeError("intentional failure")
 
         artifacts_dir = tmp_path / "artifacts"

--- a/tests/test_result_cache.py
+++ b/tests/test_result_cache.py
@@ -544,9 +544,9 @@ class TestCachedEndpoint:
         resp = client_with_cache.get("/api/simulations/cached/artifacts/missing.txt")
         assert resp.status_code == 404
 
-    def test_artifact_served(self, client_with_cache: TestClient):
+    def test_artifact_served(self, client_with_cache: TestClient, tmp_path: Path):
         """GET /api/simulations/cached/artifacts/<name> serves existing artifact files."""
-        artifacts_dir = client_with_cache.app.state.preloaded_result["artifacts_dir"]
+        artifacts_dir = tmp_path / "artifacts"
         test_file = artifacts_dir / "test.txt"
         test_file.write_text("hello", encoding="utf-8")
         resp = client_with_cache.get("/api/simulations/cached/artifacts/test.txt")

--- a/tests/test_result_cache.py
+++ b/tests/test_result_cache.py
@@ -1,0 +1,423 @@
+"""Tests for boulder.result_cache.
+
+Asserts:
+- compute_fingerprint is deterministic and changes when config or mechanism changes.
+- save_result / load_result round-trips the GUI payload and config snapshot.
+- A CACHE_VERSION mismatch causes load_result to return None (invalidation).
+- Missing COMPLETE marker causes load_result to return None (incomplete write guard).
+- Pruning removes oldest entries when MAX_CACHE_ENTRIES is exceeded.
+- GET /api/simulations/cached returns {"cached": false} when no cache exists.
+- CacheContributorPlugin subclasses register and are called during run_contributors.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import Any, Dict
+from unittest.mock import MagicMock
+
+import pytest
+
+from boulder.result_cache import (
+    CACHE_VERSION,
+    CacheContributorPlugin,
+    CacheContributorRegistry,
+    _entry_dir,
+    cache_dir_for,
+    compute_fingerprint,
+    load_result,
+    run_contributors,
+    save_result,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+SIMPLE_CONFIG: Dict[str, Any] = {
+    "nodes": [{"id": "r1", "type": "IdealGasReactor", "properties": {"T": 1000}}],
+    "connections": [],
+    "settings": {"solver": {"kind": "steady_state"}},
+    "phases": {"gas": {"mechanism": "gri30.yaml"}},
+}
+
+SIMPLE_PAYLOAD: Dict[str, Any] = {
+    "status": "complete",
+    "is_complete": True,
+    "error_message": None,
+    "times": [0.0],
+    "reactors_series": {"r1": {"T": [1000.0], "P": [101325.0], "X": {}}},
+    "reactor_reports": {},
+    "connection_reports": {},
+    "code_str": "# generated",
+    "summary": [],
+    "sankey_links": None,
+    "sankey_nodes": None,
+    "elapsed_time": 1.23,
+    "updated_nodes": None,
+    "updated_connections": None,
+}
+
+
+# ---------------------------------------------------------------------------
+# Fingerprint
+# ---------------------------------------------------------------------------
+
+
+class TestComputeFingerprint:
+    def test_deterministic(self):
+        """compute_fingerprint returns the same digest for identical inputs."""
+        fp1 = compute_fingerprint(SIMPLE_CONFIG, mechanism="gri30.yaml")
+        fp2 = compute_fingerprint(SIMPLE_CONFIG, mechanism="gri30.yaml")
+        assert fp1 == fp2
+
+    def test_changes_with_config(self):
+        """Different configs produce different fingerprints."""
+        cfg2 = dict(SIMPLE_CONFIG)
+        cfg2["nodes"] = [{"id": "r2", "type": "IdealGasReactor", "properties": {"T": 2000}}]
+        fp1 = compute_fingerprint(SIMPLE_CONFIG)
+        fp2 = compute_fingerprint(cfg2)
+        assert fp1 != fp2
+
+    def test_changes_with_mechanism(self):
+        """Changing the mechanism changes the fingerprint."""
+        fp1 = compute_fingerprint(SIMPLE_CONFIG, mechanism="gri30.yaml")
+        fp2 = compute_fingerprint(SIMPLE_CONFIG, mechanism="h2o2.yaml")
+        assert fp1 != fp2
+
+    def test_hex_string(self):
+        """Fingerprint is a 64-character hex string."""
+        fp = compute_fingerprint(SIMPLE_CONFIG)
+        assert len(fp) == 64
+        assert all(c in "0123456789abcdef" for c in fp)
+
+    def test_extra_included_in_hash(self):
+        """Extra dict is included in hash, changing the result."""
+        fp1 = compute_fingerprint(SIMPLE_CONFIG)
+        fp2 = compute_fingerprint(SIMPLE_CONFIG, extra={"simulation_time": 10.0})
+        assert fp1 != fp2
+
+
+# ---------------------------------------------------------------------------
+# cache_dir_for
+# ---------------------------------------------------------------------------
+
+
+class TestCacheDirFor:
+    def test_sidecar_from_path(self, tmp_path: Path):
+        """cache_dir_for returns .boulder-cache next to the YAML when no override."""
+        yaml_path = tmp_path / "model.yaml"
+        yaml_path.touch()
+        result = cache_dir_for(str(yaml_path))
+        assert result == yaml_path.parent / ".boulder-cache"
+
+    def test_env_override(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        """BOULDER_CACHE_DIR env var overrides the sidecar location."""
+        override = tmp_path / "custom_cache"
+        monkeypatch.setenv("BOULDER_CACHE_DIR", str(override))
+        result = cache_dir_for("/some/path/model.yaml")
+        assert result == override
+
+    def test_none_without_path_or_env(self, monkeypatch: pytest.MonkeyPatch):
+        """Returns None when no config path and no env override."""
+        monkeypatch.delenv("BOULDER_CACHE_DIR", raising=False)
+        result = cache_dir_for(None)
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# save_result / load_result
+# ---------------------------------------------------------------------------
+
+
+class TestSaveLoadRoundTrip:
+    def test_round_trip(self, tmp_path: Path):
+        """save_result followed by load_result returns identical payload and snapshot."""
+        fingerprint = "a" * 64
+        save_result(
+            cache_root=tmp_path,
+            fingerprint=fingerprint,
+            gui_payload=SIMPLE_PAYLOAD,
+            config_snapshot=SIMPLE_CONFIG,
+            mechanism="gri30.yaml",
+        )
+        loaded = load_result(tmp_path, fingerprint)
+
+        assert loaded is not None
+        assert loaded["fingerprint"] == fingerprint
+        assert loaded["gui_payload"]["status"] == "complete"
+        assert loaded["config_snapshot"]["phases"]["gas"]["mechanism"] == "gri30.yaml"
+        assert isinstance(loaded["artifacts_dir"], Path)
+
+    def test_complete_marker_required(self, tmp_path: Path):
+        """load_result returns None when COMPLETE marker is absent."""
+        fingerprint = "b" * 64
+        entry = _entry_dir(tmp_path, fingerprint)
+        entry.mkdir(parents=True)
+        (entry / "result.json").write_text("{}", encoding="utf-8")
+        (entry / "meta.json").write_text(
+            json.dumps({"cache_version": CACHE_VERSION}), encoding="utf-8"
+        )
+        # No COMPLETE file written
+        assert load_result(tmp_path, fingerprint) is None
+
+    def test_version_mismatch_invalidates(self, tmp_path: Path):
+        """A stale cache_version in meta.json causes load_result to return None."""
+        fingerprint = "c" * 64
+        save_result(
+            cache_root=tmp_path,
+            fingerprint=fingerprint,
+            gui_payload=SIMPLE_PAYLOAD,
+            config_snapshot=SIMPLE_CONFIG,
+        )
+        # Overwrite meta.json with mismatched version
+        entry = _entry_dir(tmp_path, fingerprint)
+        meta_path = entry / "meta.json"
+        meta = json.loads(meta_path.read_text(encoding="utf-8"))
+        meta["cache_version"] = CACHE_VERSION + 99
+        meta_path.write_text(json.dumps(meta), encoding="utf-8")
+
+        assert load_result(tmp_path, fingerprint) is None
+
+    def test_missing_entry_returns_none(self, tmp_path: Path):
+        """load_result returns None for a fingerprint that was never saved."""
+        assert load_result(tmp_path, "d" * 64) is None
+
+    def test_meta_contains_versions(self, tmp_path: Path):
+        """Saved meta.json includes boulder_version and cantera_version keys."""
+        fingerprint = "e" * 64
+        save_result(
+            cache_root=tmp_path,
+            fingerprint=fingerprint,
+            gui_payload=SIMPLE_PAYLOAD,
+            config_snapshot=SIMPLE_CONFIG,
+        )
+        loaded = load_result(tmp_path, fingerprint)
+        assert loaded is not None
+        meta = loaded["meta"]
+        assert "boulder_version" in meta
+        assert "cantera_version" in meta
+        assert meta["cache_version"] == CACHE_VERSION
+
+    def test_artifacts_dir_exists(self, tmp_path: Path):
+        """The artifacts/ subdirectory exists after save_result."""
+        fingerprint = "f" * 64
+        save_result(
+            cache_root=tmp_path,
+            fingerprint=fingerprint,
+            gui_payload=SIMPLE_PAYLOAD,
+            config_snapshot=SIMPLE_CONFIG,
+        )
+        loaded = load_result(tmp_path, fingerprint)
+        assert loaded is not None
+        assert loaded["artifacts_dir"].is_dir()
+
+    def test_numpy_coercion(self, tmp_path: Path):
+        """save_result coerces numpy-like scalars to JSON-native types."""
+        import numpy as np
+
+        fingerprint = "g" * 64
+        payload_with_numpy = {
+            **SIMPLE_PAYLOAD,
+            "elapsed_time": np.float64(2.5),
+            "summary": [{"value": np.int32(42), "label": "T"}],
+        }
+        save_result(
+            cache_root=tmp_path,
+            fingerprint=fingerprint,
+            gui_payload=payload_with_numpy,
+            config_snapshot=SIMPLE_CONFIG,
+        )
+        loaded = load_result(tmp_path, fingerprint)
+        assert loaded is not None
+        assert loaded["gui_payload"]["elapsed_time"] == 2.5
+        assert loaded["gui_payload"]["summary"][0]["value"] == 42
+
+
+# ---------------------------------------------------------------------------
+# Pruning
+# ---------------------------------------------------------------------------
+
+
+class TestPruning:
+    def test_prune_keeps_max_entries(self, tmp_path: Path):
+        """Saving more than MAX_CACHE_ENTRIES entries prunes the oldest ones."""
+        from boulder.result_cache import MAX_CACHE_ENTRIES
+
+        # Write MAX_CACHE_ENTRIES + 2 entries with distinct fingerprints
+        fingerprints = []
+        for i in range(MAX_CACHE_ENTRIES + 2):
+            fp = f"{i:064x}"
+            fingerprints.append(fp)
+            save_result(
+                cache_root=tmp_path,
+                fingerprint=fp,
+                gui_payload=SIMPLE_PAYLOAD,
+                config_snapshot=SIMPLE_CONFIG,
+            )
+            time.sleep(0.01)  # ensure mtime ordering
+
+        complete_entries = [
+            d
+            for d in tmp_path.iterdir()
+            if d.is_dir() and (d / "COMPLETE").exists()
+        ]
+        assert len(complete_entries) == MAX_CACHE_ENTRIES
+
+
+# ---------------------------------------------------------------------------
+# CacheContributorPlugin
+# ---------------------------------------------------------------------------
+
+
+class _DummyContributor(CacheContributorPlugin):
+    """Test contributor that writes a sentinel file."""
+
+    @property
+    def contributor_id(self) -> str:
+        return "test_dummy"
+
+    def contribute(
+        self,
+        config: Dict[str, Any],
+        converter: Any,
+        simulation_result: Any,
+        fingerprint: str,
+        artifacts_dir: Path,
+    ) -> None:
+        (artifacts_dir / "sentinel.txt").write_text(fingerprint[:8], encoding="utf-8")
+
+
+class TestCacheContributorPlugin:
+    def test_register_and_no_duplicate(self):
+        """Registering the same contributor_id twice is a no-op."""
+        registry = CacheContributorRegistry()
+        c = _DummyContributor()
+        registry.register(c)
+        registry.register(c)
+        assert len(registry.contributors) == 1
+
+    def test_run_contributors_calls_contribute(self, tmp_path: Path):
+        """run_contributors invokes each registered contributor."""
+        fingerprint = "h" * 64
+        artifacts_dir = tmp_path / "artifacts"
+        artifacts_dir.mkdir()
+
+        contributor = _DummyContributor()
+        run_contributors(
+            contributors=[contributor],
+            config=SIMPLE_CONFIG,
+            converter=MagicMock(),
+            simulation_result=MagicMock(),
+            fingerprint=fingerprint,
+            artifacts_dir=artifacts_dir,
+        )
+
+        sentinel = artifacts_dir / "sentinel.txt"
+        assert sentinel.is_file()
+        assert sentinel.read_text() == fingerprint[:8]
+
+    def test_run_contributors_swallows_errors(self, tmp_path: Path):
+        """run_contributors does not raise when a contributor fails."""
+
+        class _FailingContributor(CacheContributorPlugin):
+            @property
+            def contributor_id(self) -> str:
+                return "test_failing"
+
+            def contribute(self, config, converter, simulation_result, fingerprint, artifacts_dir):
+                raise RuntimeError("intentional failure")
+
+        artifacts_dir = tmp_path / "artifacts"
+        artifacts_dir.mkdir()
+
+        # Must not raise even though the contributor throws
+        run_contributors(
+            contributors=[_FailingContributor()],
+            config=SIMPLE_CONFIG,
+            converter=MagicMock(),
+            simulation_result=MagicMock(),
+            fingerprint="i" * 64,
+            artifacts_dir=artifacts_dir,
+        )
+        # If we reach here, the error was swallowed as required.
+
+
+# ---------------------------------------------------------------------------
+# API: GET /api/simulations/cached
+# ---------------------------------------------------------------------------
+
+
+pytest.importorskip("fastapi")
+from fastapi.testclient import TestClient  # noqa: E402
+
+from boulder.api.main import create_app  # noqa: E402
+
+
+class TestCachedEndpoint:
+    @pytest.fixture
+    def client_no_cache(self):
+        """TestClient with no preloaded cache.
+
+        The lifespan initialises preloaded_result=None when no BOULDER_CONFIG_PATH
+        is set, so the /cached endpoint returns {cached: false}.
+        """
+        app = create_app()
+        with TestClient(app) as client:
+            yield client
+
+    @pytest.fixture
+    def client_with_cache(self, tmp_path: Path):
+        """TestClient with a pre-populated cache entry injected after startup.
+
+        We set app.state inside the TestClient context manager (after lifespan
+        startup) so that the lifespan reset does not overwrite our value.
+        """
+        fingerprint = "j" * 64
+        artifacts_dir = tmp_path / "artifacts"
+        artifacts_dir.mkdir()
+        cache_data = {
+            "fingerprint": fingerprint,
+            "gui_payload": SIMPLE_PAYLOAD,
+            "config_snapshot": SIMPLE_CONFIG,
+            "meta": {"cache_version": CACHE_VERSION, "created_at": time.time()},
+            "artifacts_dir": artifacts_dir,
+        }
+        app = create_app()
+        with TestClient(app) as client:
+            # Inject after lifespan startup
+            app.state.preloaded_result = cache_data
+            app.state.preloaded_fingerprint = fingerprint
+            yield client
+
+    def test_no_cache_returns_false(self, client_no_cache: TestClient):
+        """GET /api/simulations/cached returns {cached: false} when no cache exists."""
+        resp = client_no_cache.get("/api/simulations/cached")
+        assert resp.status_code == 200
+        assert resp.json()["cached"] is False
+
+    def test_cache_present_returns_result(self, client_with_cache: TestClient):
+        """GET /api/simulations/cached returns the payload when cache is loaded."""
+        resp = client_with_cache.get("/api/simulations/cached")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["cached"] is True
+        assert data["result"]["status"] == "complete"
+        assert "fingerprint" in data
+        assert "meta" in data
+
+    def test_artifact_missing_returns_404(self, client_with_cache: TestClient):
+        """GET /api/simulations/cached/artifacts/missing.txt returns 404."""
+        resp = client_with_cache.get("/api/simulations/cached/artifacts/missing.txt")
+        assert resp.status_code == 404
+
+    def test_artifact_served(self, client_with_cache: TestClient):
+        """GET /api/simulations/cached/artifacts/<name> serves existing artifact files."""
+        artifacts_dir = client_with_cache.app.state.preloaded_result["artifacts_dir"]
+        test_file = artifacts_dir / "test.txt"
+        test_file.write_text("hello", encoding="utf-8")
+        resp = client_with_cache.get("/api/simulations/cached/artifacts/test.txt")
+        assert resp.status_code == 200
+        assert b"hello" in resp.content


### PR DESCRIPTION
Add a Caching mechanism of results ; so that simulations already computed do not need to be ran again. This is specially relevant in the case of complex networks or slow mechanisms ; allowing Boulder to be used as a tool to visualize the results. 

## Details 

Boulder stores the GUI results payload (times, reactor series, reports,
Sankey, summary, updated nodes/connections) to a fingerprinted directory
next to the loaded YAML file.  On startup, if the preloaded config
fingerprint matches a cache entry, Boulder loads it and sends it to the
frontend immediately so outputs are visible without re-running.

Host packages (e.g. Bloc) register :class:`CacheContributorPlugin`
implementations.  After each successful GUI solve, Boulder calls every
registered contributor so they can write package-specific artifacts
(e.g. a calc-note bundle JSON + figure PNGs) into the same cache entry.
The contributor receives the solved ``converter`` so it can access
live network objects.

Cache layout
------------
::

    <yaml_dir>/.boulder-cache/         (or $BOULDER_CACHE_DIR)
        <fingerprint>/
            result.json                GUI payload + config snapshot
            meta.json                  created_at, versions, fingerprint inputs
            COMPLETE                   marker written last (atomic write guard)
            artifacts/                 contributor-written files

Fingerprint
-----------
SHA-256 hex of canonical sorted-key JSON of:

* normalized config (nodes, connections, settings, phases)
* mechanism identity (content hash for local files; name+cantera-version for builtins)
* package source identity (git HEAD + dirty token for editable installs)
* cantera version
* per-plugin source identity from ``BOULDER_PLUGINS``
* ``BOULDER_PLUGINS`` env var
* ``CACHE_VERSION`` integer

:data:`CACHE_VERSION` must be bumped whenever the ``result.json``
or ``meta.json`` schema changes.

---

Fixes #51 