### PR TITLE
add ymin=0 for pressure Plot

### DIFF
--- a/frontend/src/components/results/ConvergenceTab.tsx
+++ b/frontend/src/components/results/ConvergenceTab.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from "react";
 import Plot from "react-plotly.js";
+import { coerceNumericSeries, pressureYAxis } from "@/lib/plotAxis";
 import { useSelectionStore } from "@/stores/selectionStore";
 import { useThemeStore } from "@/stores/themeStore";
 import type { SimulationProgress } from "@/types/simulation";
@@ -194,7 +195,7 @@ export function ConvergenceTab({ data }: Props) {
           data={[
             {
               x: times,
-              y: series.P ?? [],
+              y: coerceNumericSeries(series.P),
               type: "scatter",
               mode: "lines",
               name: selectedReactorId,
@@ -205,7 +206,7 @@ export function ConvergenceTab({ data }: Props) {
             ...layoutDefaults,
             title: { text: "Pressure vs Time", font: { size: 14 } },
             xaxis: { title: { text: "Time (s)", font: { size: 12 } }, gridcolor },
-            yaxis: { title: { text: "Pressure (Pa)", font: { size: 12 } }, gridcolor },
+            yaxis: pressureYAxis(gridcolor),
           }}
           config={{ responsive: true, displayModeBar: false }}
           useResizeHandler

--- a/frontend/src/components/results/PlotsTab.test.tsx
+++ b/frontend/src/components/results/PlotsTab.test.tsx
@@ -20,6 +20,10 @@ interface PlotTrace {
 
 interface PlotProps {
   data: PlotTrace[];
+  layout?: {
+    yaxis?: Record<string, unknown>;
+    title?: { text?: string };
+  };
 }
 
 const plotCalls = vi.hoisted(() => [] as PlotProps[]);
@@ -56,6 +60,22 @@ const steadySingleSample: SimulationProgress = {
   },
 };
 
+const spatialPressureSample = {
+  is_running: false,
+  is_complete: true,
+  times: [],
+  reactors_series: {
+    pfr: {
+      is_spatial: true,
+      x: [5.7, 5.8, 5.9],
+      T: [1200, 1210, 1220],
+      P: ["100000", "101325", "102500"],
+      X: { N2: [0.8, 0.79, 0.78] },
+      Y: { N2: [0.8, 0.79, 0.78] },
+    },
+  },
+} as unknown as SimulationProgress;
+
 describe("PlotsTab", () => {
   beforeEach(() => {
     plotCalls.length = 0;
@@ -76,6 +96,28 @@ describe("PlotsTab", () => {
       x: [0],
       y: [101325],
       mode: "lines+markers",
+    });
+    expect(plotCalls[1].layout?.yaxis).toMatchObject({
+      rangemode: "tozero",
+      tickformat: ",.0f",
+    });
+  });
+
+  it("uses a zero baseline for spatial pressure profiles", () => {
+    useSelectionStore.setState({
+      selectedElement: { type: "node", data: { id: "pfr" } },
+    });
+    render(<PlotsTab data={spatialPressureSample} />);
+
+    const pressurePlot = plotCalls.find(
+      (plot) => plot.layout?.title?.text === "Pressure vs Position",
+    );
+    expect(pressurePlot).toBeDefined();
+    expect(pressurePlot?.data[0]?.y).toEqual([100000, 101325, 102500]);
+    expect(pressurePlot?.layout?.yaxis).toMatchObject({
+      rangemode: "tozero",
+      tickformat: ",.0f",
+      exponentformat: "none",
     });
   });
 });

--- a/frontend/src/components/results/PlotsTab.tsx
+++ b/frontend/src/components/results/PlotsTab.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from "react";
 import Plot from "react-plotly.js";
+import { coerceNumericSeries, pressureYAxis } from "@/lib/plotAxis";
 import { useSelectionStore } from "@/stores/selectionStore";
 import { useThemeStore } from "@/stores/themeStore";
 import type { SimulationProgress } from "@/types/simulation";
@@ -146,7 +147,7 @@ export function PlotsTab({ data }: Props) {
             data={[
               {
                 x: xAxis,
-                y: reactorSeries.P ?? [],
+                y: coerceNumericSeries(reactorSeries.P),
                 type: "scatter",
                 mode: profileTraceMode,
                 name: selectedReactorId,
@@ -157,7 +158,7 @@ export function PlotsTab({ data }: Props) {
               ...layoutDefaults,
               title: { text: `Pressure vs ${coordLabel}`, font: { size: 14 } },
               xaxis: { title: { text: xLabel, font: { size: 12 } }, gridcolor },
-              yaxis: { title: { text: "Pressure (Pa)", font: { size: 12 } }, gridcolor },
+              yaxis: pressureYAxis(gridcolor),
             }}
             config={{ responsive: true, displayModeBar: false }}
             useResizeHandler
@@ -378,7 +379,7 @@ export function PlotsTab({ data }: Props) {
           data={[
             {
               x: data.times,
-              y: data.reactors_series[selectedReactorId]?.P ?? [],
+              y: coerceNumericSeries(data.reactors_series[selectedReactorId]?.P),
               type: "scatter" as const,
               mode: timeTraceMode,
               name: selectedReactorId,
@@ -392,10 +393,7 @@ export function PlotsTab({ data }: Props) {
               title: { text: "Time (s)", font: { size: 12 } },
               gridcolor,
             },
-            yaxis: {
-              title: { text: "Pressure (Pa)", font: { size: 12 } },
-              gridcolor,
-            },
+            yaxis: pressureYAxis(gridcolor),
           }}
           config={{ responsive: true, displayModeBar: false }}
           useResizeHandler

--- a/frontend/src/lib/plotAxis.test.ts
+++ b/frontend/src/lib/plotAxis.test.ts
@@ -1,0 +1,28 @@
+/**
+ * Unit tests for plot axis helpers.
+ *
+ * Asserts:
+ * - coerceNumericSeries converts string values to numbers.
+ * - pressureYAxis pins the autorange baseline to zero and uses plain Pa ticks.
+ */
+
+import { describe, expect, it } from "vitest";
+import { coerceNumericSeries, pressureYAxis } from "./plotAxis";
+
+describe("plotAxis", () => {
+  it("coerces string pressure samples to numeric series", () => {
+    expect(coerceNumericSeries(["101325", "102000", "bad"])).toEqual([
+      101325, 102000,
+    ]);
+  });
+
+  it("pressureYAxis includes a zero baseline and fixed-format ticks", () => {
+    expect(pressureYAxis("#ccc")).toEqual({
+      title: { text: "Pressure (Pa)", font: { size: 12 } },
+      gridcolor: "#ccc",
+      rangemode: "tozero",
+      tickformat: ",.0f",
+      exponentformat: "none",
+    });
+  });
+});

--- a/frontend/src/lib/plotAxis.ts
+++ b/frontend/src/lib/plotAxis.ts
@@ -1,0 +1,18 @@
+/** Helpers for consistent Plotly axis configuration in result tabs. */
+
+export function coerceNumericSeries(
+  values: Array<number | string> | undefined,
+): number[] {
+  if (!values?.length) return [];
+  return values.map((v) => Number(v)).filter((v) => Number.isFinite(v));
+}
+
+export function pressureYAxis(gridcolor: string) {
+  return {
+    title: { text: "Pressure (Pa)", font: { size: 12 } },
+    gridcolor,
+    rangemode: "tozero" as const,
+    tickformat: ",.0f",
+    exponentformat: "none" as const,
+  };
+}


### PR DESCRIPTION
## Summary

Fixes the malformed pressure y-axis in the Boulder Plot tab 

- **Zero baseline:** `rangemode: tozero` so pressure plots include 0 Pa on the y-axis.
- **Readable ticks:** plain `,.0f` Pa labels with `exponentformat: none` (no broken SI prefixes).
- **Numeric coercion:** string pressure samples are converted to numbers so Plotly treats the axis as numeric, not categorical.
