### PR TITLE
Add scenarii pane

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -159,11 +159,27 @@ GUI renders. `CACHE_VERSION` (in `result_cache.py`) gates cache entries; `PAYLOA
 `schema_version` attr) versions the HDF5 layout. Mechanism is stored as a resolved path + sha256; an
 unresolved mechanism on read is a graceful cache miss, never a crash.
 
+#### Scenario-focus channel (remote control)
+
+`api/routes/scenarios.py` exposes a generic seam so an **external process** (e.g. a separate result
+dashboard) can drive the open GUI to load a scenario, without polling or a page reload:
+
+- `POST /api/scenarios/focus` `{scenario_id}` — validates the id against the active store and pushes it
+  onto every subscriber (an in-process set of `asyncio.Queue`s on `app.state`); also remembered as
+  `app.state.focused_scenario`.
+- `GET /api/scenarios/focus/stream` — SSE; emits the current focus on connect (late-joiner sync) then
+  one `focus` event per POST. The frontend `useScenarioFocus` hook subscribes and calls the existing
+  `scenarioStore.setActive(id)` sink, so the trajectory appears in the Plots tab in place.
+
+The push carries only a scenario id (domain-neutral). A typical use: a dashboard `POST`s a focus from a
+server-side click handler — no browser CORS involved, since the GUI's own same-origin tab is the only
+SSE subscriber.
+
 ### Frontend (`frontend/src/`)
 
 - **API** — `api/client.ts`, `configs.ts`, `simulations.ts`, `mechanisms.ts`, `plugins.ts`
 - **State** — Zustand stores (`configStore`, `simulationStore`, `selectionStore`, etc.)
-- **Graph / results** — `ReactorGraph`, `ResultsTabs`, `PluginTab`, `useSimulationSSE`
+- **Graph / results** — `ReactorGraph`, `ResultsTabs`, `PluginTab`, `useSimulationSSE`, `useScenarioFocus`
 
 Plugins: `GET /api/plugins` lists tabs; `POST /api/plugins/{id}/render` returns structured JSON (image, table, html, plotly, etc.) consumed by `PluginTab`.
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -126,6 +126,39 @@ series keys when copying progress snapshots, the SSE/results API forwards them u
 plot mode from the inherited series metadata (`is_spatial`, `is_psr`, etc.); they should not re-classify
 reactors by kind string.
 
+### Result serialization (`boulder/payload_store.py`)
+
+A computed result is persisted in **one** composite-HDF5 format, shared by the result cache and the
+scenario inspector — so there is a single on-disk encoding and a single payload builder. Numerics are
+stored as natively-to-Cantera as possible; everything else rides alongside as JSON.
+
+- **`solution` tier** — a state series (`T`/`P`/`X` over an index) whose species the mechanism can
+  represent (and whose `X` rows are normalized) is saved as a Cantera `SolutionArray` group. `Y` is
+  *derived* on load. **Every per-state numeric column rides along as an `extra`** — `t` (time) *and*
+  `x` (position), so a **PFR spatial profile is stored natively here** (it's a Lagrangian state
+  sequence), not dumped to JSON.
+- **`arrays` tier** — same shape but the mechanism can't represent it (mechanism-switch reactors, or
+  non-normalized `X`): binary HDF5 datasets (one per extra column too) — no `Solution` needed to read.
+- **`raw` tier** — only genuinely non-state structures land here, verbatim in the JSON blob.
+- **Non-per-state fields** — flags (`is_spatial`, `is_psr`, `is_residence`) and off-shape arrays
+  (`fbs_convergence`, which is per-FBS-iteration, not per-state) ride in each reactor's `meta` in the
+  index and are merged back on load.
+- **`payload_json` dataset** — the rest of the `SimulationResults` (Sankey, reports, summary, code,
+  node/connection overlays) plus a `reactors_index` mapping each reactor to its tier/group.
+
+Two **profiles** of this one encoding:
+
+| | Result file (cache) | Collection file (scenario store) |
+|---|---|---|
+| File | `<cache>/<fp>/result.h5` (+ `meta.json` carries config_snapshot) | `results/<map>_scenarios.h5` |
+| Holds | one result (1..n reactors, groups `r0`,`r1`,…) | many single-reactor results, one group per scenario |
+| Producer / reader | `result_cache.save_result` / `load_result*` | `run_sweep.py` (Bloc) / `api/routes/scenarios.py` |
+
+Both call `payload_store.gui_payload_from_solution_array` to rebuild the same `SimulationResults` the
+GUI renders. `CACHE_VERSION` (in `result_cache.py`) gates cache entries; `PAYLOAD_SCHEMA` (== the root
+`schema_version` attr) versions the HDF5 layout. Mechanism is stored as a resolved path + sha256; an
+unresolved mechanism on read is a graceful cache miss, never a crash.
+
 ### Frontend (`frontend/src/`)
 
 - **API** — `api/client.ts`, `configs.ts`, `simulations.ts`, `mechanisms.ts`, `plugins.ts`

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -152,7 +152,7 @@ Two **profiles** of this one encoding:
 |---|---|---|
 | File | `<cache>/<fp>/result.h5` (+ `meta.json` carries config_snapshot) | `results/<map>_scenarios.h5` |
 | Holds | one result (1..n reactors, groups `r0`,`r1`,…) | many single-reactor results, one group per scenario |
-| Producer / reader | `result_cache.save_result` / `load_result*` | `run_sweep.py` (Bloc) / `api/routes/scenarios.py` |
+| Producer / reader | `result_cache.save_result` / `load_result*` | `run_sweep.py` (host) / `api/routes/scenarios.py` |
 
 Both call `payload_store.gui_payload_from_solution_array` to rebuild the same `SimulationResults` the
 GUI renders. `CACHE_VERSION` (in `result_cache.py`) gates cache entries; `PAYLOAD_SCHEMA` (== the root

--- a/STONE_SPECIFICATIONS.md
+++ b/STONE_SPECIFICATIONS.md
@@ -27,9 +27,13 @@ ______________________________________________________________________
 ## 2. Allowed Top-Level Keys
 
 ```
-metadata   phases   settings   stages   network   export   sweeps   scenarios
+metadata   phases   settings   stages   network   export   sweep   sweeps   scenario
 continuation   signals   bindings   scopes
 ```
+
+`scenario:` and `sweep:` declare inline run-set variations (Section 14). Boulder validates and
+passes them through; a host's reporting/expansion layer consumes them. (The legacy plural
+`scenarios:` list form is removed — use the `scenario:` mapping.)
 
 Dynamic stage block names (declared under `stages:`) are also allowed at the top level.
 
@@ -1253,3 +1257,47 @@ name), `mechanism_sha256` (diagnostic; the cache fingerprint is the correctness 
 - An unresolved/mismatched mechanism on read is a graceful cache miss (cache) or a clear error
   (scenario route) — never a crash.
 - One `Solution` is cached per mechanism per process.
+
+______________________________________________________________________
+
+## 14. Inline run-set variations — `scenario:` and `sweep:`
+
+A STONE file may declare multiple runs inline, instead of a glob of separate overlay files. Boulder
+validates and passes these blocks through; a host's expansion/reporting layer turns them into the
+run set (one config per run). They never alter the topology a single run sees — each expanded run is
+the base with its overlay/patch deep-merged, and the directives stripped.
+
+### `scenario:` — a mapping of `id → overlay`
+
+```yaml
+scenario:
+  Q600:                      # key is the scenario id
+    settings:
+      post_processing: {T_hot_out: 600}
+  QmMax_Q600:                # a full STONE subtree, deep-merged onto the base
+    stages:
+      pfr_stage: {mechanism: abf_1bar.yaml}
+    settings:
+      get_carbon_yield: {n_C_min: 9}
+```
+
+Each value is a STONE subtree (`metadata`/`stages`/`settings`/`network`/…) deep-merged onto the base
+(id-keyed `nodes`/`connections` merge by id). The **key is the scenario id**. This is the same delta a
+standalone `from:` overlay file carries — `from:` remains fully valid and is unaffected.
+
+### `sweep:` — a Cartesian parameter grid
+
+```yaml
+sweep:
+  T:  {path: "nodes[id=torch].properties.T_out", values: [2600, 2700]}
+  mdot: {path: "...", min: 1.0e-4, max: 2.0e-4, num: 3}   # or min/max/num (+ spacing: log)
+```
+
+`sweep:` may appear at the top level (expanded on the base) **or inside a `scenario:` entry**
+(expanded on that scenario only). Ids are suffixed `__<axis>=<value>`.
+
+### Run-set semantics (union)
+
+The run set is the **union**: the top-level `sweep:` points **⊎** each `scenario:` entry (each
+expanded across its *own* inner `sweep:` if present). A top-level sweep and the scenarios do **not**
+cross-multiply. (`sweep:` and `sweeps:` are accepted spellings.)

--- a/STONE_SPECIFICATIONS.md
+++ b/STONE_SPECIFICATIONS.md
@@ -1192,3 +1192,64 @@ connections:
 ```
 
 Boulder rejects v1 files with an actionable error message pointing to this document.
+
+______________________________________________________________________
+
+## 13. Result serialization schema (`result.h5` / `*_scenarios.h5`)
+
+A computed result is persisted in **one** composite-HDF5 format (`boulder/payload_store.py`), shared
+by the fingerprinted result cache and the sweep scenario store. This is an on-disk contract, not part
+of the YAML a user writes — documented here alongside the config schema so tooling recognizes it.
+
+### Core encoding — three tiers (per reactor series)
+
+| Tier | When | How stored | Notes |
+|---|---|---|---|
+| `solution` | state-shaped (`T`,`P`,`X`); species ⊆ mechanism; `X` rows sum to 1 ± 1e-6 | Cantera `SolutionArray` group (`r0`,`r1`,…) | `Y` derived on load; every per-state numeric column (`t`, `x`, …) is a SolutionArray `extra` |
+| `arrays` | state-shaped but mechanism can't represent it, or `X` not normalized | binary HDF5 datasets `T`,`P` (1D), `X`/`Y` (2D), `extra__<k>` per extra column, + `species_names` attr | no `Solution` needed to read |
+| `raw` | not state-shaped (no `T`/`P` lists or no `X` dict) | verbatim in the JSON blob | lossless |
+
+A **spatial PFR profile is a state sequence** (its `x` is just another per-state column) and is stored
+natively in `solution`/`arrays` — not raw. Per-reactor fields that are *not* per-state columns — flags
+(`is_spatial`, `is_psr`, `is_residence`) and off-shape arrays (`fbs_convergence`, which is
+per-FBS-iteration) — ride in the reactor's `meta` (below) and are merged back on load, so the original
+series is reproduced exactly.
+
+### `payload_json` dataset
+
+A UTF-8 JSON string dataset (not an attribute — no ~64 KB cap) holding the rest of the
+`SimulationResults` (`times`, `reactor_reports`, `connection_reports`, `summary`, `code_str`,
+`sankey_links`, `sankey_nodes`, `updated_nodes`, `updated_connections`) plus a `reactors_index`:
+
+```jsonc
+"reactors_index": {
+  "<id>": { "kind": "solution", "group": "r0", "extra_keys": ["t"],      "meta": {"is_residence": true} },
+  "<id>": { "kind": "arrays",   "group": "r1", "extra_keys": ["t", "x"], "meta": {"is_spatial": true, "fbs_convergence": [12.0, 3.0]} },
+  "<id>": { "kind": "raw",      "series": { ... } }
+}
+```
+
+The config snapshot is **not** here — for the cache it lives in `meta.json` so a snapshot scan need
+not restore numerics.
+
+### Root attributes & versioning
+
+`schema_version` (== `payload_store.PAYLOAD_SCHEMA`), `mechanism` (resolved abs path, or bundled
+name), `mechanism_sha256` (diagnostic; the cache fingerprint is the correctness guard), `mechanism_name`.
+`result_cache.CACHE_VERSION` gates cache entries (mismatch ⇒ silent miss + recompute).
+
+### Two profiles
+
+- **Result file** `<cache>/<fp>/result.h5` — one result, reactor groups `r0…`, file-level
+  `payload_json`; `meta.json` carries `created_at`/versions/`mechanism`/`config_snapshot`.
+- **Collection file** `results/<map>_scenarios.h5` — many single-reactor results, one group per
+  scenario keyed by id (e.g. `T0_1273K`); root attrs add `reactor_id`, `reactor_mode`, `map_config`,
+  `created_at`, `cantera_version`; per-group attrs carry scenario KPIs (`t0_K`, `label`, `n_points`,
+  `final_temperature_K`, `solid_carbon_yield_pct`, `computed_at`).
+
+### Invariants
+
+- `Y` is derived for the `solution` tier (exact for Cantera-consistent states).
+- An unresolved/mismatched mechanism on read is a graceful cache miss (cache) or a clear error
+  (scenario route) — never a crash.
+- One `Solution` is cached per mechanism per process.

--- a/STONE_SPECIFICATIONS.md
+++ b/STONE_SPECIFICATIONS.md
@@ -64,7 +64,7 @@ phases:
   gas:
     mechanism: gri30.yaml
   fuel:
-    mechanism: Fincke_GRC.yaml
+    mechanism: h2o2.yaml
 ```
 
 A `mechanism:` value in a stage or node may be a phase alias (`gas`, `fuel`) or a raw mechanism
@@ -1271,14 +1271,14 @@ the base with its overlay/patch deep-merged, and the directives stripped.
 
 ```yaml
 scenario:
-  Q600:                      # key is the scenario id
+  case_a:                    # key is the scenario id
     settings:
-      post_processing: {T_hot_out: 600}
-  QmMax_Q600:                # a full STONE subtree, deep-merged onto the base
+      solver: {atol: 1.0e-12}
+  case_b:                    # a full STONE subtree, deep-merged onto the base
     stages:
-      pfr_stage: {mechanism: abf_1bar.yaml}
-    settings:
-      get_carbon_yield: {n_C_min: 9}
+      stage_2: {mechanism: h2o2.yaml}
+    network:
+      - {id: reactor1, IdealGasReactor: {initial: {temperature: 1400 K}}}
 ```
 
 Each value is a STONE subtree (`metadata`/`stages`/`settings`/`network`/…) deep-merged onto the base

--- a/boulder/api/main.py
+++ b/boulder/api/main.py
@@ -194,7 +194,9 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         if store_env and store_env.strip():
             app.state.scenario_store_path = store_env.strip()
         elif app.state.preloaded_config and app.state.preloaded_config_path:
-            extra = (app.state.preloaded_config.get("metadata") or {}).get("extra") or {}
+            extra = (app.state.preloaded_config.get("metadata") or {}).get(
+                "extra"
+            ) or {}
             rel = extra.get("scenario_store")
             base = Path(app.state.preloaded_config_path).resolve().parent
             if rel:
@@ -205,9 +207,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
                 stem = Path(app.state.preloaded_config_path).stem
                 app.state.scenario_store_path = str(base / f"{stem}_scenarios.h5")
         if app.state.scenario_store_path:
-            logger.info(
-                "Scenario store enabled: %s", app.state.scenario_store_path
-            )
+            logger.info("Scenario store enabled: %s", app.state.scenario_store_path)
     except Exception as store_err:  # noqa: BLE001
         logger.warning("Scenario store resolution failed: %s", store_err)
         app.state.scenario_store_path = None

--- a/boulder/api/main.py
+++ b/boulder/api/main.py
@@ -212,6 +212,11 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         logger.warning("Scenario store resolution failed: %s", store_err)
         app.state.scenario_store_path = None
 
+    # Scenario-focus channel: external tools (e.g. a result dashboard) can drive
+    # the open GUI to load a scenario id; tabs subscribe over SSE.
+    app.state.scenario_focus_subscribers = set()
+    app.state.focused_scenario = None
+
     logger.info("Boulder API started – plugins loaded, converter ready")
     yield
     # Shutdown: nothing to clean up

--- a/boulder/api/main.py
+++ b/boulder/api/main.py
@@ -31,7 +31,16 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 
-from .routes import configs, graph, gui_actions, mechanisms, plugins, simulations
+from .routes import (
+    configs,
+    graph,
+    gui_actions,
+    mechanisms,
+    plugins,
+    scenarios,
+    simulations,
+    sweep,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -75,6 +84,9 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     app.state.preloaded_config_path = None  # full path for script generation
     app.state.preloaded_result = None
     app.state.preloaded_fingerprint = None
+    app.state.scenario_store_path = None
+    app.state.preloaded_raw = None  # inheritance-resolved config (keeps sweeps:)
+    app.state.sweep_job = None
 
     if env_config_path and env_config_path.strip():
         try:
@@ -93,6 +105,9 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
             # plain Boulder use.
             runner_cls = _runner_class or BoulderRunner
             config = runner_cls.load(cleaned)
+            # Keep the inheritance-resolved config before normalize strips
+            # ``sweeps:`` — the Run Sweep button needs to see it.
+            app.state.preloaded_raw = config
 
             # Keep the original YAML string for the editor panel.  For inheritance
             # overlays the "original" shown is the leaf file (what the user opened),
@@ -169,6 +184,27 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         except Exception as e:
             logger.error(f"Failed to load preloaded configuration: {e}")
 
+    # Resolve the scenario-inspector store (HDF5): explicit env override wins,
+    # else the preloaded config's ``metadata.extra.scenario_store`` resolved
+    # relative to the YAML's directory. Enables the GUI Scenario Pane.
+    try:
+        store_env = os.environ.get("BOULDER_SCENARIO_STORE")
+        if store_env and store_env.strip():
+            app.state.scenario_store_path = store_env.strip()
+        elif app.state.preloaded_config and app.state.preloaded_config_path:
+            extra = (app.state.preloaded_config.get("metadata") or {}).get("extra") or {}
+            rel = extra.get("scenario_store")
+            if rel:
+                base = Path(app.state.preloaded_config_path).resolve().parent
+                app.state.scenario_store_path = str((base / rel).resolve())
+        if app.state.scenario_store_path:
+            logger.info(
+                "Scenario store enabled: %s", app.state.scenario_store_path
+            )
+    except Exception as store_err:  # noqa: BLE001
+        logger.warning("Scenario store resolution failed: %s", store_err)
+        app.state.scenario_store_path = None
+
     logger.info("Boulder API started – plugins loaded, converter ready")
     yield
     # Shutdown: nothing to clean up
@@ -209,6 +245,8 @@ def create_app() -> FastAPI:
     app.include_router(
         gui_actions.router, prefix="/api/gui-actions", tags=["gui-actions"]
     )
+    app.include_router(scenarios.router, prefix="/api/scenarios", tags=["scenarios"])
+    app.include_router(sweep.router, prefix="/api/sweep", tags=["sweep"])
 
     # Health check
     @app.get("/api/health")

--- a/boulder/api/main.py
+++ b/boulder/api/main.py
@@ -87,6 +87,8 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     app.state.scenario_store_path = None
     app.state.preloaded_raw = None  # inheritance-resolved config (keeps sweeps:)
     app.state.sweep_job = None
+    # ``bloc --sweep`` (GUI): default the split button to Run Sweep.
+    app.state.sweep_default = bool(os.environ.get("BOULDER_SWEEP_MODE"))
 
     if env_config_path and env_config_path.strip():
         try:
@@ -194,9 +196,14 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         elif app.state.preloaded_config and app.state.preloaded_config_path:
             extra = (app.state.preloaded_config.get("metadata") or {}).get("extra") or {}
             rel = extra.get("scenario_store")
+            base = Path(app.state.preloaded_config_path).resolve().parent
             if rel:
-                base = Path(app.state.preloaded_config_path).resolve().parent
                 app.state.scenario_store_path = str((base / rel).resolve())
+            elif os.environ.get("BOULDER_SWEEP_MODE"):
+                # Sweep mode with no declared store → default next to the config,
+                # so pre-computed scenarios (if any) show in the pane.
+                stem = Path(app.state.preloaded_config_path).stem
+                app.state.scenario_store_path = str(base / f"{stem}_scenarios.h5")
         if app.state.scenario_store_path:
             logger.info(
                 "Scenario store enabled: %s", app.state.scenario_store_path

--- a/boulder/api/main.py
+++ b/boulder/api/main.py
@@ -87,7 +87,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     app.state.scenario_store_path = None
     app.state.preloaded_raw = None  # inheritance-resolved config (keeps sweeps:)
     app.state.sweep_job = None
-    # ``bloc --sweep`` (GUI): default the split button to Run Sweep.
+    # ``--sweep`` GUI mode (BOULDER_SWEEP_MODE): default the split button to Run Sweep.
     app.state.sweep_default = bool(os.environ.get("BOULDER_SWEEP_MODE"))
 
     if env_config_path and env_config_path.strip():

--- a/boulder/api/routes/scenarios.py
+++ b/boulder/api/routes/scenarios.py
@@ -71,41 +71,7 @@ def _solution_for(request: Request, mechanism: str) -> ct.Solution:
     return cache[mechanism]
 
 
-def _reactors_series(states: ct.SolutionArray, reactor_id: str) -> Dict[str, Any]:
-    names = list(states.species_names)
-    mole = states.X
-    mass = states.Y
-    return {
-        reactor_id: {
-            "T": [float(v) for v in states.T],
-            "P": [float(v) for v in states.P],
-            "X": {sp: [float(v) for v in mole[:, i]] for i, sp in enumerate(names)},
-            "Y": {sp: [float(v) for v in mass[:, i]] for i, sp in enumerate(names)},
-            "is_residence": True,
-            "t": [float(v) for v in states.t],
-        }
-    }
-
-
-def _gui_payload(states: ct.SolutionArray, reactor_id: str) -> Dict[str, Any]:
-    series = _reactors_series(states, reactor_id)
-    return {
-        "status": "complete",
-        "is_running": False,
-        "is_complete": True,
-        "error_message": None,
-        "times": series[reactor_id]["t"],
-        "reactors_series": series,
-        "reactor_reports": {},
-        "connection_reports": {},
-        "code_str": "",
-        "summary": [],
-        "sankey_links": None,
-        "sankey_nodes": None,
-        "elapsed_time": None,
-        "updated_nodes": None,
-        "updated_connections": None,
-    }
+from ...payload_store import gui_payload_from_solution_array as _gui_payload
 
 
 @router.get("")
@@ -120,6 +86,7 @@ async def list_scenarios(request: Request) -> Dict[str, Any]:
         "store": store.name,
         "mechanism": root.get("mechanism_name"),
         "reactor_mode": root.get("reactor_mode"),
+        "created_at": root.get("created_at"),
         "scenarios": _scenario_entries(store),
     }
 

--- a/boulder/api/routes/scenarios.py
+++ b/boulder/api/routes/scenarios.py
@@ -122,7 +122,7 @@ class FocusRequest(BaseModel):
 
 
 def _focus_subscribers(request: Request) -> "set[asyncio.Queue]":
-    """The live set of SSE subscriber queues (created on first use)."""
+    """Return the live set of SSE subscriber queues (created on first use)."""
     subs = getattr(request.app.state, "scenario_focus_subscribers", None)
     if subs is None:
         subs = set()

--- a/boulder/api/routes/scenarios.py
+++ b/boulder/api/routes/scenarios.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-import cantera as ct
 import h5py
 from fastapi import APIRouter, HTTPException, Request
 
@@ -48,30 +47,18 @@ def _root_attrs(h5_path: Path) -> Dict[str, Any]:
 
 
 def _scenario_entries(h5_path: Path) -> List[Dict[str, Any]]:
+    """List scenario composites — top-level groups holding a ``payload_json``."""
     entries: List[Dict[str, Any]] = []
     with h5py.File(str(h5_path), "r") as handle:
         for name, node in handle.items():
-            if not isinstance(node, h5py.Group) or "t0_K" not in node.attrs:
+            if not isinstance(node, h5py.Group) or "payload_json" not in node:
                 continue
             entry = {key: _to_py(val) for key, val in node.attrs.items()}
             entry["id"] = name
             entries.append(entry)
-    entries.sort(key=lambda e: e.get("t0_K", 0.0))
+    # Sort by explicit order, else by initial temperature, else by id.
+    entries.sort(key=lambda e: (e.get("order", e.get("t0_K", 0.0)), e["id"]))
     return entries
-
-
-def _solution_for(request: Request, mechanism: str) -> ct.Solution:
-    """Return a cached empty Solution per mechanism (load paid once)."""
-    cache = getattr(request.app.state, "_scenario_solutions", None)
-    if cache is None:
-        cache = {}
-        request.app.state._scenario_solutions = cache
-    if mechanism not in cache:
-        cache[mechanism] = ct.Solution(mechanism)
-    return cache[mechanism]
-
-
-from ...payload_store import gui_payload_from_solution_array as _gui_payload
 
 
 @router.get("")
@@ -93,7 +80,7 @@ async def list_scenarios(request: Request) -> Dict[str, Any]:
 
 @router.get("/{scenario_id}")
 async def get_scenario(scenario_id: str, request: Request) -> Dict[str, Any]:
-    """Restore one scenario's SolutionArray and return it as a results payload."""
+    """Return one scenario's composite payload (multi-reactor, reports, Sankey)."""
     store = _store_path(request)
     if store is None or not store.is_file():
         raise HTTPException(status_code=404, detail="No scenario store available")
@@ -104,15 +91,12 @@ async def get_scenario(scenario_id: str, request: Request) -> Dict[str, Any]:
 
     root = _root_attrs(store)
     mechanism = str(root.get("mechanism") or root.get("mechanism_name") or "")
-    reactor_id = str(root.get("reactor_id") or "reactor")
     try:
-        gas = _solution_for(request, mechanism)
-        states = ct.SolutionArray(gas)
-        states.restore(str(store), name=scenario_id)
+        from ...payload_store import read_payload
+
+        return read_payload(store, mechanism_override=mechanism, group=scenario_id)
     except Exception as exc:  # noqa: BLE001
         raise HTTPException(
             status_code=500,
             detail=f"Failed to restore scenario {scenario_id!r}: {exc}",
         ) from exc
-
-    return _gui_payload(states, reactor_id)

--- a/boulder/api/routes/scenarios.py
+++ b/boulder/api/routes/scenarios.py
@@ -16,11 +16,15 @@ HDF5 schema is the contract between producer and GUI.
 
 from __future__ import annotations
 
+import asyncio
+import json
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 import h5py
 from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import StreamingResponse
+from pydantic import BaseModel
 
 router = APIRouter()
 
@@ -100,3 +104,92 @@ async def get_scenario(scenario_id: str, request: Request) -> Dict[str, Any]:
             status_code=500,
             detail=f"Failed to restore scenario {scenario_id!r}: {exc}",
         ) from exc
+
+
+# --------------------------------------------------------------------------- #
+# Scenario-focus channel — a generic remote-control seam.
+#
+# An external process (e.g. a separate result dashboard) can ask the open GUI to
+# load and visualise a given scenario id by POSTing to ``/focus``; every browser
+# tab subscribed to ``/focus/stream`` receives the id and loads it. The push is
+# in-process (a set of asyncio queues on ``app.state``); it carries only a
+# scenario id, so it stays domain-neutral.
+# --------------------------------------------------------------------------- #
+
+
+class FocusRequest(BaseModel):
+    scenario_id: str
+
+
+def _focus_subscribers(request: Request) -> "set[asyncio.Queue]":
+    """The live set of SSE subscriber queues (created on first use)."""
+    subs = getattr(request.app.state, "scenario_focus_subscribers", None)
+    if subs is None:
+        subs = set()
+        request.app.state.scenario_focus_subscribers = subs
+    return subs
+
+
+def _focus_event(scenario_id: str) -> str:
+    """One SSE ``focus`` event carrying the scenario id."""
+    return f"event: focus\ndata: {json.dumps({'scenario_id': scenario_id})}\n\n"
+
+
+@router.post("/focus")
+async def focus_scenario(req: FocusRequest, request: Request) -> Dict[str, Any]:
+    """Tell every subscribed GUI tab to load scenario ``scenario_id`` (live)."""
+    store = _store_path(request)
+    if store is None or not store.is_file():
+        raise HTTPException(status_code=404, detail="No scenario store available")
+    known = {e["id"] for e in _scenario_entries(store)}
+    if req.scenario_id not in known:
+        raise HTTPException(
+            status_code=404, detail=f"Unknown scenario {req.scenario_id!r}"
+        )
+
+    request.app.state.focused_scenario = req.scenario_id
+    for queue in list(_focus_subscribers(request)):
+        try:
+            queue.put_nowait(req.scenario_id)
+        except asyncio.QueueFull:  # pragma: no cover — unbounded queues
+            pass
+    return {"ok": True, "scenario_id": req.scenario_id}
+
+
+@router.get("/focus/stream")
+async def focus_stream(request: Request) -> StreamingResponse:
+    """SSE stream of scenario-focus events for the GUI to follow.
+
+    Emits the current focus (if any) immediately so a late-joining tab syncs,
+    then one ``focus`` event per :func:`focus_scenario` call; periodic comments
+    keep the connection alive.
+    """
+    subs = _focus_subscribers(request)
+    queue: asyncio.Queue = asyncio.Queue()
+    subs.add(queue)
+    current = getattr(request.app.state, "focused_scenario", None)
+
+    async def gen():
+        try:
+            if current:
+                yield _focus_event(current)
+            while True:
+                if await request.is_disconnected():
+                    break
+                try:
+                    scenario_id = await asyncio.wait_for(queue.get(), timeout=15.0)
+                    yield _focus_event(scenario_id)
+                except asyncio.TimeoutError:
+                    yield ": keep-alive\n\n"  # SSE comment — no event fired
+        finally:
+            subs.discard(queue)
+
+    return StreamingResponse(
+        gen(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",
+        },
+    )

--- a/boulder/api/routes/scenarios.py
+++ b/boulder/api/routes/scenarios.py
@@ -1,0 +1,151 @@
+"""Scenario inspector API: list and load precomputed reactor trajectories.
+
+Reads a self-describing HDF5 *scenario store* — one Cantera
+:class:`~cantera.SolutionArray` per scenario (named HDF5 group), with per-group
+and root attributes — and serves each scenario as a ``SimulationResults``-shaped
+payload that the frontend renders through ``setResults`` (the same path used for
+a cached solve). All scenarios share one network topology, so the GUI only swaps
+result data and never rebuilds the graph.
+
+Store location: ``app.state.scenario_store_path`` (set by the lifespan from the
+preloaded config's ``metadata.extra.scenario_store``, or ``BOULDER_SCENARIO_STORE``).
+
+This module depends only on ``cantera`` + ``h5py`` + stdlib (no host package); the
+HDF5 schema is the contract between producer and GUI.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import cantera as ct
+import h5py
+from fastapi import APIRouter, HTTPException, Request
+
+router = APIRouter()
+
+
+def _store_path(request: Request) -> Optional[Path]:
+    raw = getattr(request.app.state, "scenario_store_path", None)
+    return Path(raw) if raw else None
+
+
+def _to_py(value: Any) -> Any:
+    if isinstance(value, bytes):
+        return value.decode("utf-8", "replace")
+    if hasattr(value, "item"):
+        try:
+            return value.item()
+        except (ValueError, TypeError):
+            return value
+    return value
+
+
+def _root_attrs(h5_path: Path) -> Dict[str, Any]:
+    with h5py.File(str(h5_path), "r") as handle:
+        return {key: _to_py(val) for key, val in handle.attrs.items()}
+
+
+def _scenario_entries(h5_path: Path) -> List[Dict[str, Any]]:
+    entries: List[Dict[str, Any]] = []
+    with h5py.File(str(h5_path), "r") as handle:
+        for name, node in handle.items():
+            if not isinstance(node, h5py.Group) or "t0_K" not in node.attrs:
+                continue
+            entry = {key: _to_py(val) for key, val in node.attrs.items()}
+            entry["id"] = name
+            entries.append(entry)
+    entries.sort(key=lambda e: e.get("t0_K", 0.0))
+    return entries
+
+
+def _solution_for(request: Request, mechanism: str) -> ct.Solution:
+    """Return a cached empty Solution per mechanism (load paid once)."""
+    cache = getattr(request.app.state, "_scenario_solutions", None)
+    if cache is None:
+        cache = {}
+        request.app.state._scenario_solutions = cache
+    if mechanism not in cache:
+        cache[mechanism] = ct.Solution(mechanism)
+    return cache[mechanism]
+
+
+def _reactors_series(states: ct.SolutionArray, reactor_id: str) -> Dict[str, Any]:
+    names = list(states.species_names)
+    mole = states.X
+    mass = states.Y
+    return {
+        reactor_id: {
+            "T": [float(v) for v in states.T],
+            "P": [float(v) for v in states.P],
+            "X": {sp: [float(v) for v in mole[:, i]] for i, sp in enumerate(names)},
+            "Y": {sp: [float(v) for v in mass[:, i]] for i, sp in enumerate(names)},
+            "is_residence": True,
+            "t": [float(v) for v in states.t],
+        }
+    }
+
+
+def _gui_payload(states: ct.SolutionArray, reactor_id: str) -> Dict[str, Any]:
+    series = _reactors_series(states, reactor_id)
+    return {
+        "status": "complete",
+        "is_running": False,
+        "is_complete": True,
+        "error_message": None,
+        "times": series[reactor_id]["t"],
+        "reactors_series": series,
+        "reactor_reports": {},
+        "connection_reports": {},
+        "code_str": "",
+        "summary": [],
+        "sankey_links": None,
+        "sankey_nodes": None,
+        "elapsed_time": None,
+        "updated_nodes": None,
+        "updated_connections": None,
+    }
+
+
+@router.get("")
+async def list_scenarios(request: Request) -> Dict[str, Any]:
+    """List the scenarios in the active store (fast — reads attrs only)."""
+    store = _store_path(request)
+    if store is None or not store.is_file():
+        return {"available": False, "scenarios": []}
+    root = _root_attrs(store)
+    return {
+        "available": True,
+        "store": store.name,
+        "mechanism": root.get("mechanism_name"),
+        "reactor_mode": root.get("reactor_mode"),
+        "scenarios": _scenario_entries(store),
+    }
+
+
+@router.get("/{scenario_id}")
+async def get_scenario(scenario_id: str, request: Request) -> Dict[str, Any]:
+    """Restore one scenario's SolutionArray and return it as a results payload."""
+    store = _store_path(request)
+    if store is None or not store.is_file():
+        raise HTTPException(status_code=404, detail="No scenario store available")
+
+    entries = {e["id"]: e for e in _scenario_entries(store)}
+    if scenario_id not in entries:
+        raise HTTPException(status_code=404, detail=f"Unknown scenario {scenario_id!r}")
+
+    root = _root_attrs(store)
+    mechanism = str(root.get("mechanism") or root.get("mechanism_name") or "")
+    reactor_id = str(root.get("reactor_id") or "reactor")
+    try:
+        gas = _solution_for(request, mechanism)
+        states = ct.SolutionArray(gas)
+        states.restore(str(store), name=scenario_id)
+    except Exception as exc:  # noqa: BLE001
+        raise HTTPException(
+            status_code=500,
+            detail=f"Failed to restore scenario {scenario_id!r}: {exc}",
+        ) from exc
+
+    return _gui_payload(states, reactor_id)

--- a/boulder/api/routes/simulations.py
+++ b/boulder/api/routes/simulations.py
@@ -149,9 +149,17 @@ async def start_simulation(
             existing_kind = solver_block.get("kind", "")
             if existing_kind not in TRANSIENT_SOLVER_KINDS:
                 solver_block.setdefault("kind", "advance_grid")
-            grid = solver_block.setdefault("grid", {})
-            grid["stop"] = simulation_time
-            grid["dt"] = time_step
+            # Respect an already-declared grid (e.g. an explicit list of save
+            # times, or a {start,stop,dt} dict) — it is authoritative. Only
+            # synthesize a {stop,dt} grid from the time/step overrides when none
+            # exists yet (avoids indexing a list grid as a dict).
+            existing_grid = solver_block.get("grid")
+            if isinstance(existing_grid, dict):
+                existing_grid["stop"] = simulation_time
+                existing_grid["dt"] = time_step
+            elif existing_grid is None:
+                solver_block["grid"] = {"stop": simulation_time, "dt": time_step}
+            # else: explicit list grid — leave it untouched.
 
         # Create a fresh worker for this simulation.
         # Pass app.state so the worker can update preloaded_result after the

--- a/boulder/api/routes/simulations.py
+++ b/boulder/api/routes/simulations.py
@@ -357,7 +357,7 @@ async def get_cached_artifact(
 ) -> Any:
     """Serve a file from the cached artifacts directory.
 
-    Used by contributor plugins (e.g. Bloc) to fetch package-specific
+    Used by contributor plugins to fetch package-specific
     artifacts they wrote during a previous solve.
     """
     from fastapi.responses import FileResponse

--- a/boulder/api/routes/sweep.py
+++ b/boulder/api/routes/sweep.py
@@ -144,7 +144,7 @@ async def sweep_info(request: Request) -> Dict[str, Any]:
         "can_run": has and cmd is not None,
         "reason": reason,
         "running": running,
-        # ``bloc --sweep`` GUI mode → frontend defaults the split button to Run Sweep.
+        # ``--sweep`` GUI mode → frontend defaults the split button to Run Sweep.
         "default": bool(getattr(request.app.state, "sweep_default", False)),
     }
 

--- a/boulder/api/routes/sweep.py
+++ b/boulder/api/routes/sweep.py
@@ -30,8 +30,8 @@ _SCENARIO_RE = re.compile(r"scenario\s+(\d+)\s*/\s*(\d+)", re.IGNORECASE)
 _RUNNER_NAME = "run_sweep.py"
 
 
-def _count_scenarios(sweeps: Dict[str, Any]) -> int:
-    """Cartesian-product size of the sweep axes (generic; no host import)."""
+def _sweep_points(sweeps: Dict[str, Any]) -> int:
+    """Cartesian-product size of a sweep block's axes (generic; no host import)."""
     if not isinstance(sweeps, dict) or not sweeps:
         return 0
     total = 1
@@ -50,9 +50,28 @@ def _count_scenarios(sweeps: Dict[str, Any]) -> int:
     return total
 
 
-def _sweeps(request: Request) -> Dict[str, Any]:
+def _sweep_block(d: Dict[str, Any]) -> Dict[str, Any]:
+    return d.get("sweep") or d.get("sweeps") or {}
+
+
+def _run_set_size(raw: Dict[str, Any]) -> int:
+    """Union run-set size (generic; mirrors expand_scenarios without importing it):
+    global sweep points ⊎ each `scenario:` entry (its inner sweep, else 1)."""
+    scenario = raw.get("scenario") or {}
+    total = _sweep_points(_sweep_block(raw))  # global sweep points (0 if none)
+    for overlay in scenario.values():
+        inner = _sweep_block(overlay or {})
+        total += _sweep_points(inner) if inner else 1
+    return total
+
+
+def _has_run_set(request: Request) -> bool:
     raw = getattr(request.app.state, "preloaded_raw", None) or {}
-    return raw.get("sweeps") or {}
+    return bool(raw.get("scenario") or _sweep_block(raw))
+
+
+def _raw(request: Request) -> Dict[str, Any]:
+    return getattr(request.app.state, "preloaded_raw", None) or {}
 
 
 def _runner_path(request: Request) -> Optional[Path]:
@@ -65,24 +84,24 @@ def _runner_path(request: Request) -> Optional[Path]:
 
 @router.get("")
 async def sweep_info(request: Request) -> Dict[str, Any]:
-    """Report whether a sweep can be run for the preloaded config."""
-    sweeps = _sweeps(request)
-    n = _count_scenarios(sweeps)
+    """Report whether a run-set (scenarios and/or sweep) can be run."""
+    has = _has_run_set(request)
+    n = _run_set_size(_raw(request))
     runner = _runner_path(request)
     job = getattr(request.app.state, "sweep_job", None)
     running = bool(job and job.get("status") == "running")
 
-    if not sweeps:
-        reason = "No sweep in this config"
+    if not has:
+        reason = "No scenarios or sweep in this config"
     elif runner is None:
         reason = f"No {_RUNNER_NAME} next to the config"
     else:
-        reason = f"Run {n} sweep scenarios"
+        reason = f"Run {n} scenarios"
 
     return {
-        "available": bool(sweeps),
+        "available": has,
         "n_scenarios": n,
-        "can_run": bool(sweeps) and runner is not None,
+        "can_run": has and runner is not None,
         "reason": reason,
         "running": running,
     }
@@ -90,18 +109,17 @@ async def sweep_info(request: Request) -> Dict[str, Any]:
 
 @router.post("/run")
 async def sweep_run(request: Request) -> Dict[str, Any]:
-    """Start the sweep subprocess for the preloaded config."""
-    sweeps = _sweeps(request)
+    """Start the run-set subprocess for the preloaded config."""
     runner = _runner_path(request)
-    if not sweeps or runner is None:
-        raise HTTPException(status_code=400, detail="No runnable sweep for this config")
+    if not _has_run_set(request) or runner is None:
+        raise HTTPException(status_code=400, detail="No runnable run-set for this config")
 
     job = getattr(request.app.state, "sweep_job", None)
     if job and job.get("status") == "running":
         raise HTTPException(status_code=409, detail="A sweep is already running")
 
     cfg_path = Path(str(getattr(request.app.state, "preloaded_config_path")))
-    total = _count_scenarios(sweeps)
+    total = _run_set_size(_raw(request))
     state: Dict[str, Any] = {
         "status": "running",
         "current": 0,

--- a/boulder/api/routes/sweep.py
+++ b/boulder/api/routes/sweep.py
@@ -74,6 +74,21 @@ def _raw(request: Request) -> Dict[str, Any]:
     return getattr(request.app.state, "preloaded_raw", None) or {}
 
 
+def _store_path(request: Request) -> Optional[Path]:
+    """The collection store the run-set writes — declared
+    (``metadata.extra.scenario_store``) or the ``<stem>_scenarios.h5`` default
+    (must match the runner's default)."""
+    cfg_path = getattr(request.app.state, "preloaded_config_path", None)
+    if not cfg_path:
+        return None
+    cfg = Path(cfg_path).resolve()
+    rel = ((_raw(request).get("metadata") or {}).get("extra") or {}).get("scenario_store")
+    if rel:
+        p = Path(rel)
+        return p if p.is_absolute() else cfg.parent / p
+    return cfg.parent / f"{cfg.stem}_scenarios.h5"
+
+
 def _runner_command(request: Request) -> Optional[Dict[str, Any]]:
     """Resolve how to run the run-set: a ``run_sweep.py`` next to the config, or
     a host-registered ``sweep_runner`` command. Returns ``{argv, cwd}`` or None."""
@@ -132,6 +147,11 @@ async def sweep_run(request: Request) -> Dict[str, Any]:
         raise HTTPException(status_code=409, detail="A sweep is already running")
 
     total = _run_set_size(_raw(request))
+    # Point the server at the store the run-set writes so the Scenario Pane shows
+    # the results on refresh — even when the config declares no scenario_store.
+    store = _store_path(request)
+    if store is not None:
+        request.app.state.scenario_store_path = str(store)
     state: Dict[str, Any] = {
         "status": "running",
         "current": 0,

--- a/boulder/api/routes/sweep.py
+++ b/boulder/api/routes/sweep.py
@@ -74,12 +74,25 @@ def _raw(request: Request) -> Dict[str, Any]:
     return getattr(request.app.state, "preloaded_raw", None) or {}
 
 
-def _runner_path(request: Request) -> Optional[Path]:
+def _runner_command(request: Request) -> Optional[Dict[str, Any]]:
+    """Resolve how to run the run-set: a ``run_sweep.py`` next to the config, or
+    a host-registered ``sweep_runner`` command. Returns ``{argv, cwd}`` or None."""
     cfg_path = getattr(request.app.state, "preloaded_config_path", None)
     if not cfg_path:
         return None
-    runner = Path(cfg_path).resolve().parent / _RUNNER_NAME
-    return runner if runner.is_file() else None
+    cfg = Path(cfg_path).resolve()
+    local = cfg.parent / _RUNNER_NAME
+    if local.is_file():
+        return {"argv": [sys.executable, _RUNNER_NAME, cfg.name, "--no-plot"], "cwd": str(cfg.parent)}
+    from ...cantera_converter import get_plugins  # noqa: PLC0415
+
+    runner = getattr(get_plugins(), "sweep_runner", None)
+    if runner:
+        return {
+            "argv": [sys.executable, *runner, str(cfg), "--no-plot"],
+            "cwd": str(cfg.parent),
+        }
+    return None
 
 
 @router.get("")
@@ -87,21 +100,21 @@ async def sweep_info(request: Request) -> Dict[str, Any]:
     """Report whether a run-set (scenarios and/or sweep) can be run."""
     has = _has_run_set(request)
     n = _run_set_size(_raw(request))
-    runner = _runner_path(request)
+    cmd = _runner_command(request)
     job = getattr(request.app.state, "sweep_job", None)
     running = bool(job and job.get("status") == "running")
 
     if not has:
         reason = "No scenarios or sweep in this config"
-    elif runner is None:
-        reason = f"No {_RUNNER_NAME} next to the config"
+    elif cmd is None:
+        reason = "No scenario runner available"
     else:
         reason = f"Run {n} scenarios"
 
     return {
         "available": has,
         "n_scenarios": n,
-        "can_run": has and runner is not None,
+        "can_run": has and cmd is not None,
         "reason": reason,
         "running": running,
     }
@@ -110,15 +123,14 @@ async def sweep_info(request: Request) -> Dict[str, Any]:
 @router.post("/run")
 async def sweep_run(request: Request) -> Dict[str, Any]:
     """Start the run-set subprocess for the preloaded config."""
-    runner = _runner_path(request)
-    if not _has_run_set(request) or runner is None:
+    cmd = _runner_command(request)
+    if not _has_run_set(request) or cmd is None:
         raise HTTPException(status_code=400, detail="No runnable run-set for this config")
 
     job = getattr(request.app.state, "sweep_job", None)
     if job and job.get("status") == "running":
         raise HTTPException(status_code=409, detail="A sweep is already running")
 
-    cfg_path = Path(str(getattr(request.app.state, "preloaded_config_path")))
     total = _run_set_size(_raw(request))
     state: Dict[str, Any] = {
         "status": "running",
@@ -132,8 +144,8 @@ async def sweep_run(request: Request) -> Dict[str, Any]:
     def _worker() -> None:
         try:
             proc = subprocess.Popen(
-                [sys.executable, runner.name, cfg_path.name, "--no-plot"],
-                cwd=str(cfg_path.parent),
+                cmd["argv"],
+                cwd=cmd["cwd"],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
                 text=True,

--- a/boulder/api/routes/sweep.py
+++ b/boulder/api/routes/sweep.py
@@ -1,0 +1,159 @@
+"""Run-sweep API: execute a config's ``sweeps:`` as a background batch job.
+
+A sweep is a heavy, host-specific batch (build + solve every scenario, write the
+scenario store), so it is run out-of-process by invoking a ``run_sweep.py`` script
+located next to the config. Progress is parsed from the subprocess stdout
+(``scenario N/M``); the frontend polls :func:`sweep_status` and refreshes the
+Scenario Pane on completion.
+
+Endpoints (prefix ``/api/sweep``):
+  GET  ""        -> availability / scenario count / can_run / running
+  POST "/run"    -> start the sweep subprocess (409 if one is already running)
+  GET  "/status" -> current job status (idle | running | done | error)
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+import threading
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from fastapi import APIRouter, HTTPException, Request
+
+router = APIRouter()
+
+_SCENARIO_RE = re.compile(r"scenario\s+(\d+)\s*/\s*(\d+)", re.IGNORECASE)
+_RUNNER_NAME = "run_sweep.py"
+
+
+def _count_scenarios(sweeps: Dict[str, Any]) -> int:
+    """Cartesian-product size of the sweep axes (generic; no host import)."""
+    if not isinstance(sweeps, dict) or not sweeps:
+        return 0
+    total = 1
+    for axis in sweeps.values():
+        if not isinstance(axis, dict):
+            continue
+        if axis.get("values") is not None:
+            n = len(axis["values"])
+        elif axis.get("num") is not None:
+            n = int(axis["num"])
+        elif axis.get("npoints") is not None:
+            n = int(axis["npoints"])
+        else:
+            n = 0
+        total *= max(n, 0)
+    return total
+
+
+def _sweeps(request: Request) -> Dict[str, Any]:
+    raw = getattr(request.app.state, "preloaded_raw", None) or {}
+    return raw.get("sweeps") or {}
+
+
+def _runner_path(request: Request) -> Optional[Path]:
+    cfg_path = getattr(request.app.state, "preloaded_config_path", None)
+    if not cfg_path:
+        return None
+    runner = Path(cfg_path).resolve().parent / _RUNNER_NAME
+    return runner if runner.is_file() else None
+
+
+@router.get("")
+async def sweep_info(request: Request) -> Dict[str, Any]:
+    """Report whether a sweep can be run for the preloaded config."""
+    sweeps = _sweeps(request)
+    n = _count_scenarios(sweeps)
+    runner = _runner_path(request)
+    job = getattr(request.app.state, "sweep_job", None)
+    running = bool(job and job.get("status") == "running")
+
+    if not sweeps:
+        reason = "No sweep in this config"
+    elif runner is None:
+        reason = f"No {_RUNNER_NAME} next to the config"
+    else:
+        reason = f"Run {n} sweep scenarios"
+
+    return {
+        "available": bool(sweeps),
+        "n_scenarios": n,
+        "can_run": bool(sweeps) and runner is not None,
+        "reason": reason,
+        "running": running,
+    }
+
+
+@router.post("/run")
+async def sweep_run(request: Request) -> Dict[str, Any]:
+    """Start the sweep subprocess for the preloaded config."""
+    sweeps = _sweeps(request)
+    runner = _runner_path(request)
+    if not sweeps or runner is None:
+        raise HTTPException(status_code=400, detail="No runnable sweep for this config")
+
+    job = getattr(request.app.state, "sweep_job", None)
+    if job and job.get("status") == "running":
+        raise HTTPException(status_code=409, detail="A sweep is already running")
+
+    cfg_path = Path(str(getattr(request.app.state, "preloaded_config_path")))
+    total = _count_scenarios(sweeps)
+    state: Dict[str, Any] = {
+        "status": "running",
+        "current": 0,
+        "total": total,
+        "message": "starting…",
+        "returncode": None,
+    }
+    request.app.state.sweep_job = state
+
+    def _worker() -> None:
+        try:
+            proc = subprocess.Popen(
+                [sys.executable, runner.name, cfg_path.name, "--no-plot"],
+                cwd=str(cfg_path.parent),
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+                bufsize=1,
+                env=os.environ.copy(),
+            )
+            tail: list[str] = []
+            assert proc.stdout is not None
+            for raw_line in proc.stdout:
+                line = raw_line.rstrip()
+                match = _SCENARIO_RE.search(line)
+                if match:
+                    state["current"] = int(match.group(1))
+                    state["total"] = int(match.group(2))
+                    state["message"] = line.strip()
+                if line:
+                    tail.append(line)
+                    del tail[:-30]
+            proc.wait()
+            state["returncode"] = proc.returncode
+            if proc.returncode == 0:
+                state["status"] = "done"
+                state["message"] = "Sweep complete"
+            else:
+                state["status"] = "error"
+                state["message"] = "\n".join(tail[-8:]) or f"exited {proc.returncode}"
+        except Exception as exc:  # noqa: BLE001
+            state["status"] = "error"
+            state["message"] = str(exc)
+
+    threading.Thread(target=_worker, daemon=True).start()
+    return {"status": "running", "total": total}
+
+
+@router.get("/status")
+async def sweep_status(request: Request) -> Dict[str, Any]:
+    """Return the current sweep job status (for polling)."""
+    job = getattr(request.app.state, "sweep_job", None)
+    if not job:
+        return {"status": "idle"}
+    return dict(job)

--- a/boulder/api/routes/sweep.py
+++ b/boulder/api/routes/sweep.py
@@ -55,8 +55,10 @@ def _sweep_block(d: Dict[str, Any]) -> Dict[str, Any]:
 
 
 def _run_set_size(raw: Dict[str, Any]) -> int:
-    """Union run-set size (generic; mirrors expand_scenarios without importing it):
-    global sweep points ⊎ each `scenario:` entry (its inner sweep, else 1)."""
+    """Return the union run-set size (mirrors expand_scenarios without importing it).
+
+    Global sweep points ⊎ each `scenario:` entry (its inner sweep, else 1).
+    """
     scenario = raw.get("scenario") or {}
     total = _sweep_points(_sweep_block(raw))  # global sweep points (0 if none)
     for overlay in scenario.values():
@@ -75,14 +77,18 @@ def _raw(request: Request) -> Dict[str, Any]:
 
 
 def _store_path(request: Request) -> Optional[Path]:
-    """The collection store the run-set writes — declared
-    (``metadata.extra.scenario_store``) or the ``<stem>_scenarios.h5`` default
-    (must match the runner's default)."""
+    """Return the collection store the run-set writes to.
+
+    Declared via ``metadata.extra.scenario_store`` or the ``<stem>_scenarios.h5``
+    default (must match the runner's default).
+    """
     cfg_path = getattr(request.app.state, "preloaded_config_path", None)
     if not cfg_path:
         return None
     cfg = Path(cfg_path).resolve()
-    rel = ((_raw(request).get("metadata") or {}).get("extra") or {}).get("scenario_store")
+    rel = ((_raw(request).get("metadata") or {}).get("extra") or {}).get(
+        "scenario_store"
+    )
     if rel:
         p = Path(rel)
         return p if p.is_absolute() else cfg.parent / p
@@ -90,15 +96,21 @@ def _store_path(request: Request) -> Optional[Path]:
 
 
 def _runner_command(request: Request) -> Optional[Dict[str, Any]]:
-    """Resolve how to run the run-set: a ``run_sweep.py`` next to the config, or
-    a host-registered ``sweep_runner`` command. Returns ``{argv, cwd}`` or None."""
+    """Resolve how to run the run-set.
+
+    A ``run_sweep.py`` next to the config, or a host-registered ``sweep_runner``
+    command. Returns ``{argv, cwd}`` or None.
+    """
     cfg_path = getattr(request.app.state, "preloaded_config_path", None)
     if not cfg_path:
         return None
     cfg = Path(cfg_path).resolve()
     local = cfg.parent / _RUNNER_NAME
     if local.is_file():
-        return {"argv": [sys.executable, _RUNNER_NAME, cfg.name, "--no-plot"], "cwd": str(cfg.parent)}
+        return {
+            "argv": [sys.executable, _RUNNER_NAME, cfg.name, "--no-plot"],
+            "cwd": str(cfg.parent),
+        }
     from ...cantera_converter import get_plugins  # noqa: PLC0415
 
     runner = getattr(get_plugins(), "sweep_runner", None)
@@ -142,7 +154,9 @@ async def sweep_run(request: Request) -> Dict[str, Any]:
     """Start the run-set subprocess for the preloaded config."""
     cmd = _runner_command(request)
     if not _has_run_set(request) or cmd is None:
-        raise HTTPException(status_code=400, detail="No runnable run-set for this config")
+        raise HTTPException(
+            status_code=400, detail="No runnable run-set for this config"
+        )
 
     job = getattr(request.app.state, "sweep_job", None)
     if job and job.get("status") == "running":

--- a/boulder/api/routes/sweep.py
+++ b/boulder/api/routes/sweep.py
@@ -132,6 +132,8 @@ async def sweep_info(request: Request) -> Dict[str, Any]:
         "can_run": has and cmd is not None,
         "reason": reason,
         "running": running,
+        # ``bloc --sweep`` GUI mode → frontend defaults the split button to Run Sweep.
+        "default": bool(getattr(request.app.state, "sweep_default", False)),
     }
 
 

--- a/boulder/cantera_converter.py
+++ b/boulder/cantera_converter.py
@@ -1093,6 +1093,99 @@ class DualCanteraConverter:
         self.reactors[rid] = reactor
         return reactor, gas
 
+    @staticmethod
+    def _transient_save_times(config: Optional[Dict[str, Any]]) -> List[float]:
+        """Save-time grid for a transient trajectory, read from ``settings.solver``.
+
+        Accepts ``solver.grid`` as an explicit list (e.g. a logspace residence
+        grid) or a ``{start, stop, dt}`` dict, falling back to top-level
+        ``settings.end_time``/``dt``. Returns ``[]`` when no grid is declared.
+        """
+        import numpy as np
+
+        settings = (config or {}).get("settings") or {}
+        solver = settings.get("solver") or {}
+        grid = solver.get("grid")
+        if isinstance(grid, (list, tuple)) and len(grid) > 0:
+            return [float(t) for t in grid]
+        if isinstance(grid, dict) and "stop" in grid and "dt" in grid:
+            start, stop, dt = (
+                float(grid.get("start", 0.0)),
+                float(grid["stop"]),
+                float(grid["dt"]),
+            )
+            if dt > 0 and stop > start:
+                return [float(t) for t in np.arange(start + dt, stop + dt / 2, dt)]
+        end, dt = settings.get("end_time"), settings.get("dt")
+        if end and dt and float(end) > 0 and float(dt) > 0:
+            return [float(t) for t in np.arange(float(dt), float(end) + float(dt) / 2, float(dt))]
+        return []
+
+    def _capture_transient_trajectory(
+        self, config: Optional[Dict[str, Any]]
+    ) -> Optional[Dict[str, Any]]:
+        """Capture one transient reactor's full ``T(t)`` over the save-time grid.
+
+        For a config with exactly one non-reservoir reactor and a transient grid,
+        build a *fresh isolated* reactor on a throwaway converter and advance it
+        with native :meth:`cantera.ReactorNet.advance` over the grid, snapshotting
+        each state into a ``SolutionArray``. This is pure data capture — it does
+        not touch the staged solve, the live network, or the result state, and
+        produces identical physics — so a live "Run Simulation" shows the real
+        trajectory instead of only the converged endpoint. Returns
+        ``{reactor_id: series}`` or ``None`` when not applicable (any failure
+        falls back to the single-point snapshot).
+        """
+        try:
+            reactors = self._unique_non_reservoir_reactors()
+            if len(reactors) != 1:
+                return None
+            rid = getattr(reactors[0], "name", "") or ""
+            times = self._transient_save_times(config)
+            if not times:
+                return None
+            node = next(
+                (n for n in (config.get("nodes") or []) if n.get("id") == rid), None
+            )
+            if node is None:
+                return None
+
+            props = node.get("properties") or {}
+            sub = DualCanteraConverter(mechanism=self.mechanism, plugins=self.plugins)
+            reactor, gas = sub.build_isolated_reactor(node)
+            net = ct.ReactorNet([reactor])
+            if props.get("use_preconditioner"):
+                try:
+                    net.preconditioner = ct.AdaptivePreconditioner()
+                except Exception:  # noqa: BLE001 — preconditioner is an optimisation
+                    pass
+
+            # Read the reactor's own phase after each advance — create_reactor_*
+            # does not necessarily reuse the `gas` handle, so `gas` would stay at
+            # the initial state.
+            phase = reactor.thermo
+            states = ct.SolutionArray(phase, extra=["t"])
+            states.append(phase.state, t=0.0)
+            for t in times:
+                net.advance(float(t))
+                states.append(reactor.thermo.state, t=float(t))
+
+            names = list(phase.species_names)
+            mole, mass = states.X, states.Y
+            return {
+                rid: {
+                    "T": [float(v) for v in states.T],
+                    "P": [float(v) for v in states.P],
+                    "X": {sp: [float(v) for v in mole[:, i]] for i, sp in enumerate(names)},
+                    "Y": {sp: [float(v) for v in mass[:, i]] for i, sp in enumerate(names)},
+                    "t": [float(v) for v in states.t],
+                    "is_residence": True,
+                }
+            }
+        except Exception as exc:  # noqa: BLE001 — never break Run Simulation
+            logger.warning("Transient trajectory capture skipped: %s", exc)
+            return None
+
     # ------------------------------------------------------------------
     # Staged solving
     # ------------------------------------------------------------------
@@ -1841,6 +1934,19 @@ class DualCanteraConverter:
                 # propagate the flag so the frontend can adapt its visualisation.
                 elif self.reactor_meta.get(reactor_id, {}).get("is_psr"):
                     reactors_series[reactor_id]["is_psr"] = True
+
+            # Transient single-reactor configs: replace the converged single-point
+            # snapshot with the captured T(t) trajectory (native advance, no solver
+            # change). Reports/Sankey/code from finalize are kept; only the series
+            # is swapped. Spatial profiles (set above) are left untouched.
+            _traj = self._capture_transient_trajectory(getattr(self, "_last_config", None))
+            if _traj:
+                for _rid, _series in _traj.items():
+                    if _rid in reactors_series and not reactors_series[_rid].get(
+                        "is_spatial"
+                    ):
+                        reactors_series[_rid] = _series
+                        times[:] = _series["t"]
 
             if progress_callback:
                 progress_callback(

--- a/boulder/cantera_converter.py
+++ b/boulder/cantera_converter.py
@@ -20,7 +20,12 @@ from typing import (
 import cantera as ct  # type: ignore
 import numpy as np
 
-from .config import CANTERA_MECHANISM, TRANSIENT_SOLVER_KINDS
+from .reactor_energy import (
+    build_reactor_with_energy,
+    energy_ctor_suffix,
+    validate_energy_on_built_reactor,
+    validate_explicit_energy,
+)
 from .output_summary import evaluate_output_items, parse_output_block
 from .sankey import generate_sankey_input_from_sim, sankey_links_for_api
 from .spatial_inference import try_infer_spatial_reactor_series
@@ -757,30 +762,50 @@ class DualCanteraConverter:
         if typ in self.plugins.reactor_builders:
             reactor = self.plugins.reactor_builders[typ](self, node)
             reactor.name = rid
+            validate_energy_on_built_reactor(reactor, props, typ)
         elif typ == "IdealGasReactor":
-            reactor = ct.IdealGasReactor(gas_for_node, clone=clone)
+            reactor = build_reactor_with_energy(
+                ct.IdealGasReactor, gas_for_node, props=props, clone=clone, type_name=typ
+            )
             reactor.name = rid
         elif typ == "ConstPressureReactor":
-            _energy_val = props.get("energy", "on")
-            # Accept bool False / string "off" / string "false" (case-insensitive) as off.
-            if isinstance(_energy_val, bool):
-                energy: Literal["on", "off"] = "off" if not _energy_val else "on"
-            else:
-                energy = (
-                    "off" if str(_energy_val).lower() in ("off", "false", "0") else "on"
-                )
-            reactor = ct.ConstPressureReactor(gas_for_node, energy=energy, clone=clone)
+            reactor = build_reactor_with_energy(
+                ct.ConstPressureReactor,
+                gas_for_node,
+                props=props,
+                clone=clone,
+                type_name=typ,
+            )
             reactor.name = rid
         elif typ == "IdealGasConstPressureReactor":
-            reactor = ct.IdealGasConstPressureReactor(gas_for_node, clone=clone)
+            reactor = build_reactor_with_energy(
+                ct.IdealGasConstPressureReactor,
+                gas_for_node,
+                props=props,
+                clone=clone,
+                type_name=typ,
+            )
             reactor.name = rid
         elif typ == "IdealGasConstPressureMoleReactor":
-            reactor = ct.IdealGasConstPressureMoleReactor(gas_for_node, clone=clone)
+            reactor = build_reactor_with_energy(
+                ct.IdealGasConstPressureMoleReactor,
+                gas_for_node,
+                props=props,
+                clone=clone,
+                type_name=typ,
+            )
             reactor.name = rid
         elif typ == "IdealGasMoleReactor":
-            reactor = ct.IdealGasMoleReactor(gas_for_node, clone=clone)  # type: ignore[attr-defined]
+            reactor = build_reactor_with_energy(
+                ct.IdealGasMoleReactor,  # type: ignore[arg-type]
+                gas_for_node,
+                props=props,
+                clone=clone,
+                type_name=typ,
+            )
             reactor.name = rid
         elif typ == "Reservoir":
+            validate_explicit_energy(props, ct.Reservoir, typ)
             reactor = ct.Reservoir(gas_for_node, clone=clone)  # type: ignore[assignment]
             reactor.name = rid
         elif typ == "OutletSink":
@@ -788,6 +813,7 @@ class DualCanteraConverter:
             # Prefer inter-stage stream-point diamonds (``{source}_outlet`` Reservoirs
             # populated by :func:`boulder.staged_solver._update_stream_point`).
             # Remove this branch when OutletSink is dropped from STONE v2.
+            validate_explicit_energy(props, ct.Reservoir, typ)
             reactor = ct.Reservoir(gas_for_node, clone=clone)  # type: ignore[assignment]
             reactor.name = rid
         else:
@@ -996,6 +1022,75 @@ class DualCanteraConverter:
                 hook(self, config)
             except Exception as exc:
                 logger.warning("Post-build hook failed: %s", exc)
+
+    def build_isolated_reactor(
+        self, node: Dict[str, Any]
+    ) -> Tuple["ct.Reactor", "ct.Solution"]:
+        """Build a single reactor from one node, with no surrounding network.
+
+        Resolves the node's mechanism, sets the gas state from its initial
+        properties (``temperature`` / ``pressure`` / ``composition`` /
+        ``mass_composition``, either top-level or under ``initial:``), and
+        delegates to :meth:`create_reactor_from_node` so that ``energy``,
+        ``clone``, ``volume`` and any other recognised properties are honoured
+        exactly as in a full network build.  This is the single source of truth
+        for reactor construction for callers (e.g. parametric τ-sweeps) that
+        drive their own :class:`~cantera.ReactorNet` instead of the staged
+        solver.
+
+        Property values may be unit strings (``"1273.15 K"``, ``"1 bar"``) or
+        plain numbers; temperature/pressure are coerced to SI.
+
+        Parameters
+        ----------
+        node :
+            A node dict with ``id``, ``type``, and ``properties`` (the
+            normalised form; STONE ``Kind: {...}`` blocks must be converted to
+            ``type`` / ``properties`` by the caller first).
+
+        Returns
+        -------
+        (reactor, gas)
+            The constructed reactor and the :class:`~cantera.Solution` carrying
+            its initial state.
+        """
+        from .utils import coerce_unit_string  # noqa: PLC0415
+
+        rid = node.get("id", "reactor")
+        props = node.get("properties") or {}
+        node_mech = str(
+            props.get("mechanism") or node.get("mechanism") or self.mechanism
+        )
+        gas = self._get_gas_for_mech(node_mech)
+
+        initial = props.get("initial") or {}
+        temp = initial.get("temperature", props.get("temperature"))
+        pres = initial.get("pressure", props.get("pressure"))
+        compo = initial.get("composition", props.get("composition"))
+        mass_compo = initial.get("mass_composition", props.get("mass_composition"))
+
+        t_use = (
+            float(coerce_unit_string(temp, "temperature"))
+            if temp is not None
+            else float(gas.T)
+        )
+        p_use = (
+            float(coerce_unit_string(pres, "pressure"))
+            if pres is not None
+            else float(gas.P)
+        )
+        if compo is not None:
+            gas.TPX = (t_use, p_use, self.parse_composition(compo))
+        elif mass_compo is not None:
+            gas.TPY = (t_use, p_use, self.parse_composition(mass_compo))
+        else:
+            gas.TPX = (t_use, p_use, gas.X)
+
+        self.gas = gas
+        self.reactor_meta[rid] = {"mechanism": node_mech, "gas_solution": gas}
+        reactor = self.create_reactor_from_node(node, gas)
+        self.reactors[rid] = reactor
+        return reactor, gas
 
     # ------------------------------------------------------------------
     # Staged solving

--- a/boulder/cantera_converter.py
+++ b/boulder/cantera_converter.py
@@ -8,7 +8,6 @@ from typing import (
     Callable,
     Dict,
     List,
-    Literal,
     Mapping,
     Optional,
     Sequence,
@@ -21,13 +20,12 @@ import cantera as ct  # type: ignore
 import numpy as np
 
 from .config import CANTERA_MECHANISM, TRANSIENT_SOLVER_KINDS
+from .output_summary import evaluate_output_items, parse_output_block
 from .reactor_energy import (
     build_reactor_with_energy,
-    energy_ctor_suffix,
     validate_energy_on_built_reactor,
     validate_explicit_energy,
 )
-from .output_summary import evaluate_output_items, parse_output_block
 from .sankey import generate_sankey_input_from_sim, sankey_links_for_api
 from .spatial_inference import try_infer_spatial_reactor_series
 from .staged_solver import _order_stage_nodes_for_flow
@@ -453,14 +451,14 @@ def get_plugins() -> BoulderPlugins:
 
 
 class _TrajectoryRecorder:
-    """Full-state recorder for a transient solve, driven by the existing
-    ``_scope_recorder.record(t)`` hook in :meth:`_run_transient_solver`.
+    """Capture full reactor state at each transient grid step.
 
-    The staged ``advance_grid`` solve already steps each reactor through every
-    grid time; this captures the per-reactor state at each step so the GUI can
-    show the real ``T(t)`` trajectory. The network is therefore solved **once** —
-    no re-integration. It does not modify the solve (the ``record`` calls already
-    exist) and produces no side effects on reactor state.
+    Driven by the existing ``_scope_recorder.record(t)`` hook in
+    :meth:`_run_transient_solver`. The staged ``advance_grid`` solve already steps
+    each reactor through every grid time; this captures the per-reactor state at
+    each step so the GUI can show the real ``T(t)`` trajectory. The network is
+    therefore solved **once** — no re-integration. It does not modify the solve
+    (the ``record`` calls already exist) and produces no side effects.
     """
 
     def __init__(self, converter: "DualCanteraConverter") -> None:
@@ -477,7 +475,13 @@ class _TrajectoryRecorder:
             phase = reactor.thermo
             d = self._data.setdefault(
                 rid,
-                {"t": [], "T": [], "P": [], "X": [], "names": list(phase.species_names)},
+                {
+                    "t": [],
+                    "T": [],
+                    "P": [],
+                    "X": [],
+                    "names": list(phase.species_names),
+                },
             )
             d["t"].append(float(t))
             d["T"].append(float(phase.T))
@@ -835,7 +839,11 @@ class DualCanteraConverter:
             validate_energy_on_built_reactor(reactor, props, typ)
         elif typ == "IdealGasReactor":
             reactor = build_reactor_with_energy(
-                ct.IdealGasReactor, gas_for_node, props=props, clone=clone, type_name=typ
+                ct.IdealGasReactor,
+                gas_for_node,
+                props=props,
+                clone=clone,
+                type_name=typ,
             )
             reactor.name = rid
         elif typ == "ConstPressureReactor":

--- a/boulder/cantera_converter.py
+++ b/boulder/cantera_converter.py
@@ -438,6 +438,61 @@ def get_plugins() -> BoulderPlugins:
     return plugins
 
 
+class _TrajectoryRecorder:
+    """Full-state recorder for a transient solve, driven by the existing
+    ``_scope_recorder.record(t)`` hook in :meth:`_run_transient_solver`.
+
+    The staged ``advance_grid`` solve already steps each reactor through every
+    grid time; this captures the per-reactor state at each step so the GUI can
+    show the real ``T(t)`` trajectory. The network is therefore solved **once** —
+    no re-integration. It does not modify the solve (the ``record`` calls already
+    exist) and produces no side effects on reactor state.
+    """
+
+    def __init__(self, converter: "DualCanteraConverter") -> None:
+        self._converter = converter
+        self._data: Dict[str, Dict[str, Any]] = {}
+
+    def record(self, t: float) -> None:
+        try:
+            reactors = self._converter._unique_non_reservoir_reactors()
+        except Exception:  # noqa: BLE001 — recording must never break the solve
+            return
+        for reactor in reactors:
+            rid = getattr(reactor, "name", "") or str(id(reactor))
+            phase = reactor.thermo
+            d = self._data.setdefault(
+                rid,
+                {"t": [], "T": [], "P": [], "X": [], "names": list(phase.species_names)},
+            )
+            d["t"].append(float(t))
+            d["T"].append(float(phase.T))
+            d["P"].append(float(phase.P))
+            d["X"].append(phase.X.copy())
+
+    def series(self) -> Dict[str, Dict[str, Any]]:
+        """Return ``{reactor_id: series}`` for reactors with a real trajectory."""
+        import numpy as np
+
+        out: Dict[str, Dict[str, Any]] = {}
+        for rid, d in self._data.items():
+            if len(d["t"]) < 2:
+                continue
+            names = d["names"]
+            xmat = np.asarray(d["X"], dtype=float)
+            out[rid] = {
+                "T": [float(v) for v in d["T"]],
+                "P": [float(v) for v in d["P"]],
+                "X": {
+                    sp: [float(xmat[i, j]) for i in range(xmat.shape[0])]
+                    for j, sp in enumerate(names)
+                },
+                "t": [float(v) for v in d["t"]],
+                "is_residence": True,
+            }
+        return out
+
+
 # class CanteraConverter:
 #    """Former Cantera converter lived there, now fully replaced by DualCanteraConverter
 #    which generates code in parallel to solving the simulation
@@ -1093,99 +1148,6 @@ class DualCanteraConverter:
         self.reactors[rid] = reactor
         return reactor, gas
 
-    @staticmethod
-    def _transient_save_times(config: Optional[Dict[str, Any]]) -> List[float]:
-        """Save-time grid for a transient trajectory, read from ``settings.solver``.
-
-        Accepts ``solver.grid`` as an explicit list (e.g. a logspace residence
-        grid) or a ``{start, stop, dt}`` dict, falling back to top-level
-        ``settings.end_time``/``dt``. Returns ``[]`` when no grid is declared.
-        """
-        import numpy as np
-
-        settings = (config or {}).get("settings") or {}
-        solver = settings.get("solver") or {}
-        grid = solver.get("grid")
-        if isinstance(grid, (list, tuple)) and len(grid) > 0:
-            return [float(t) for t in grid]
-        if isinstance(grid, dict) and "stop" in grid and "dt" in grid:
-            start, stop, dt = (
-                float(grid.get("start", 0.0)),
-                float(grid["stop"]),
-                float(grid["dt"]),
-            )
-            if dt > 0 and stop > start:
-                return [float(t) for t in np.arange(start + dt, stop + dt / 2, dt)]
-        end, dt = settings.get("end_time"), settings.get("dt")
-        if end and dt and float(end) > 0 and float(dt) > 0:
-            return [float(t) for t in np.arange(float(dt), float(end) + float(dt) / 2, float(dt))]
-        return []
-
-    def _capture_transient_trajectory(
-        self, config: Optional[Dict[str, Any]]
-    ) -> Optional[Dict[str, Any]]:
-        """Capture one transient reactor's full ``T(t)`` over the save-time grid.
-
-        For a config with exactly one non-reservoir reactor and a transient grid,
-        build a *fresh isolated* reactor on a throwaway converter and advance it
-        with native :meth:`cantera.ReactorNet.advance` over the grid, snapshotting
-        each state into a ``SolutionArray``. This is pure data capture — it does
-        not touch the staged solve, the live network, or the result state, and
-        produces identical physics — so a live "Run Simulation" shows the real
-        trajectory instead of only the converged endpoint. Returns
-        ``{reactor_id: series}`` or ``None`` when not applicable (any failure
-        falls back to the single-point snapshot).
-        """
-        try:
-            reactors = self._unique_non_reservoir_reactors()
-            if len(reactors) != 1:
-                return None
-            rid = getattr(reactors[0], "name", "") or ""
-            times = self._transient_save_times(config)
-            if not times:
-                return None
-            node = next(
-                (n for n in (config.get("nodes") or []) if n.get("id") == rid), None
-            )
-            if node is None:
-                return None
-
-            props = node.get("properties") or {}
-            sub = DualCanteraConverter(mechanism=self.mechanism, plugins=self.plugins)
-            reactor, gas = sub.build_isolated_reactor(node)
-            net = ct.ReactorNet([reactor])
-            if props.get("use_preconditioner"):
-                try:
-                    net.preconditioner = ct.AdaptivePreconditioner()
-                except Exception:  # noqa: BLE001 — preconditioner is an optimisation
-                    pass
-
-            # Read the reactor's own phase after each advance — create_reactor_*
-            # does not necessarily reuse the `gas` handle, so `gas` would stay at
-            # the initial state.
-            phase = reactor.thermo
-            states = ct.SolutionArray(phase, extra=["t"])
-            states.append(phase.state, t=0.0)
-            for t in times:
-                net.advance(float(t))
-                states.append(reactor.thermo.state, t=float(t))
-
-            names = list(phase.species_names)
-            mole, mass = states.X, states.Y
-            return {
-                rid: {
-                    "T": [float(v) for v in states.T],
-                    "P": [float(v) for v in states.P],
-                    "X": {sp: [float(v) for v in mole[:, i]] for i, sp in enumerate(names)},
-                    "Y": {sp: [float(v) for v in mass[:, i]] for i, sp in enumerate(names)},
-                    "t": [float(v) for v in states.t],
-                    "is_residence": True,
-                }
-            }
-        except Exception as exc:  # noqa: BLE001 — never break Run Simulation
-            logger.warning("Transient trajectory capture skipped: %s", exc)
-            return None
-
     # ------------------------------------------------------------------
     # Staged solving
     # ------------------------------------------------------------------
@@ -1700,6 +1662,32 @@ class DualCanteraConverter:
 
         from .staged_solver import build_stage_graph, solve_staged
 
+        # Transient solve with no declared checkpoints: inject a default linspace
+        # grid so the recorder still yields a trajectory ("do whatever" when no
+        # required grid is given). Required checkpoints, when present, are left
+        # untouched and advanced through exactly. Config-prep only — not a solver
+        # change.
+        _settings = config.get("settings") or {}
+        _default_end = float(_settings.get("end_time") or 1.0)
+        for _group in (config.get("groups") or {}).values():
+            _solver = _group.get("solver") or {}
+            if _solver.get("kind") == "advance_grid" and not _solver.get("grid"):
+                _solver["grid"] = {
+                    "start": 0.0,
+                    "stop": _default_end,
+                    "dt": _default_end / 50.0,
+                }
+                _group["solver"] = _solver
+
+        # Install a full-state trajectory recorder so a transient (advance_grid)
+        # solve also yields the per-step T(t) — captured during the *single*
+        # staged solve via the existing record() hook, never a re-integration.
+        # Skip if a real scopes recorder is already installed (don't clobber it).
+        self._trajectory_recorder = None
+        if getattr(self, "_scope_recorder", None) is None:
+            self._scope_recorder = _TrajectoryRecorder(self)
+            self._trajectory_recorder = self._scope_recorder
+
         plan = build_stage_graph(config)
         trajectory = solve_staged(
             self,
@@ -1935,18 +1923,18 @@ class DualCanteraConverter:
                 elif self.reactor_meta.get(reactor_id, {}).get("is_psr"):
                     reactors_series[reactor_id]["is_psr"] = True
 
-            # Transient single-reactor configs: replace the converged single-point
-            # snapshot with the captured T(t) trajectory (native advance, no solver
-            # change). Reports/Sankey/code from finalize are kept; only the series
-            # is swapped. Spatial profiles (set above) are left untouched.
-            _traj = self._capture_transient_trajectory(getattr(self, "_last_config", None))
-            if _traj:
-                for _rid, _series in _traj.items():
-                    if _rid in reactors_series and not reactors_series[_rid].get(
-                        "is_spatial"
-                    ):
-                        reactors_series[_rid] = _series
-                        times[:] = _series["t"]
+            # Transient solve: replace the converged single-point snapshot with the
+            # T(t) trajectory captured *during* the (single) staged solve by the
+            # recorder. No re-integration; reports/Sankey/code from finalize are
+            # kept; only the series is swapped. Spatial profiles are left untouched.
+            _recorder = getattr(self, "_trajectory_recorder", None)
+            _traj = _recorder.series() if _recorder is not None else {}
+            for _rid, _series in _traj.items():
+                if _rid in reactors_series and not reactors_series[_rid].get(
+                    "is_spatial"
+                ):
+                    reactors_series[_rid] = _series
+                    times[:] = _series["t"]
 
             if progress_callback:
                 progress_callback(

--- a/boulder/cantera_converter.py
+++ b/boulder/cantera_converter.py
@@ -83,6 +83,11 @@ class BoulderPlugins:
     config_transforms: List[Callable[[Dict[str, Any]], Dict[str, Any]]] = field(
         default_factory=list
     )
+    #: Extra ``python`` args that run a host's scenario/sweep runner for the Run
+    #: Sweep button, invoked as ``[python, *sweep_runner, <config>, "--no-plot"]``.
+    #: e.g. ``["-m", "bloc.scenario_sweep"]``. Used when no ``run_sweep.py`` sits
+    #: next to the config. Registered by an external plugin package.
+    sweep_runner: Optional[List[str]] = None
 
     #: Per-source provenance for introspection (``boulder plugins list``).
     #: ``{"entry_point": [(ep_name, module)], "env_var": [module_name]}``.

--- a/boulder/cantera_converter.py
+++ b/boulder/cantera_converter.py
@@ -74,6 +74,15 @@ class BoulderPlugins:
     #: Called when an inter-stage connection carries a ``mechanism_switch`` block.
     #: Registered by an external plugin package via its plugin entry point.
     mechanism_switch_fn: Optional[Callable] = None
+    #: ``(config: dict) -> dict`` transforms applied to the raw STONE config at the
+    #: start of :func:`normalize_config`, before dialect detection. Lets a host
+    #: derive recognised STONE fields from its own ``export``/``metadata`` blocks
+    #: (e.g. a transient ``settings.solver`` grid from a residence-time spec)
+    #: without editing the YAML. Each returns the (possibly new) config; a raising
+    #: transform is skipped. Registered by an external plugin package.
+    config_transforms: List[Callable[[Dict[str, Any]], Dict[str, Any]]] = field(
+        default_factory=list
+    )
 
     #: Per-source provenance for introspection (``boulder plugins list``).
     #: ``{"entry_point": [(ep_name, module)], "env_var": [module_name]}``.

--- a/boulder/cantera_converter.py
+++ b/boulder/cantera_converter.py
@@ -20,6 +20,7 @@ from typing import (
 import cantera as ct  # type: ignore
 import numpy as np
 
+from .config import CANTERA_MECHANISM, TRANSIENT_SOLVER_KINDS
 from .reactor_energy import (
     build_reactor_with_energy,
     energy_ctor_suffix,

--- a/boulder/cantera_converter.py
+++ b/boulder/cantera_converter.py
@@ -83,8 +83,8 @@ class BoulderPlugins:
     )
     #: Extra ``python`` args that run a host's scenario/sweep runner for the Run
     #: Sweep button, invoked as ``[python, *sweep_runner, <config>, "--no-plot"]``.
-    #: e.g. ``["-m", "bloc.scenario_sweep"]``. Used when no ``run_sweep.py`` sits
-    #: next to the config. Registered by an external plugin package.
+    #: e.g. ``["-m", "<host_pkg>.scenario_sweep"]``. Used when no ``run_sweep.py``
+    #: sits next to the config. Registered by an external plugin package.
     sweep_runner: Optional[List[str]] = None
 
     #: Per-source provenance for introspection (``boulder plugins list``).
@@ -1626,7 +1626,7 @@ class DualCanteraConverter:
 
         # Resolve any MFC mass flow rates that were still pending once all
         # inter-stage devices are in place.  Until now intra-stage passes only
-        # saw a sub-topology; mixers on stage boundaries (SPRING_A3 shape) or
+        # saw a sub-topology; mixers on stage boundaries or
         # inter-stage MFCs without explicit mass_flow_rate would otherwise
         # stay at 0 kg/s and make Sankey bands collapse.
         self.apply_flow_conservation()

--- a/boulder/cli.py
+++ b/boulder/cli.py
@@ -513,10 +513,12 @@ def main(argv: list[str] | None = None, *, runner_class=None) -> None:
 
     args = parse_args(argv)
 
-    # --sweep: headless run-set runner. Boulder has no run-set concept, so it
-    # delegates to a host-registered runner command (BoulderPlugins.sweep_runner,
-    # e.g. ["-m", "bloc.scenario_sweep"]) — keeping Boulder host-agnostic.
-    if args.sweep:
+    # --sweep is "Run Sweep mode":
+    #   * with --headless → run the whole run-set now, no GUI (delegates to the
+    #     host-registered BoulderPlugins.sweep_runner; Boulder stays host-agnostic).
+    #   * without --headless → launch the GUI with Run Sweep as the default action
+    #     and the (pre-computed) scenario store shown in the pane (BOULDER_SWEEP_MODE).
+    if args.sweep and args.headless:
         if not args.config:
             print("Error: --sweep requires a config file", file=sys.stderr)
             sys.exit(2)
@@ -535,6 +537,9 @@ def main(argv: list[str] | None = None, *, runner_class=None) -> None:
 
         cmd = [sys.executable, *runner, str(_Path(args.config).resolve())]
         sys.exit(subprocess.call(cmd))
+    if args.sweep:
+        # GUI sweep mode — read by the lifespan / frontend.
+        os.environ["BOULDER_SWEEP_MODE"] = "1"
 
     # --runner flag overrides the kwarg (shell users)
     if args.runner:

--- a/boulder/cli.py
+++ b/boulder/cli.py
@@ -151,6 +151,15 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Run without starting the web UI",
     )
     parser.add_argument(
+        "--sweep",
+        action="store_true",
+        help=(
+            "Headless run-set runner: expand the config's scenario:/sweep: blocks, "
+            "solve every run, and serialize each into the collection store. Uses a "
+            "host-registered sweep runner (BoulderPlugins.sweep_runner). No web UI."
+        ),
+    )
+    parser.add_argument(
         "--download",
         metavar="OUTPUT_FILE",
         help="Generate Python code from YAML and save to file (requires --headless)",
@@ -503,6 +512,29 @@ def main(argv: list[str] | None = None, *, runner_class=None) -> None:
         sys.exit(rc)
 
     args = parse_args(argv)
+
+    # --sweep: headless run-set runner. Boulder has no run-set concept, so it
+    # delegates to a host-registered runner command (BoulderPlugins.sweep_runner,
+    # e.g. ["-m", "bloc.scenario_sweep"]) — keeping Boulder host-agnostic.
+    if args.sweep:
+        if not args.config:
+            print("Error: --sweep requires a config file", file=sys.stderr)
+            sys.exit(2)
+        from .cantera_converter import get_plugins
+
+        runner = getattr(get_plugins(), "sweep_runner", None)
+        if not runner:
+            print(
+                "Error: no sweep runner registered (BoulderPlugins.sweep_runner). "
+                "Install a host plugin that provides one.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        import subprocess
+        from pathlib import Path as _Path
+
+        cmd = [sys.executable, *runner, str(_Path(args.config).resolve())]
+        sys.exit(subprocess.call(cmd))
 
     # --runner flag overrides the kwarg (shell users)
     if args.runner:

--- a/boulder/config.py
+++ b/boulder/config.py
@@ -1252,6 +1252,16 @@ def normalize_config(config: Dict[str, Any], plugins: Any = None) -> Dict[str, A
 
         plugins = get_plugins()
 
+    # Host config transforms (e.g. derive a transient solver grid from an
+    # export residence-time spec) run on the raw config before dialect detection.
+    for _transform in getattr(plugins, "config_transforms", None) or []:
+        try:
+            _result = _transform(config)
+            if isinstance(_result, dict):
+                config = _result
+        except Exception as _exc:  # noqa: BLE001 — a transform must not break load
+            logger.debug("config_transform %r skipped: %s", _transform, _exc)
+
     # --- STONE v2 detection and normalization ---
     # Detect dialect first; this raises ValueError for v1 or unknown shapes.
     dialect = _detect_stone_dialect(config)

--- a/boulder/config.py
+++ b/boulder/config.py
@@ -47,7 +47,8 @@ STONE_TOP_LEVEL_KEYS: frozenset = frozenset(
         "output",
         "export",
         "sweeps",
-        "scenarios",
+        "sweep",
+        "scenario",
     }
 )
 
@@ -64,7 +65,8 @@ STONE_V2_BASE_KEYS: frozenset = frozenset(
         "output",
         "export",
         "sweeps",
-        "scenarios",
+        "sweep",
+        "scenario",
         "continuation",
         "signals",
         "bindings",
@@ -547,7 +549,8 @@ def _normalize_v2_network(raw: Dict[str, Any]) -> Dict[str, Any]:
         "output",
         "export",
         "sweeps",
-        "scenarios",
+        "sweep",
+        "scenario",
         "continuation",
         "signals",
         "bindings",
@@ -848,7 +851,8 @@ def _normalize_v2_staged(raw: Dict[str, Any]) -> Dict[str, Any]:
         "output",
         "export",
         "sweeps",
-        "scenarios",
+        "sweep",
+        "scenario",
         "continuation",
         "signals",
         "bindings",
@@ -1955,7 +1959,7 @@ def convert_to_stone_format(config: dict) -> dict:
     if "settings" in config:
         stone_config["settings"] = config["settings"]
 
-    for passthrough in ("output", "export", "sweeps", "scenarios"):
+    for passthrough in ("output", "export", "sweeps", "sweep", "scenario"):
         if passthrough in config:
             stone_config[passthrough] = config[passthrough]
 

--- a/boulder/download_script_emitter.py
+++ b/boulder/download_script_emitter.py
@@ -17,6 +17,7 @@ from pprint import pformat
 from typing import Any, Dict, List, Optional
 
 from .config import TRANSIENT_SOLVER_KINDS
+from .reactor_energy import energy_ctor_suffix
 from .staged_solver import (
     _order_stage_nodes_for_flow,
     build_stage_graph,
@@ -253,17 +254,25 @@ class CanteraScriptEmitter:
                 f"'gas_solution': gas_{var}}}"
             )
         elif ntype == "IdealGasConstPressureMoleReactor":
+            energy_kw = energy_ctor_suffix(props)
             out.append(
-                f"{var} = ct.IdealGasConstPressureMoleReactor(gas_{var}, clone=True)"
+                f"{var} = ct.IdealGasConstPressureMoleReactor("
+                f"gas_{var}, clone=True{energy_kw})"
             )
         elif ntype == "IdealGasConstPressureReactor":
+            energy_kw = energy_ctor_suffix(props)
             out.append(
-                f"{var} = ct.IdealGasConstPressureReactor(gas_{var}, clone=True)"
+                f"{var} = ct.IdealGasConstPressureReactor("
+                f"gas_{var}, clone=True{energy_kw})"
             )
         elif ntype == "IdealGasReactor":
-            out.append(f"{var} = ct.IdealGasReactor(gas_{var}, clone=True)")
+            energy_kw = energy_ctor_suffix(props)
+            out.append(f"{var} = ct.IdealGasReactor(gas_{var}, clone=True{energy_kw})")
         elif ntype == "ConstPressureReactor":
-            out.append(f"{var} = ct.ConstPressureReactor(gas_{var}, clone=True)")
+            energy_kw = energy_ctor_suffix(props)
+            out.append(
+                f"{var} = ct.ConstPressureReactor(gas_{var}, clone=True{energy_kw})"
+            )
         else:
             out.append(
                 f'raise ValueError("Unsupported reactor type {ntype!r} in native '

--- a/boulder/payload_store.py
+++ b/boulder/payload_store.py
@@ -1,0 +1,422 @@
+"""Composite HDF5 (de)serialization for GUI result payloads.
+
+This is the single, shared on-disk representation for a computed result. It is
+used by both the fingerprinted result cache (:mod:`boulder.result_cache`) and
+the scenario inspector (:mod:`boulder.api.routes.scenarios`) so there is exactly
+**one** payload format and **one** builder.
+
+Why composite — "best of both":
+
+* The heavy numeric reactor state (``T``, ``P``, per-species ``X`` over an index,
+  plus any per-state column such as ``t`` (time) or ``x`` (position)) is stored
+  as natively-to-Cantera as possible (see the tiers below) — compact, lossless,
+  no ~453-column JSON blow-up.
+* Everything a case may *also* produce — Sankey links/nodes, reactor/connection
+  reports, summary, generated code, node/connection overlays — is plain
+  JSON-serialisable and stored verbatim in a single ``payload_json`` dataset.
+  The config snapshot is **not** stored here (cache keeps it in ``meta.json``).
+
+Per-reactor tiers, chosen by :func:`_classify_series`:
+
+1. ``solution`` — a state series (``T``/``P``/``X`` over an index) whose species
+   the mechanism can represent and whose ``X`` rows are normalised, stored as a
+   Cantera :class:`~cantera.SolutionArray` group. ``Y`` is derived on load.
+   **Every per-state numeric column** (``t``, ``x``, any length-``n`` array) rides
+   along as a SolutionArray ``extra``. A PFR spatial profile is a state sequence
+   with an ``x`` column — it is stored natively here, not dumped to JSON.
+2. ``arrays`` — same shape but the mechanism can't represent it (mechanism-switch
+   reactors, or non-normalised ``X``): raw HDF5 datasets (``T``/``P`` 1D, ``X``/
+   ``Y`` 2D, one dataset per extra column). Binary, and **no Solution needed on
+   read**.
+3. ``raw`` — genuinely non-state structures: the series dict verbatim in JSON.
+
+Non-per-state fields (flags ``is_residence``/``is_psr``/``is_spatial``, and
+off-shape arrays such as ``fbs_convergence`` which is per-FBS-iteration, not
+per-state) ride in the per-reactor ``meta`` of ``reactors_index`` and are merged
+back on load, so the original series is reproduced exactly.
+
+Depends only on ``cantera`` + ``h5py`` + numpy + stdlib.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from numbers import Real
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import cantera as ct
+import h5py
+import numpy as np
+
+#: Bump when the HDF5 layout changes incompatibly (== root ``schema_version``).
+PAYLOAD_SCHEMA = 1
+
+#: Tolerance for the "X rows sum to 1" guard that gates the ``solution`` tier.
+_X_SUM_TOL = 1e-6
+
+#: Series keys handled structurally (not as generic per-state extra columns).
+_STRUCTURAL_KEYS = frozenset({"T", "P", "X", "Y"})
+
+# Cache one empty Solution per mechanism — loading a 453-species mechanism is
+# the dominant cost of a restore; pay it once per process per mechanism.
+_SOLUTION_CACHE: Dict[str, ct.Solution] = {}
+
+
+# --------------------------------------------------------------------------- #
+# Mechanism handling
+# --------------------------------------------------------------------------- #
+def _resolve_mechanism(mechanism: str) -> Tuple[str, str]:
+    """Return ``(stored_mechanism, sha256)`` for the root attrs.
+
+    A local mechanism file → its resolved absolute path + content hash. A
+    bundled/data-path name (e.g. ``gri30.yaml``) → the bare name + empty hash.
+    """
+    if not mechanism:
+        return "", ""
+    try:
+        p = Path(mechanism)
+        if p.is_file():
+            return str(p.resolve()), hashlib.sha256(p.read_bytes()).hexdigest()
+    except OSError:
+        pass
+    return mechanism, ""
+
+
+def _solution_for(mechanism: str) -> Optional[ct.Solution]:
+    if not mechanism:
+        return None
+    sol = _SOLUTION_CACHE.get(mechanism)
+    if sol is None:
+        sol = ct.Solution(mechanism)
+        _SOLUTION_CACHE[mechanism] = sol
+    return sol
+
+
+# --------------------------------------------------------------------------- #
+# Series shape analysis
+# --------------------------------------------------------------------------- #
+def _is_numeric_list(value: Any, n: int) -> bool:
+    return (
+        isinstance(value, list)
+        and len(value) == n
+        and all(isinstance(v, Real) and not isinstance(v, bool) for v in value)
+    )
+
+
+def _is_state_series(series: Any) -> bool:
+    """True when a series is state-shaped: T, P lists (equal len, >0) + X dict."""
+    if not isinstance(series, dict):
+        return False
+    T, P, X = series.get("T"), series.get("P"), series.get("X")
+    if not isinstance(T, list) or not isinstance(P, list) or not isinstance(X, dict):
+        return False
+    return len(T) > 0 and len(P) == len(T)
+
+
+def _split_series(series: Dict[str, Any]) -> Tuple[List[str], Dict[str, Any]]:
+    """Partition a state series' non-structural keys.
+
+    Returns ``(extra_keys, meta)`` where *extra_keys* are per-state numeric
+    columns of length ``n`` (e.g. ``t``, ``x``) stored natively, and *meta* is
+    everything else (flags, strings, off-shape arrays like ``fbs_convergence``)
+    carried verbatim in the JSON index.
+    """
+    n = len(series["T"])
+    extra_keys: List[str] = []
+    meta: Dict[str, Any] = {}
+    for key, value in series.items():
+        if key in _STRUCTURAL_KEYS:
+            continue
+        if _is_numeric_list(value, n):
+            extra_keys.append(key)
+        else:
+            meta[key] = value
+    return extra_keys, meta
+
+
+def _x_matrix(series: Dict[str, Any], names: List[str]) -> np.ndarray:
+    """Build an ``[n × n_species]`` X matrix aligned to *names*."""
+    n = len(series["T"])
+    Xd = series["X"]
+    Xmat = np.zeros((n, len(names)), dtype=float)
+    for j, sp in enumerate(names):
+        col = Xd.get(sp)
+        if col is not None:
+            Xmat[:, j] = np.asarray(col, dtype=float)
+    return Xmat
+
+
+def _can_represent(series: Dict[str, Any], gas: Optional[ct.Solution]) -> bool:
+    if gas is None:
+        return False
+    valid = set(gas.species_names)
+    return all(sp in valid for sp in series["X"].keys())
+
+
+def _x_rows_normalised(series: Dict[str, Any]) -> bool:
+    """True when every X row sums to 1 ± tol (R2: don't let Cantera silently
+    renormalise a non-normalised/diagnostic series)."""
+    cols = list(series["X"].values())
+    if not cols:
+        return False
+    sums = np.sum(np.asarray(cols, dtype=float), axis=0)  # sum over species per index
+    return bool(np.all(np.abs(sums - 1.0) <= _X_SUM_TOL))
+
+
+def _classify_series(series: Any, gas: Optional[ct.Solution]) -> str:
+    """Return the tier: ``solution`` | ``arrays`` | ``raw``.
+
+    A state-shaped series (incl. spatial profiles, whose ``x`` is just another
+    per-state column) is native; only genuinely non-state structures are raw.
+    """
+    if not _is_state_series(series):
+        return "raw"
+    if gas is not None and _can_represent(series, gas) and _x_rows_normalised(series):
+        return "solution"
+    return "arrays"
+
+
+# --------------------------------------------------------------------------- #
+# Numeric conversion
+# --------------------------------------------------------------------------- #
+def _series_to_solution_array(
+    gas: ct.Solution, series: Dict[str, Any], extra_keys: List[str]
+) -> ct.SolutionArray:
+    T = np.asarray(series["T"], dtype=float)
+    P = np.asarray(series["P"], dtype=float)
+    Xmat = _x_matrix(series, gas.species_names)
+    extra = {k: np.asarray(series[k], dtype=float) for k in extra_keys}
+    states = ct.SolutionArray(gas, shape=(len(T),), extra=extra or None)
+    states.TPX = T, P, Xmat
+    return states
+
+
+def _solution_array_to_series(
+    states: ct.SolutionArray, extra_keys: List[str]
+) -> Dict[str, Any]:
+    names = list(states.species_names)
+    mole = states.X
+    mass = states.Y
+    out: Dict[str, Any] = {
+        "T": [float(v) for v in states.T],
+        "P": [float(v) for v in states.P],
+        "X": {sp: [float(v) for v in mole[:, i]] for i, sp in enumerate(names)},
+        "Y": {sp: [float(v) for v in mass[:, i]] for i, sp in enumerate(names)},
+    }
+    for key in extra_keys:
+        out[key] = [float(v) for v in getattr(states, key)]
+    return out
+
+
+def _series_to_datasets(
+    group: "h5py.Group", series: Dict[str, Any], extra_keys: List[str]
+) -> None:
+    """Write a state series as binary datasets (``arrays`` tier)."""
+    names = list(series["X"].keys())
+    group.create_dataset("T", data=np.asarray(series["T"], dtype=float))
+    group.create_dataset("P", data=np.asarray(series["P"], dtype=float))
+    group.create_dataset("X", data=_x_matrix(series, names))
+    group.attrs["species_names"] = np.array(names, dtype=h5py.string_dtype())
+    Y = series.get("Y")
+    if isinstance(Y, dict) and Y:
+        ynames = list(Y.keys())
+        ymat = np.zeros((len(series["T"]), len(ynames)), dtype=float)
+        for j, sp in enumerate(ynames):
+            ymat[:, j] = np.asarray(Y[sp], dtype=float)
+        group.create_dataset("Y", data=ymat)
+        group.attrs["y_species_names"] = np.array(ynames, dtype=h5py.string_dtype())
+    for key in extra_keys:
+        group.create_dataset(f"extra__{key}", data=np.asarray(series[key], dtype=float))
+
+
+def _datasets_to_series(group: "h5py.Group", extra_keys: List[str]) -> Dict[str, Any]:
+    names = [_to_str(s) for s in group.attrs["species_names"]]
+    Xmat = group["X"][()]
+    out: Dict[str, Any] = {
+        "T": [float(v) for v in group["T"][()]],
+        "P": [float(v) for v in group["P"][()]],
+        "X": {sp: [float(v) for v in Xmat[:, i]] for i, sp in enumerate(names)},
+    }
+    if "Y" in group:
+        ynames = [_to_str(s) for s in group.attrs["y_species_names"]]
+        Ymat = group["Y"][()]
+        out["Y"] = {sp: [float(v) for v in Ymat[:, i]] for i, sp in enumerate(ynames)}
+    for key in extra_keys:
+        out[key] = [float(v) for v in group[f"extra__{key}"][()]]
+    return out
+
+
+def _to_str(value: Any) -> str:
+    if isinstance(value, bytes):
+        return value.decode("utf-8", "replace")
+    return str(value)
+
+
+# --------------------------------------------------------------------------- #
+# Top-level write / read
+# --------------------------------------------------------------------------- #
+def write_payload(h5_path: Path, gui_payload: Dict[str, Any], mechanism: str) -> None:
+    """Serialize *gui_payload* to a composite HDF5 file.
+
+    Reactor series are routed to the most native tier they qualify for; the rest
+    of the payload (plus a ``reactors_index``) goes into ``payload_json``. The
+    file is written fresh. The config snapshot is the caller's concern.
+    """
+    h5_path = Path(h5_path)
+    if h5_path.exists():
+        h5_path.unlink()
+
+    # Shallow-copy the top level and pop the heavy series — never deepcopy the
+    # big X arrays (P3); they are routed straight into HDF5.
+    lean = dict(gui_payload)
+    series_map: Dict[str, Any] = lean.pop("reactors_series", None) or {}
+
+    gas = _solution_for(mechanism)
+
+    index: Dict[str, Dict[str, Any]] = {}
+    solution_groups: List[Tuple[str, ct.SolutionArray]] = []
+    array_series: List[Tuple[str, Dict[str, Any], List[str]]] = []
+    for i, (rid, series) in enumerate(series_map.items()):
+        kind = _classify_series(series, gas)
+        if kind == "raw":
+            index[rid] = {"kind": "raw", "series": _jsonify(series)}
+            continue
+        group = f"r{i}"
+        extra_keys, meta = _split_series(series)
+        index[rid] = {
+            "kind": kind,
+            "group": group,
+            "extra_keys": extra_keys,
+            "meta": _jsonify(meta),
+        }
+        if kind == "solution":
+            solution_groups.append(
+                (group, _series_to_solution_array(gas, series, extra_keys))  # type: ignore[arg-type]
+            )
+        else:
+            array_series.append((group, series, extra_keys))
+
+    lean["reactors_index"] = index
+    blob = json.dumps(lean, ensure_ascii=False, separators=(",", ":"))
+
+    # 1) Cantera writes its SolutionArray groups first and fully, before any
+    #    h5py handle touches the file (R4: no interleaved open handles).
+    for idx, (group, states) in enumerate(solution_groups):
+        states.save(str(h5_path), name=group, overwrite=(idx == 0))
+
+    # 2) Then a single h5py session for array groups + the JSON blob + attrs.
+    mode = "r+" if h5_path.exists() else "w"
+    stored_mech, sha = _resolve_mechanism(mechanism)
+    with h5py.File(str(h5_path), mode) as handle:
+        for group, series, extra_keys in array_series:
+            _series_to_datasets(handle.create_group(group), series, extra_keys)
+        if "payload_json" in handle:
+            del handle["payload_json"]
+        handle.create_dataset("payload_json", data=blob)
+        handle.attrs["schema_version"] = PAYLOAD_SCHEMA
+        handle.attrs["mechanism"] = stored_mech
+        handle.attrs["mechanism_sha256"] = sha
+        handle.attrs["mechanism_name"] = Path(mechanism).name if mechanism else ""
+
+
+def read_payload(h5_path: Path, mechanism_override: Optional[str] = None) -> Dict[str, Any]:
+    """Inverse of :func:`write_payload` → the full ``gui_payload``.
+
+    Rehydrates ``reactors_series`` by tier and merges each reactor's ``meta``.
+    Raises on restore failure; callers decide miss-vs-error (R1).
+    """
+    h5_path = Path(h5_path)
+    with h5py.File(str(h5_path), "r") as handle:
+        raw = handle["payload_json"][()]
+        mechanism = mechanism_override or _to_str(handle.attrs.get("mechanism", ""))
+    if isinstance(raw, bytes):
+        raw = raw.decode("utf-8")
+    gui = json.loads(raw)
+
+    index = gui.pop("reactors_index", None)
+    if index is None:
+        return gui  # defensive: nothing to rehydrate
+
+    needs_solution = any(e.get("kind") == "solution" for e in index.values())
+    gas = _solution_for(mechanism) if needs_solution else None
+
+    series: Dict[str, Any] = {}
+    array_entries = []
+    for rid, entry in index.items():
+        kind = entry.get("kind")
+        if kind == "raw":
+            series[rid] = entry["series"]
+        elif kind == "solution":
+            states = ct.SolutionArray(gas)
+            states.restore(str(h5_path), name=entry["group"])
+            rebuilt = _solution_array_to_series(states, entry.get("extra_keys") or [])
+            rebuilt.update(entry.get("meta") or {})
+            series[rid] = rebuilt
+        else:  # arrays — read together in one h5py session below
+            array_entries.append((rid, entry))
+
+    if array_entries:
+        with h5py.File(str(h5_path), "r") as handle:
+            for rid, entry in array_entries:
+                rebuilt = _datasets_to_series(
+                    handle[entry["group"]], entry.get("extra_keys") or []
+                )
+                rebuilt.update(entry.get("meta") or {})
+                series[rid] = rebuilt
+
+    gui["reactors_series"] = series
+    return gui
+
+
+def _jsonify(value: Any) -> Any:
+    """Best-effort JSON-safe coercion (numpy scalars/arrays) for raw/meta blobs."""
+    if isinstance(value, dict):
+        return {k: _jsonify(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_jsonify(v) for v in value]
+    if isinstance(value, np.generic):
+        return value.item()
+    if isinstance(value, np.ndarray):
+        return value.tolist()
+    return value
+
+
+# --------------------------------------------------------------------------- #
+# Shared builder (scenario inspector)
+# --------------------------------------------------------------------------- #
+def gui_payload_from_solution_array(
+    states: ct.SolutionArray,
+    reactor_id: str,
+    extra: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Build a full ``SimulationResults`` gui_payload from one SolutionArray.
+
+    Shared by the scenario inspector so a restored trajectory renders through
+    the exact same shape as a cached live run. ``extra`` may override/augment
+    derived fields (e.g. Sankey for a richer case).
+    """
+    rebuilt = _solution_array_to_series(states, ["t"])
+    rebuilt["is_residence"] = True
+    series = {reactor_id: rebuilt}
+    payload: Dict[str, Any] = {
+        "status": "complete",
+        "is_running": False,
+        "is_complete": True,
+        "error_message": None,
+        "times": rebuilt["t"],
+        "reactors_series": series,
+        "reactor_reports": {},
+        "connection_reports": {},
+        "code_str": "",
+        "summary": [],
+        "sankey_links": None,
+        "sankey_nodes": None,
+        "elapsed_time": None,
+        "updated_nodes": None,
+        "updated_connections": None,
+    }
+    if extra:
+        payload.update(extra)
+    return payload

--- a/boulder/payload_store.py
+++ b/boulder/payload_store.py
@@ -257,16 +257,34 @@ def _to_str(value: Any) -> str:
 # --------------------------------------------------------------------------- #
 # Top-level write / read
 # --------------------------------------------------------------------------- #
-def write_payload(h5_path: Path, gui_payload: Dict[str, Any], mechanism: str) -> None:
+def write_payload(
+    h5_path: Path,
+    gui_payload: Dict[str, Any],
+    mechanism: str,
+    group: Optional[str] = None,
+    fresh: bool = True,
+) -> None:
     """Serialize *gui_payload* to a composite HDF5 file.
 
     Reactor series are routed to the most native tier they qualify for; the rest
-    of the payload (plus a ``reactors_index``) goes into ``payload_json``. The
-    file is written fresh. The config snapshot is the caller's concern.
+    of the payload (plus a ``reactors_index``) goes into ``payload_json``.
+
+    Parameters
+    ----------
+    group:
+        When set, the result is written under ``<group>/…`` (one composite per
+        scenario in a *collection* file). When ``None``, written at the top level
+        (a single-result *cache* file).
+    fresh:
+        When ``True`` (and no ``group``), any existing file is replaced. For a
+        collection (``group`` set) pass ``fresh=False`` to append without wiping
+        previously-written scenarios.
     """
     h5_path = Path(h5_path)
-    if h5_path.exists():
+    if fresh and group is None and h5_path.exists():
         h5_path.unlink()
+
+    prefix = f"{group}/" if group else ""
 
     # Shallow-copy the top level and pop the heavy series — never deepcopy the
     # big X arrays (P3); they are routed straight into HDF5.
@@ -283,54 +301,71 @@ def write_payload(h5_path: Path, gui_payload: Dict[str, Any], mechanism: str) ->
         if kind == "raw":
             index[rid] = {"kind": "raw", "series": _jsonify(series)}
             continue
-        group = f"r{i}"
+        rgroup = f"r{i}"  # stored relative; prefixed on disk/read
         extra_keys, meta = _split_series(series)
         index[rid] = {
             "kind": kind,
-            "group": group,
+            "group": rgroup,
             "extra_keys": extra_keys,
             "meta": _jsonify(meta),
         }
         if kind == "solution":
             solution_groups.append(
-                (group, _series_to_solution_array(gas, series, extra_keys))  # type: ignore[arg-type]
+                (rgroup, _series_to_solution_array(gas, series, extra_keys))  # type: ignore[arg-type]
             )
         else:
-            array_series.append((group, series, extra_keys))
+            array_series.append((rgroup, series, extra_keys))
 
     lean["reactors_index"] = index
     blob = json.dumps(lean, ensure_ascii=False, separators=(",", ":"))
 
     # 1) Cantera writes its SolutionArray groups first and fully, before any
     #    h5py handle touches the file (R4: no interleaved open handles).
-    for idx, (group, states) in enumerate(solution_groups):
-        states.save(str(h5_path), name=group, overwrite=(idx == 0))
+    #    overwrite=True is per-group: in a collection it only replaces this
+    #    scenario's groups, never sibling scenarios.
+    for idx, (rgroup, states) in enumerate(solution_groups):
+        states.save(str(h5_path), name=f"{prefix}{rgroup}", overwrite=(bool(group) or idx == 0))
 
     # 2) Then a single h5py session for array groups + the JSON blob + attrs.
     mode = "r+" if h5_path.exists() else "w"
     stored_mech, sha = _resolve_mechanism(mechanism)
     with h5py.File(str(h5_path), mode) as handle:
-        for group, series, extra_keys in array_series:
-            _series_to_datasets(handle.create_group(group), series, extra_keys)
-        if "payload_json" in handle:
-            del handle["payload_json"]
-        handle.create_dataset("payload_json", data=blob)
-        handle.attrs["schema_version"] = PAYLOAD_SCHEMA
-        handle.attrs["mechanism"] = stored_mech
-        handle.attrs["mechanism_sha256"] = sha
-        handle.attrs["mechanism_name"] = Path(mechanism).name if mechanism else ""
+        node = handle.require_group(group) if group else handle
+        for rgroup, series, extra_keys in array_series:
+            full = f"{prefix}{rgroup}"
+            if full in handle:
+                del handle[full]
+            _series_to_datasets(handle.create_group(full), series, extra_keys)
+        if "payload_json" in node:
+            del node["payload_json"]
+        node.create_dataset("payload_json", data=blob)
+        node.attrs["schema_version"] = PAYLOAD_SCHEMA
+        node.attrs["mechanism"] = stored_mech
+        node.attrs["mechanism_sha256"] = sha
+        node.attrs["mechanism_name"] = Path(mechanism).name if mechanism else ""
 
 
-def read_payload(h5_path: Path, mechanism_override: Optional[str] = None) -> Dict[str, Any]:
+def read_payload(
+    h5_path: Path,
+    mechanism_override: Optional[str] = None,
+    group: Optional[str] = None,
+) -> Dict[str, Any]:
     """Inverse of :func:`write_payload` → the full ``gui_payload``.
 
     Rehydrates ``reactors_series`` by tier and merges each reactor's ``meta``.
-    Raises on restore failure; callers decide miss-vs-error (R1).
+    ``group`` selects one scenario's composite from a collection file. Raises on
+    restore failure; callers decide miss-vs-error (R1).
     """
     h5_path = Path(h5_path)
+    prefix = f"{group}/" if group else ""
     with h5py.File(str(h5_path), "r") as handle:
-        raw = handle["payload_json"][()]
-        mechanism = mechanism_override or _to_str(handle.attrs.get("mechanism", ""))
+        node = handle[group] if group else handle
+        raw = node["payload_json"][()]
+        mechanism = (
+            mechanism_override
+            or _to_str(node.attrs.get("mechanism", ""))
+            or _to_str(handle.attrs.get("mechanism", ""))
+        )
     if isinstance(raw, bytes):
         raw = raw.decode("utf-8")
     gui = json.loads(raw)
@@ -350,7 +385,7 @@ def read_payload(h5_path: Path, mechanism_override: Optional[str] = None) -> Dic
             series[rid] = entry["series"]
         elif kind == "solution":
             states = ct.SolutionArray(gas)
-            states.restore(str(h5_path), name=entry["group"])
+            states.restore(str(h5_path), name=f"{prefix}{entry['group']}")
             rebuilt = _solution_array_to_series(states, entry.get("extra_keys") or [])
             rebuilt.update(entry.get("meta") or {})
             series[rid] = rebuilt
@@ -361,7 +396,7 @@ def read_payload(h5_path: Path, mechanism_override: Optional[str] = None) -> Dic
         with h5py.File(str(h5_path), "r") as handle:
             for rid, entry in array_entries:
                 rebuilt = _datasets_to_series(
-                    handle[entry["group"]], entry.get("extra_keys") or []
+                    handle[f"{prefix}{entry['group']}"], entry.get("extra_keys") or []
                 )
                 rebuilt.update(entry.get("meta") or {})
                 series[rid] = rebuilt

--- a/boulder/payload_store.py
+++ b/boulder/payload_store.py
@@ -106,7 +106,7 @@ def _is_numeric_list(value: Any, n: int) -> bool:
 
 
 def _is_state_series(series: Any) -> bool:
-    """True when a series is state-shaped: T, P lists (equal len, >0) + X dict."""
+    """Return True when a series is state-shaped: T, P lists (equal len, >0) + X dict."""
     if not isinstance(series, dict):
         return False
     T, P, X = series.get("T"), series.get("P"), series.get("X")
@@ -156,8 +156,10 @@ def _can_represent(series: Dict[str, Any], gas: Optional[ct.Solution]) -> bool:
 
 
 def _x_rows_normalised(series: Dict[str, Any]) -> bool:
-    """True when every X row sums to 1 ± tol (R2: don't let Cantera silently
-    renormalise a non-normalised/diagnostic series)."""
+    """Return True when every X row sums to 1 ± tol.
+
+    R2: don't let Cantera silently renormalise a non-normalised/diagnostic series.
+    """
     cols = list(series["X"].values())
     if not cols:
         return False
@@ -188,7 +190,7 @@ def _series_to_solution_array(
     P = np.asarray(series["P"], dtype=float)
     Xmat = _x_matrix(series, gas.species_names)
     extra = {k: np.asarray(series[k], dtype=float) for k in extra_keys}
-    states = ct.SolutionArray(gas, shape=(len(T),), extra=extra or None)
+    states = ct.SolutionArray(gas, shape=(len(T),), extra=extra or None)  # type: ignore[arg-type]
     states.TPX = T, P, Xmat
     return states
 
@@ -324,7 +326,9 @@ def write_payload(
     #    overwrite=True is per-group: in a collection it only replaces this
     #    scenario's groups, never sibling scenarios.
     for idx, (rgroup, states) in enumerate(solution_groups):
-        states.save(str(h5_path), name=f"{prefix}{rgroup}", overwrite=(bool(group) or idx == 0))
+        states.save(
+            str(h5_path), name=f"{prefix}{rgroup}", overwrite=(bool(group) or idx == 0)
+        )
 
     # 2) Then a single h5py session for array groups + the JSON blob + attrs.
     mode = "r+" if h5_path.exists() else "w"
@@ -384,6 +388,7 @@ def read_payload(
         if kind == "raw":
             series[rid] = entry["series"]
         elif kind == "solution":
+            assert gas is not None  # the solution tier implies the mechanism loaded
             states = ct.SolutionArray(gas)
             states.restore(str(h5_path), name=f"{prefix}{entry['group']}")
             rebuilt = _solution_array_to_series(states, entry.get("extra_keys") or [])

--- a/boulder/reactor_energy.py
+++ b/boulder/reactor_energy.py
@@ -31,10 +31,14 @@ def parse_energy_prop(props: dict[str, Any]) -> Tuple[EnergyMode | None, bool]:
 
 def supports_energy_kwarg(reactor_cls: type) -> bool:
     """Return True when *reactor_cls* accepts ``energy=`` in its constructor."""
-    return reactor_cls in _ENERGY_REACTOR_CLASSES or hasattr(reactor_cls, "energy_enabled")
+    return reactor_cls in _ENERGY_REACTOR_CLASSES or hasattr(
+        reactor_cls, "energy_enabled"
+    )
 
 
-def validate_explicit_energy(props: dict[str, Any], reactor_cls: type, type_name: str) -> None:
+def validate_explicit_energy(
+    props: dict[str, Any], reactor_cls: type, type_name: str
+) -> None:
     """Raise if ``energy`` is set explicitly on an unsupported reactor type."""
     _, explicit = parse_energy_prop(props)
     if explicit and not supports_energy_kwarg(reactor_cls):
@@ -78,8 +82,8 @@ def build_reactor_with_energy(
 
 
 def energy_ctor_suffix(props: dict[str, Any]) -> str:
-    """Return ``', energy=\"on\"'`` / ``', energy=\"off\"'`` or empty for emitters."""
+    r"""Return ``', energy=\"on\"'`` / ``', energy=\"off\"'`` or empty for emitters."""
     energy, explicit = parse_energy_prop(props)
     if not explicit or energy is None:
         return ""
-    return f', energy={energy!r}'
+    return f", energy={energy!r}"

--- a/boulder/reactor_energy.py
+++ b/boulder/reactor_energy.py
@@ -1,0 +1,85 @@
+"""Shared helpers for STONE node ``energy`` property on Cantera reactors."""
+
+from __future__ import annotations
+
+from typing import Any, Literal, Tuple
+
+import cantera as ct
+
+EnergyMode = Literal["on", "off"]
+
+_ENERGY_REACTOR_CLASSES: tuple[type, ...] = (
+    ct.IdealGasReactor,
+    ct.ConstPressureReactor,
+    ct.IdealGasConstPressureReactor,
+    ct.IdealGasConstPressureMoleReactor,
+    ct.IdealGasMoleReactor,
+)
+
+
+def parse_energy_prop(props: dict[str, Any]) -> Tuple[EnergyMode | None, bool]:
+    """Return ``(energy, explicitly_set)``. Absent key → ``(None, False)``."""
+    if "energy" not in props:
+        return None, False
+    energy_val = props["energy"]
+    if isinstance(energy_val, bool):
+        return ("off" if not energy_val else "on"), True
+    if str(energy_val).lower() in ("off", "false", "0"):
+        return "off", True
+    return "on", True
+
+
+def supports_energy_kwarg(reactor_cls: type) -> bool:
+    """Return True when *reactor_cls* accepts ``energy=`` in its constructor."""
+    return reactor_cls in _ENERGY_REACTOR_CLASSES or hasattr(reactor_cls, "energy_enabled")
+
+
+def validate_explicit_energy(props: dict[str, Any], reactor_cls: type, type_name: str) -> None:
+    """Raise if ``energy`` is set explicitly on an unsupported reactor type."""
+    _, explicit = parse_energy_prop(props)
+    if explicit and not supports_energy_kwarg(reactor_cls):
+        raise ValueError(
+            f"Node property 'energy' is not supported for reactor type "
+            f"{type_name!r}. Remove 'energy' or choose a reactor that implements "
+            f"an energy equation (e.g. IdealGasConstPressureMoleReactor)."
+        )
+
+
+def validate_energy_on_built_reactor(
+    reactor: ct.Reactor, props: dict[str, Any], type_name: str
+) -> None:
+    """Raise if YAML set ``energy`` on a built reactor that cannot honour it."""
+    _, explicit = parse_energy_prop(props)
+    if not explicit:
+        return
+    if not hasattr(reactor, "energy_enabled"):
+        raise ValueError(
+            f"Node property 'energy' is not supported for reactor type "
+            f"{type_name!r}. Remove 'energy' or choose a reactor that implements "
+            f"an energy equation (e.g. IdealGasConstPressureMoleReactor)."
+        )
+
+
+def build_reactor_with_energy(
+    reactor_cls: type,
+    gas: ct.Solution,
+    *,
+    props: dict[str, Any],
+    clone: bool,
+    type_name: str,
+) -> ct.Reactor:
+    """Instantiate *reactor_cls* with optional ``energy`` from node properties."""
+    validate_explicit_energy(props, reactor_cls, type_name)
+    energy, _ = parse_energy_prop(props)
+    kwargs: dict[str, Any] = {"clone": clone}
+    if energy is not None:
+        kwargs["energy"] = energy
+    return reactor_cls(gas, **kwargs)
+
+
+def energy_ctor_suffix(props: dict[str, Any]) -> str:
+    """Return ``', energy=\"on\"'`` / ``', energy=\"off\"'`` or empty for emitters."""
+    energy, explicit = parse_energy_prop(props)
+    if not explicit or energy is None:
+        return ""
+    return f', energy={energy!r}'

--- a/boulder/result_cache.py
+++ b/boulder/result_cache.py
@@ -6,7 +6,7 @@ next to the loaded YAML file.  On startup, if the preloaded config
 fingerprint matches a cache entry, Boulder loads it and sends it to the
 frontend immediately so outputs are visible without re-running.
 
-Host packages (e.g. Bloc) register :class:`CacheContributorPlugin`
+Host packages register :class:`CacheContributorPlugin`
 implementations.  After each successful GUI solve, Boulder calls every
 registered contributor so they can write package-specific artifacts
 (e.g. a calc-note bundle JSON + figure PNGs) into the same cache entry.

--- a/boulder/result_cache.py
+++ b/boulder/result_cache.py
@@ -19,8 +19,8 @@ Cache layout
 
     <yaml_dir>/.boulder-cache/         (or $BOULDER_CACHE_DIR)
         <fingerprint>/
-            result.json                GUI payload + config snapshot
-            meta.json                  created_at, versions, fingerprint inputs
+            result.h5                  GUI payload (composite HDF5, see payload_store)
+            meta.json                  created_at, versions, mechanism, config_snapshot
             COMPLETE                   marker written last (atomic write guard)
             artifacts/                 contributor-written files
 
@@ -36,7 +36,7 @@ SHA-256 hex of canonical sorted-key JSON of:
 * ``BOULDER_PLUGINS`` env var
 * ``CACHE_VERSION`` integer
 
-:data:`CACHE_VERSION` must be bumped whenever the ``result.json``
+:data:`CACHE_VERSION` must be bumped whenever the ``result.h5``
 or ``meta.json`` schema changes.
 """
 
@@ -58,8 +58,10 @@ from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
 
-#: Bump when result.json / meta.json schema changes to auto-invalidate old entries.
-CACHE_VERSION: int = 1
+#: Bump when the payload (result.h5) / meta.json schema changes to auto-invalidate
+#: old entries. v2: payload moved from result.json → composite result.h5
+#: (native SolutionArray + JSON blob); see :mod:`boulder.payload_store`.
+CACHE_VERSION: int = 2
 
 #: Keep at most this many cache entries per cache directory (oldest pruned first).
 MAX_CACHE_ENTRIES: int = 5
@@ -435,9 +437,9 @@ def save_result(
 ) -> Path:
     """Atomically persist the GUI payload and config snapshot to disk.
 
-    Creates ``<cache_root>/<fingerprint>/result.json``,
-    ``meta.json``, and the ``COMPLETE`` marker.  Prunes old entries to keep
-    at most :data:`MAX_CACHE_ENTRIES`.
+    Creates ``<cache_root>/<fingerprint>/result.h5`` (composite payload),
+    ``meta.json`` (incl. ``config_snapshot``), and the ``COMPLETE`` marker.
+    Prunes old entries to keep at most :data:`MAX_CACHE_ENTRIES`.
 
     Parameters
     ----------
@@ -468,12 +470,14 @@ def save_result(
     try:
         (tmp_dir / "artifacts").mkdir()
 
-        result_data = {
-            "gui_payload": _coerce(gui_payload),
-            "config_snapshot": _coerce(config_snapshot),
-        }
-        _write_json(tmp_dir / "result.json", result_data)
+        from .payload_store import write_payload
 
+        # Composite HDF5: heavy reactor series as native SolutionArrays / binary
+        # datasets, everything else (sankey, reports, summary) as a JSON blob.
+        write_payload(tmp_dir / "result.h5", _coerce(gui_payload), mechanism or "")
+
+        # config_snapshot lives in meta.json (P1) so a snapshot scan never has
+        # to restore the numeric HDF5.
         meta: Dict[str, Any] = {
             "fingerprint": fingerprint,
             "cache_version": CACHE_VERSION,
@@ -481,6 +485,7 @@ def save_result(
             "boulder_version": _package_version("boulder"),
             "cantera_version": _package_version("cantera"),
             "mechanism": mechanism or "",
+            "config_snapshot": _coerce(config_snapshot),
         }
         if meta_extra:
             meta.update(_coerce(meta_extra))
@@ -539,20 +544,31 @@ def load_result(
     if not (entry / "COMPLETE").exists():
         return None
     try:
-        result_data = json.loads((entry / "result.json").read_text(encoding="utf-8"))
         meta = json.loads((entry / "meta.json").read_text(encoding="utf-8"))
         if meta.get("cache_version") != CACHE_VERSION:
             logger.debug("Cache entry version mismatch, ignoring: %s", fingerprint[:12])
             return None
+        from .payload_store import read_payload
+
+        gui_payload = read_payload(
+            entry / "result.h5", mechanism_override=meta.get("mechanism") or None
+        )
         return {
             "fingerprint": fingerprint,
-            "gui_payload": result_data.get("gui_payload", {}),
-            "config_snapshot": result_data.get("config_snapshot", {}),
+            "gui_payload": gui_payload,
+            "config_snapshot": meta.get("config_snapshot", {}),
             "meta": meta,
             "artifacts_dir": entry / "artifacts",
         }
     except (OSError, json.JSONDecodeError, KeyError) as exc:
         logger.debug("Failed to load cache entry %s: %s", fingerprint[:12], exc)
+        return None
+    except Exception as exc:  # noqa: BLE001 — restore failure ⇒ treat as cache miss
+        logger.warning(
+            "Cache entry %s payload restore failed, ignoring: %s",
+            fingerprint[:12],
+            exc,
+        )
         return None
 
 
@@ -653,24 +669,18 @@ def find_result_by_config_snapshot(
         if not (entry_dir / "COMPLETE").exists():
             continue
         try:
-            result_data = json.loads(
-                (entry_dir / "result.json").read_text(encoding="utf-8")
-            )
+            # Read config_snapshot from meta.json only — never restore the
+            # numeric HDF5 just to compare snapshots (P1).
             meta = json.loads((entry_dir / "meta.json").read_text(encoding="utf-8"))
             if meta.get("cache_version") != CACHE_VERSION:
                 continue
-            snapshot = result_data.get("config_snapshot") or {}
+            snapshot = meta.get("config_snapshot") or {}
             if not snapshot:
                 continue
             snapshot_fp = compute_fingerprint(snapshot, mechanism=mechanism)
             if snapshot_fp == fingerprint:
-                return {
-                    "fingerprint": entry_dir.name,
-                    "gui_payload": result_data.get("gui_payload", {}),
-                    "config_snapshot": snapshot,
-                    "meta": meta,
-                    "artifacts_dir": entry_dir / "artifacts",
-                }
+                # Match — now restore the payload for this one entry.
+                return load_result(cache_root, entry_dir.name)
         except (OSError, json.JSONDecodeError, KeyError):
             continue
     return None

--- a/boulder/runner.py
+++ b/boulder/runner.py
@@ -420,6 +420,15 @@ class BoulderRunner:
             stream_reservoirs = interface_reservoirs
 
         converter = self._ensure_converter()
+        # Alias each logical inter-stage id onto its materialized inlet MFC before
+        # computing already_built, so the converter's deferred-PressureController
+        # pass can resolve masters declared by the original YAML id (mirrors
+        # solve_staged; without this the runner path leaves e.g. 'psr_to_pfr'
+        # unregistered and PCs mastered on it never build).
+        if stream_reservoirs:
+            from .staged_solver import alias_inter_connection_mfcs
+
+            alias_inter_connection_mfcs(converter, plan)
         already_built = set(converter.connections.keys()) | set(converter.walls.keys())
         if stream_reservoirs:
             for ic in plan.all_inter_connections:

--- a/boulder/runner.py
+++ b/boulder/runner.py
@@ -771,7 +771,7 @@ class BoulderRunner:
             # BoulderRunner.scopes is non-empty even for steady-state cases.
             # Transient step-by-step recording is handled by _run_transient_solver
             # via converter._scope_recorder when set.
-            converter._scope_recorder = self._scope_recorder  # type: ignore[attr-defined]
+            converter._scope_recorder = self._scope_recorder  # type: ignore[attr-defined, assignment]
             # Take an initial snapshot at t=0 (or the final time if a trajectory is available)
             last_t = 0.0
             for _stage_traj in trajectory.networks.values():

--- a/boulder/staged_solver.py
+++ b/boulder/staged_solver.py
@@ -818,10 +818,9 @@ def solve_staged(
                 )
 
     logger.info("Staged solve complete – building visualization ReactorNet.")
-    # Legacy OutletSink only (deprecated — see _refresh_terminal_sinks).  Production
-    # chains (e.g. SPRING_A4 torch→PSR→PFR) use inter-stage stream-point diamonds
-    # refreshed in _update_stream_point during the stage loop; this call is a no-op
-    # for those configs.
+    # Legacy OutletSink only (deprecated — see _refresh_terminal_sinks).  Multi-stage
+    # chains use inter-stage stream-point diamonds refreshed in _update_stream_point
+    # during the stage loop; this call is a no-op for those configs.
     _refresh_terminal_sinks(converter, config)
     viz_net = converter.build_viz_network(
         all_connections=all_connections,
@@ -978,8 +977,8 @@ def _refresh_terminal_sinks(converter: Any, config: Dict[str, Any]) -> None:
     .. deprecated::
         ``OutletSink`` is being retired in favour of inter-stage stream-point
         diamonds (``{source}_outlet``), which are refreshed by
-        :func:`_update_stream_point` during :func:`solve_staged`.  Production
-        models such as SPRING_A4 (torch → PSR → PFR) never use this path.
+        :func:`_update_stream_point` during :func:`solve_staged`.  Multi-stage
+        models never use this path.
 
     This helper exists only so old single-stage YAMLs that still declare a
     terminal ``OutletSink`` (e.g. tube-furnace examples) show converged thermo

--- a/boulder/staged_solver.py
+++ b/boulder/staged_solver.py
@@ -505,6 +505,29 @@ def synthesize_stream_points(
 synthesize_interface_nodes = synthesize_stream_points
 
 
+def alias_inter_connection_mfcs(
+    converter: "DualCanteraConverter", plan: "StageExecutionPlan"
+) -> None:
+    """Alias each logical inter-stage connection id onto its materialized inlet MFC.
+
+    Inter-stage connections (e.g. ``psr_to_pfr``) are not built directly; the
+    staged solver synthesizes a stream-point reservoir per source node plus a
+    real inlet MFC (``<src>_outlet_to_<tgt>``) on the downstream side.  Register
+    the original logical id as an alias pointing at that real MFC object so
+    downstream consumers that use the YAML-declared name — ``PressureController``
+    ``master`` lookups and test assertions — resolve to the real device.
+
+    Must run *before* the deferred-PressureController pass in
+    :meth:`DualCanteraConverter.build_viz_network`.  Both staged-build paths
+    (:func:`solve_staged` and :meth:`BoulderRunner.build_viz_network`) call this
+    so they cannot drift apart.
+    """
+    for ic in plan.all_inter_connections:
+        inlet_mfc = converter.connections.get(ic.inlet_mfc_id)
+        if inlet_mfc is not None:
+            converter.connections[ic.id] = inlet_mfc
+
+
 # ---------------------------------------------------------------------------
 # solve_staged
 # ---------------------------------------------------------------------------
@@ -757,10 +780,7 @@ def solve_staged(
     # consumers (e.g. PressureController master lookups and test assertions) query
     # the original YAML-declared name ("psr_to_pfr") and get the real MFC back.
     if stream_reservoirs:
-        for ic in plan.all_inter_connections:
-            inlet_mfc = converter.connections.get(ic.inlet_mfc_id)
-            if inlet_mfc is not None:
-                converter.connections[ic.id] = inlet_mfc
+        alias_inter_connection_mfcs(converter, plan)
 
     already_built = set(converter.connections.keys()) | set(converter.walls.keys())
     if stream_reservoirs:

--- a/boulder/tests/test_build_isolated_reactor.py
+++ b/boulder/tests/test_build_isolated_reactor.py
@@ -1,0 +1,63 @@
+"""Tests for DualCanteraConverter.build_isolated_reactor (standalone reactor build)."""
+
+from __future__ import annotations
+
+import cantera as ct
+
+from boulder.cantera_converter import DualCanteraConverter
+
+
+def _node(props: dict) -> dict:
+    return {
+        "id": "reactor",
+        "type": "IdealGasConstPressureMoleReactor",
+        "properties": props,
+    }
+
+
+def test_build_isolated_reactor_sets_state_and_energy_off():
+    """State (T, P, X) comes from props and energy: off disables the energy eqn."""
+    conv = DualCanteraConverter(mechanism="gri30.yaml")
+    reactor, gas = conv.build_isolated_reactor(
+        _node(
+            {
+                "temperature": 1500.0,
+                "pressure": 2.0e5,
+                "composition": "CH4:1",
+                "energy": "off",
+            }
+        )
+    )
+    assert isinstance(reactor, ct.IdealGasConstPressureMoleReactor)
+    assert reactor.energy_enabled is False
+    assert abs(reactor.phase.T - 1500.0) < 1e-6
+    assert abs(reactor.phase.P - 2.0e5) < 1.0
+    phase = reactor.phase
+    assert phase.X[phase.species_index("CH4")] > 0.99
+
+
+def test_build_isolated_reactor_energy_on_default():
+    """Omitting energy leaves the energy equation enabled (Cantera default)."""
+    conv = DualCanteraConverter(mechanism="gri30.yaml")
+    reactor, _gas = conv.build_isolated_reactor(
+        _node({"temperature": 1200.0, "pressure": 1.0e5, "composition": "CH4:1"})
+    )
+    assert reactor.energy_enabled is True
+
+
+def test_build_isolated_reactor_accepts_unit_strings_and_volume():
+    """Unit-string T/P are coerced to SI and `volume` is honoured."""
+    conv = DualCanteraConverter(mechanism="gri30.yaml")
+    reactor, _gas = conv.build_isolated_reactor(
+        _node(
+            {
+                "temperature": "1273.15 K",
+                "pressure": "1 bar",
+                "composition": "CH4:1",
+                "volume": 0.25,
+            }
+        )
+    )
+    assert abs(reactor.phase.T - 1273.15) < 1e-6
+    assert abs(reactor.phase.P - 1.0e5) < 1.0
+    assert abs(reactor.volume - 0.25) < 1e-9

--- a/boulder/tests/test_reactor_energy.py
+++ b/boulder/tests/test_reactor_energy.py
@@ -49,5 +49,5 @@ def test_reservoir_rejects_explicit_energy():
 
 def test_emitter_energy_suffix():
     """Download emitter suffix includes explicit energy."""
-    assert energy_ctor_suffix({"energy": "off"}) == ', energy=\'off\''
+    assert energy_ctor_suffix({"energy": "off"}) == ", energy='off'"
     assert energy_ctor_suffix({}) == ""

--- a/boulder/tests/test_reactor_energy.py
+++ b/boulder/tests/test_reactor_energy.py
@@ -1,0 +1,53 @@
+"""Tests for STONE node energy property handling on Cantera reactors."""
+
+from __future__ import annotations
+
+import cantera as ct
+import pytest
+
+from boulder.reactor_energy import (
+    build_reactor_with_energy,
+    energy_ctor_suffix,
+    parse_energy_prop,
+    validate_explicit_energy,
+)
+
+
+def test_parse_energy_prop_absent():
+    """Absent energy key returns not explicit."""
+    energy, explicit = parse_energy_prop({})
+    assert energy is None
+    assert explicit is False
+
+
+def test_parse_energy_prop_off_string():
+    """String 'off' parses to energy off."""
+    energy, explicit = parse_energy_prop({"energy": "off"})
+    assert energy == "off"
+    assert explicit is True
+
+
+def test_mole_reactor_energy_off():
+    """IdealGasConstPressureMoleReactor honours energy: off from props."""
+    gas = ct.Solution("gri30.yaml")
+    gas.TPX = 1200, 101325, "CH4:1"
+    reactor = build_reactor_with_energy(
+        ct.IdealGasConstPressureMoleReactor,
+        gas,
+        props={"energy": "off"},
+        clone=True,
+        type_name="IdealGasConstPressureMoleReactor",
+    )
+    assert reactor.energy_enabled is False
+
+
+def test_reservoir_rejects_explicit_energy():
+    """Reservoir with energy: off raises ValueError."""
+    with pytest.raises(ValueError, match="not supported"):
+        validate_explicit_energy({"energy": "off"}, ct.Reservoir, "Reservoir")
+
+
+def test_emitter_energy_suffix():
+    """Download emitter suffix includes explicit energy."""
+    assert energy_ctor_suffix({"energy": "off"}) == ', energy=\'off\''
+    assert energy_ctor_suffix({}) == ""

--- a/boulder/utils.py
+++ b/boulder/utils.py
@@ -142,6 +142,10 @@ def coerce_config_units(obj: Any, _key: str = "") -> Any:
     """
     if isinstance(obj, dict):
         for k, v in obj.items():
+            # `metadata:` is descriptive free text (title, assumptions, author, …),
+            # never unit-bearing — don't try to parse e.g. "2 torches…" as a unit.
+            if k == "metadata":
+                continue
             obj[k] = coerce_config_units(v, _key=k)
         return obj
     if isinstance(obj, list):

--- a/boulder/validation.py
+++ b/boulder/validation.py
@@ -450,8 +450,8 @@ class NormalizedConfigModel(BaseModel):
 def warn_flow_device_conventions(config: Dict[str, Any]) -> List[str]:
     """Return non-fatal notes about ``MassFlowController`` values that are often legacies.
 
-    A declared ``mass_flow_rate: 0.0`` is valid for a intentionally closed
-    side feed (e.g. ``feed_secondary`` in SPRING) but is also the obsolete
+    A declared ``mass_flow_rate: 0.0`` is valid for an intentionally closed
+    side feed but is also the obsolete
     placeholder for a tube-furnace outlet; :func:`warn_flow_device_conventions`
     nudges authors toward :func:`boulder.config.expand_port_shortcuts` or
     omitting the rate.  Call from ``boulder validate`` only — not from every

--- a/environment.yml
+++ b/environment.yml
@@ -6,6 +6,7 @@ dependencies:
 - pip
 - cantera
 - numpy>=2.4.0     # np.trapz replaced with np.trapezoid
+- h5py             # composite-HDF5 result serialization (payload_store)
 - pandas
 - plotly
 - pint

--- a/frontend/src/api/scenarios.ts
+++ b/frontend/src/api/scenarios.ts
@@ -33,3 +33,18 @@ export function listScenarios() {
 export function fetchScenario(id: string) {
   return apiFetch<SimulationResults>(`/scenarios/${encodeURIComponent(id)}`);
 }
+
+/**
+ * Ask every subscribed GUI tab to load scenario ``id`` (the scenario-focus
+ * remote-control channel — used by external dashboards). Returns once the
+ * backend has broadcast the focus.
+ */
+export function focusScenario(id: string) {
+  return apiFetch<{ ok: boolean; scenario_id: string }>("/scenarios/focus", {
+    method: "POST",
+    body: JSON.stringify({ scenario_id: id }),
+  });
+}
+
+/** SSE URL the GUI subscribes to for scenario-focus events. */
+export const SCENARIO_FOCUS_STREAM_URL = "/api/scenarios/focus/stream";

--- a/frontend/src/api/scenarios.ts
+++ b/frontend/src/api/scenarios.ts
@@ -10,6 +10,8 @@ export interface ScenarioMeta {
   n_points?: number;
   final_temperature_K?: number;
   solid_carbon_yield_pct?: number;
+  /** Unix seconds when this scenario was computed (per-scenario; newer stores). */
+  computed_at?: number;
 }
 
 export interface ScenarioListResponse {
@@ -17,6 +19,8 @@ export interface ScenarioListResponse {
   store?: string;
   mechanism?: string | null;
   reactor_mode?: string | null;
+  /** Unix seconds when the store (sweep) was written (fallback for all rows). */
+  created_at?: number | null;
   scenarios: ScenarioMeta[];
 }
 

--- a/frontend/src/api/scenarios.ts
+++ b/frontend/src/api/scenarios.ts
@@ -1,0 +1,31 @@
+import { apiFetch } from "./client";
+import type { SimulationResults } from "@/types/simulation";
+
+/** One precomputed scenario (trajectory) in the active store. */
+export interface ScenarioMeta {
+  id: string;
+  t0_K: number;
+  label: string;
+  reactor_mode?: string;
+  n_points?: number;
+  final_temperature_K?: number;
+  solid_carbon_yield_pct?: number;
+}
+
+export interface ScenarioListResponse {
+  available: boolean;
+  store?: string;
+  mechanism?: string | null;
+  reactor_mode?: string | null;
+  scenarios: ScenarioMeta[];
+}
+
+/** List the scenarios available in the server's active store (fast — attrs only). */
+export function listScenarios() {
+  return apiFetch<ScenarioListResponse>("/scenarios");
+}
+
+/** Load one scenario's trajectory as a results payload (rendered via setResults). */
+export function fetchScenario(id: string) {
+  return apiFetch<SimulationResults>(`/scenarios/${encodeURIComponent(id)}`);
+}

--- a/frontend/src/api/sweep.ts
+++ b/frontend/src/api/sweep.ts
@@ -1,0 +1,34 @@
+import { apiFetch } from "./client";
+
+export interface SweepInfo {
+  available: boolean;
+  n_scenarios: number;
+  can_run: boolean;
+  reason: string;
+  running: boolean;
+}
+
+export interface SweepStatus {
+  status: "idle" | "running" | "done" | "error";
+  current?: number;
+  total?: number;
+  message?: string;
+}
+
+/** Whether the preloaded config has a runnable sweep, and how many scenarios. */
+export function getSweepInfo() {
+  return apiFetch<SweepInfo>("/sweep");
+}
+
+/** Start the sweep as a background batch job on the server. */
+export function startSweep() {
+  return apiFetch<{ status: string; total: number }>("/sweep/run", {
+    method: "POST",
+    body: "{}",
+  });
+}
+
+/** Poll the running/last sweep job's status. */
+export function getSweepStatus() {
+  return apiFetch<SweepStatus>("/sweep/status");
+}

--- a/frontend/src/api/sweep.ts
+++ b/frontend/src/api/sweep.ts
@@ -6,6 +6,8 @@ export interface SweepInfo {
   can_run: boolean;
   reason: string;
   running: boolean;
+  /** ``bloc --sweep`` launched the GUI in sweep mode → default the button to Run Sweep. */
+  default?: boolean;
 }
 
 export interface SweepStatus {

--- a/frontend/src/api/sweep.ts
+++ b/frontend/src/api/sweep.ts
@@ -6,7 +6,7 @@ export interface SweepInfo {
   can_run: boolean;
   reason: string;
   running: boolean;
-  /** ``bloc --sweep`` launched the GUI in sweep mode → default the button to Run Sweep. */
+  /** ``--sweep`` launched the GUI in sweep mode → default the button to Run Sweep. */
   default?: boolean;
 }
 

--- a/frontend/src/components/graph/ReactorGraph.tsx
+++ b/frontend/src/components/graph/ReactorGraph.tsx
@@ -811,7 +811,7 @@ export function ReactorGraph() {
       if (typeof anchor === "string" && anchor.trim()) nodeToAnchor.set(node.id, anchor.trim());
     }
     // When no explicit layout_lane is declared, infer the main-flow spine and
-    // branch nodes from the network topology so simple models (SPRING_A3, A4)
+    // branch nodes from the network topology so simple multi-stage models
     // get an organised layout without any YAML metadata.
     let inferredAnchors: Map<string, string> | null = null;
     if (nodeToLane.size === 0) {

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -4,6 +4,7 @@ import { useThemeStore } from "@/stores/themeStore";
 import { useConfigStore } from "@/stores/configStore";
 import { useSimulationStore } from "@/stores/simulationStore";
 import { useSimulationSSE } from "@/hooks/useSimulationSSE";
+import { useScenarioFocus } from "@/hooks/useScenarioFocus";
 import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
 import { startSimulation } from "@/api/simulations";
 import { fetchDefaultConfig, fetchPreloadedConfig } from "@/api/configs";
@@ -48,6 +49,9 @@ export function AppShell() {
 
   // Connect SSE stream
   useSimulationSSE();
+
+  // Follow scenario-focus pushes (external dashboard → load scenario live).
+  useScenarioFocus();
 
   // Ctrl/Cmd+B toggles the left sidebar (Claude-desktop convention).
   useEffect(() => {

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -11,6 +11,10 @@ import { fetchCachedResult } from "@/api/resultCache";
 import { EditNetworkCard } from "@/components/panels/EditNetworkCard";
 import { SimulateCard } from "@/components/panels/SimulateCard";
 import { PropertiesPanel } from "@/components/panels/PropertiesPanel";
+import { ScenarioPane } from "@/components/panels/ScenarioPane";
+import { PaneToggle, PaneResizer } from "@/components/layout/paneControls";
+import { useLayoutStore } from "@/stores/layoutStore";
+import { useScenarioStore } from "@/stores/scenarioStore";
 import { ReactorGraph } from "@/components/graph/ReactorGraph";
 import { ResultsTabs } from "@/components/results/ResultsTabs";
 import { SimulationOverlay } from "@/components/simulation/SimulationOverlay";
@@ -32,9 +36,31 @@ export function AppShell() {
     );
   }, [config.settings]);
   const [showYamlEditor, setShowYamlEditor] = useState(false);
+  const { leftCollapsed, rightCollapsed, leftWidth, rightWidth, toggleLeft } =
+    useLayoutStore();
+  const scenariosAvailable = useScenarioStore((s) => s.available);
+  const refreshScenarios = useScenarioStore((s) => s.refresh);
+
+  // Discover available scenarios once so the right pane can appear.
+  useEffect(() => {
+    void refreshScenarios();
+  }, [refreshScenarios]);
 
   // Connect SSE stream
   useSimulationSSE();
+
+  // Ctrl/Cmd+B toggles the left sidebar (Claude-desktop convention).
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if ((e.ctrlKey || e.metaKey) && !e.shiftKey && e.key.toLowerCase() === "b") {
+        e.preventDefault();
+        toggleLeft();
+        requestAnimationFrame(() => window.dispatchEvent(new Event("resize")));
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [toggleLeft]);
 
   // Load preloaded config if available, otherwise load default config on mount.
   // After a successful preloaded-config fetch, check for a matching cache entry
@@ -143,6 +169,7 @@ export function AppShell() {
       {/* Header */}
       <header className="border-b border-border px-4 py-3 flex items-center justify-between">
         <div className="flex items-center gap-3">
+          <PaneToggle side="left" />
           <h1 className="text-xl font-bold">{headerTitle}</h1>
           <Button
             id="config-file-name-span"
@@ -198,12 +225,14 @@ export function AppShell() {
             {solverMode}
           </span>
         </div>
-        <Button
-          onClick={toggleTheme}
-          variant="secondary"
-          size="sm"
-          title={`Switch to ${theme === "light" ? "dark" : "light"} mode`}
-        >
+        <div className="flex items-center gap-2">
+          {scenariosAvailable && <PaneToggle side="right" />}
+          <Button
+            onClick={toggleTheme}
+            variant="secondary"
+            size="sm"
+            title={`Switch to ${theme === "light" ? "dark" : "light"} mode`}
+          >
           {theme === "light" ? (
             <span className="flex items-center gap-1.5">
               <svg
@@ -247,23 +276,45 @@ export function AppShell() {
               Light
             </span>
           )}
-        </Button>
+          </Button>
+        </div>
       </header>
 
-      {/* Main layout: 3-col left + 9-col right (12-col grid) */}
-      <div className="grid grid-cols-12 gap-4 p-4 max-w-[1600px] mx-auto">
-        {/* Left panel (3 cols) */}
-        <aside className="col-span-12 md:col-span-3 space-y-4">
-          <EditNetworkCard />
-          <SimulateCard />
-          <PropertiesPanel />
-        </aside>
+      {/* Main layout: collapsible + draggable left/right sidebars around a flex center. */}
+      <div className="flex w-full max-w-[1600px] mx-auto p-4 items-start">
+        {/* Left sidebar (Network / Simulate / Properties) */}
+        {!leftCollapsed && (
+          <>
+            <aside
+              style={{ width: leftWidth }}
+              className="shrink-0 space-y-4 overflow-y-auto max-h-[calc(100vh-5rem)] pr-1"
+            >
+              <EditNetworkCard />
+              <SimulateCard />
+              <PropertiesPanel />
+            </aside>
+            <PaneResizer side="left" />
+          </>
+        )}
 
-        {/* Right panel (9 cols) */}
-        <main className="col-span-12 space-y-4 md:col-span-9">
+        {/* Center panel (graph + results) */}
+        <main className="flex-1 min-w-0 space-y-4 px-1">
           <ReactorGraph />
           <ResultsTabs />
         </main>
+
+        {/* Right scenario-inspector pane (hidden when no store / collapsed) */}
+        {scenariosAvailable && !rightCollapsed && (
+          <>
+            <PaneResizer side="right" />
+            <aside
+              style={{ width: rightWidth }}
+              className="shrink-0 space-y-4 overflow-y-auto max-h-[calc(100vh-5rem)] pl-1"
+            >
+              <ScenarioPane />
+            </aside>
+          </>
+        )}
       </div>
 
       {/* Overlays and modals */}

--- a/frontend/src/components/layout/paneControls.tsx
+++ b/frontend/src/components/layout/paneControls.tsx
@@ -1,0 +1,73 @@
+import { PanelLeft, PanelRight } from "lucide-react";
+import { useLayoutStore } from "@/stores/layoutStore";
+
+/** Notify canvas-based components (Cytoscape, Plotly) that the layout changed. */
+function nudgeResize() {
+  window.dispatchEvent(new Event("resize"));
+}
+
+/** Header toggle button in the "collapse sidebar" style. */
+export function PaneToggle({ side }: { side: "left" | "right" }) {
+  const { leftCollapsed, rightCollapsed, toggleLeft, toggleRight } =
+    useLayoutStore();
+  const collapsed = side === "left" ? leftCollapsed : rightCollapsed;
+  const Icon = side === "left" ? PanelLeft : PanelRight;
+  const label = `${collapsed ? "Expand" : "Collapse"} ${side} sidebar`;
+  return (
+    <button
+      type="button"
+      onClick={() => {
+        side === "left" ? toggleLeft() : toggleRight();
+        // Let the flex layout settle, then re-fit canvases.
+        requestAnimationFrame(nudgeResize);
+      }}
+      title={`${label}${side === "left" ? " (Ctrl+B)" : ""}`}
+      aria-label={label}
+      aria-pressed={!collapsed}
+      className="inline-flex items-center justify-center rounded-md p-1.5 text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
+    >
+      <Icon size={18} />
+    </button>
+  );
+}
+
+/** Draggable vertical divider that resizes the adjacent sidebar. */
+export function PaneResizer({ side }: { side: "left" | "right" }) {
+  const { leftWidth, rightWidth, setLeftWidth, setRightWidth } =
+    useLayoutStore();
+
+  const onPointerDown = (e: React.PointerEvent) => {
+    e.preventDefault();
+    const startX = e.clientX;
+    const startW = side === "left" ? leftWidth : rightWidth;
+
+    const onMove = (ev: PointerEvent) => {
+      const delta = ev.clientX - startX;
+      if (side === "left") setLeftWidth(startW + delta);
+      else setRightWidth(startW - delta);
+    };
+    const onUp = () => {
+      window.removeEventListener("pointermove", onMove);
+      window.removeEventListener("pointerup", onUp);
+      document.body.style.cursor = "";
+      document.body.style.userSelect = "";
+      nudgeResize();
+    };
+    document.body.style.cursor = "col-resize";
+    document.body.style.userSelect = "none";
+    window.addEventListener("pointermove", onMove);
+    window.addEventListener("pointerup", onUp);
+  };
+
+  return (
+    <div
+      onPointerDown={onPointerDown}
+      role="separator"
+      aria-orientation="vertical"
+      title="Drag to resize"
+      className="group relative w-2 shrink-0 self-stretch cursor-col-resize select-none"
+    >
+      <div className="absolute inset-y-0 left-1/2 -translate-x-1/2 w-px bg-border group-hover:bg-blue-500 group-hover:w-0.5 transition-all" />
+    </div>
+  );
+}

--- a/frontend/src/components/panels/RunControl.tsx
+++ b/frontend/src/components/panels/RunControl.tsx
@@ -1,0 +1,200 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Check, ChevronDown } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/Button";
+import { getSweepInfo, getSweepStatus, startSweep, type SweepInfo } from "@/api/sweep";
+import { useScenarioStore } from "@/stores/scenarioStore";
+
+type RunMode = "sim" | "sweep";
+
+interface RunControlProps {
+  onRunSimulation: () => void;
+  isRunning: boolean;
+  runDisabled: boolean;
+}
+
+/**
+ * GitHub-merge-style split button: a primary action ("Run Simulation") with a
+ * caret dropdown to switch the action to "Run Sweep". Run Sweep is only
+ * selectable when the config declares a runnable ``sweeps:`` block (the reason
+ * is shown in the menu and on the button). Running a sweep streams progress and
+ * refreshes the Scenario Pane on completion.
+ */
+export function RunControl({ onRunSimulation, isRunning, runDisabled }: RunControlProps) {
+  const [runMode, setRunMode] = useState<RunMode>("sim");
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [sweep, setSweep] = useState<SweepInfo | null>(null);
+  const [sweeping, setSweeping] = useState(false);
+  const [progress, setProgress] = useState<{ current: number; total: number }>({
+    current: 0,
+    total: 0,
+  });
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const refreshScenarios = useScenarioStore((s) => s.refresh);
+
+  const loadSweepInfo = useCallback(() => {
+    getSweepInfo()
+      .then(setSweep)
+      .catch(() => setSweep(null));
+  }, []);
+
+  useEffect(() => {
+    loadSweepInfo();
+    return () => {
+      if (pollRef.current) clearInterval(pollRef.current);
+    };
+  }, [loadSweepInfo]);
+
+  const canSweep = Boolean(sweep?.can_run);
+  // If the chosen mode is no longer valid, fall back to simulation.
+  const effectiveMode: RunMode = runMode === "sweep" && canSweep ? "sweep" : "sim";
+
+  const handleRunSweep = useCallback(() => {
+    setSweeping(true);
+    setProgress({ current: 0, total: sweep?.n_scenarios ?? 0 });
+    startSweep()
+      .then(() => {
+        pollRef.current = setInterval(() => {
+          getSweepStatus()
+            .then((st) => {
+              if (st.status === "running") {
+                setProgress({ current: st.current ?? 0, total: st.total ?? 0 });
+              } else {
+                if (pollRef.current) clearInterval(pollRef.current);
+                setSweeping(false);
+                if (st.status === "done") {
+                  toast.success("Sweep complete — scenarios updated");
+                  void refreshScenarios();
+                  loadSweepInfo();
+                } else {
+                  toast.error(`Sweep failed: ${st.message ?? "unknown error"}`);
+                }
+              }
+            })
+            .catch(() => {
+              if (pollRef.current) clearInterval(pollRef.current);
+              setSweeping(false);
+            });
+        }, 1000);
+      })
+      .catch((e) => {
+        setSweeping(false);
+        toast.error(e instanceof Error ? e.message : String(e));
+      });
+  }, [sweep, refreshScenarios, loadSweepInfo]);
+
+  const primaryLabel =
+    effectiveMode === "sweep"
+      ? sweeping
+        ? `Sweeping… ${progress.current}/${progress.total}`
+        : `Run Sweep (${sweep?.n_scenarios ?? 0} scenarios)`
+      : isRunning
+        ? "Running…"
+        : "Run Simulation (Ctrl+Enter)";
+
+  const primaryDisabled =
+    effectiveMode === "sweep" ? sweeping || isRunning || !canSweep : runDisabled;
+  const variant = primaryDisabled ? "muted" : "success";
+
+  const onPrimary = () => {
+    if (effectiveMode === "sweep") handleRunSweep();
+    else onRunSimulation();
+  };
+
+  return (
+    <div className="relative w-full">
+      <div className="flex w-full">
+        <Button
+          id="run-primary"
+          onClick={onPrimary}
+          disabled={primaryDisabled}
+          variant={variant}
+          className="flex-1 rounded-r-none"
+        >
+          {primaryLabel}
+        </Button>
+        <Button
+          id="run-mode-caret"
+          onClick={() => setMenuOpen((o) => !o)}
+          disabled={isRunning || sweeping}
+          variant={variant}
+          className="rounded-l-none border-l border-black/15 px-2"
+          aria-label="Choose run action"
+          aria-haspopup="menu"
+          aria-expanded={menuOpen}
+        >
+          <ChevronDown size={16} />
+        </Button>
+      </div>
+
+      {menuOpen && (
+        <>
+          <div className="fixed inset-0 z-10" onClick={() => setMenuOpen(false)} />
+          <div
+            role="menu"
+            className="absolute right-0 z-20 mt-1 w-72 rounded-md border border-border bg-card shadow-lg overflow-hidden"
+          >
+            <RunModeItem
+              active={effectiveMode === "sim"}
+              title="Run Simulation"
+              description="Solve the single reactor as configured."
+              onClick={() => {
+                setRunMode("sim");
+                setMenuOpen(false);
+              }}
+            />
+            <div className="border-t border-border" />
+            <RunModeItem
+              active={effectiveMode === "sweep"}
+              title="Run Sweep"
+              description={sweep?.reason ?? "No sweep in this config"}
+              disabled={!canSweep}
+              onClick={() => {
+                setRunMode("sweep");
+                setMenuOpen(false);
+              }}
+            />
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+function RunModeItem({
+  active,
+  title,
+  description,
+  disabled,
+  onClick,
+}: {
+  active: boolean;
+  title: string;
+  description: string;
+  disabled?: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      role="menuitemradio"
+      aria-checked={active}
+      disabled={disabled}
+      onClick={onClick}
+      className={[
+        "w-full text-left px-3 py-2.5 flex gap-2",
+        disabled
+          ? "opacity-50 cursor-not-allowed"
+          : "hover:bg-muted cursor-pointer",
+      ].join(" ")}
+    >
+      <span className="w-4 shrink-0 pt-0.5 text-primary">
+        {active && <Check size={14} />}
+      </span>
+      <span className="min-w-0">
+        <span className="block text-sm font-semibold text-foreground">{title}</span>
+        <span className="block text-xs text-muted-foreground">{description}</span>
+      </span>
+    </button>
+  );
+}

--- a/frontend/src/components/panels/RunControl.tsx
+++ b/frontend/src/components/panels/RunControl.tsx
@@ -37,7 +37,7 @@ export function RunControl({ onRunSimulation, isRunning, runDisabled }: RunContr
     getSweepInfo()
       .then((info) => {
         setSweep(info);
-        // `bloc --sweep` GUI mode: default the split button to Run Sweep (once).
+        // `--sweep` GUI mode: default the split button to Run Sweep (once).
         if (!appliedDefault.current && info.default && info.can_run) {
           appliedDefault.current = true;
           setRunMode("sweep");

--- a/frontend/src/components/panels/RunControl.tsx
+++ b/frontend/src/components/panels/RunControl.tsx
@@ -30,11 +30,19 @@ export function RunControl({ onRunSimulation, isRunning, runDisabled }: RunContr
     total: 0,
   });
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const appliedDefault = useRef(false);
   const refreshScenarios = useScenarioStore((s) => s.refresh);
 
   const loadSweepInfo = useCallback(() => {
     getSweepInfo()
-      .then(setSweep)
+      .then((info) => {
+        setSweep(info);
+        // `bloc --sweep` GUI mode: default the split button to Run Sweep (once).
+        if (!appliedDefault.current && info.default && info.can_run) {
+          appliedDefault.current = true;
+          setRunMode("sweep");
+        }
+      })
       .catch(() => setSweep(null));
   }, []);
 

--- a/frontend/src/components/panels/ScenarioPane.tsx
+++ b/frontend/src/components/panels/ScenarioPane.tsx
@@ -1,21 +1,87 @@
-import { useEffect } from "react";
+import { type KeyboardEvent, useEffect, useRef, useState } from "react";
 import { useScenarioStore } from "@/stores/scenarioStore";
 
+/** Compact relative-time label, e.g. "just now", "2 min ago", "3 h ago". */
+function timeAgo(tsSeconds: number | undefined, nowMs: number): string {
+  if (!tsSeconds) return "";
+  const s = Math.max(0, nowMs / 1000 - tsSeconds);
+  if (s < 45) return "just now";
+  if (s < 90) return "1 min ago";
+  if (s < 3600) return `${Math.round(s / 60)} min ago`;
+  if (s < 5400) return "1 h ago";
+  if (s < 86400) return `${Math.round(s / 3600)} h ago`;
+  return `${Math.round(s / 86400)} d ago`;
+}
+
 /**
- * Right-side pane listing precomputed scenarios (trajectories) from the active
- * HDF5 store. Selecting one loads its trajectory into the results view without
- * rebuilding the network (all scenarios share one topology). Renders nothing
- * when no store is available, so ordinary configs are unaffected.
+ * Right-side pane listing precomputed scenarios from the active HDF5 store.
+ * Selecting one loads its trajectory (no network rebuild). Supports up/down
+ * arrow navigation, shows when each scenario was computed, and bumps when the
+ * list is (re)computed by a sweep. Renders nothing when no store is available.
  */
 export function ScenarioPane() {
-  const { available, scenarios, activeId, loading, error, refresh, setActive } =
-    useScenarioStore();
+  const {
+    available,
+    scenarios,
+    createdAt,
+    activeId,
+    loading,
+    error,
+    refresh,
+    setActive,
+  } = useScenarioStore();
+
+  // Tick so relative-time labels stay fresh without a reload.
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    const t = setInterval(() => setNow(Date.now()), 30_000);
+    return () => clearInterval(t);
+  }, []);
 
   useEffect(() => {
     void refresh();
   }, [refresh]);
 
+  // One-shot bump when a sweep (re)computes the store (createdAt changes).
+  const [bump, setBump] = useState(false);
+  const prevCreated = useRef<number | undefined>(undefined);
+  useEffect(() => {
+    if (createdAt === undefined) return;
+    if (prevCreated.current !== undefined && createdAt !== prevCreated.current) {
+      setBump(true);
+      setNow(Date.now());
+      const t = setTimeout(() => setBump(false), 900);
+      prevCreated.current = createdAt;
+      return () => clearTimeout(t);
+    }
+    prevCreated.current = createdAt;
+  }, [createdAt]);
+
   if (!available || scenarios.length === 0) return null;
+
+  const onKeyDown = (e: KeyboardEvent<HTMLUListElement>) => {
+    if (e.key !== "ArrowDown" && e.key !== "ArrowUp") return;
+    e.preventDefault();
+    const idx = scenarios.findIndex((s) => s.id === activeId);
+    let next =
+      idx === -1
+        ? e.key === "ArrowDown"
+          ? 0
+          : scenarios.length - 1
+        : e.key === "ArrowDown"
+          ? idx + 1
+          : idx - 1;
+    next = Math.max(0, Math.min(scenarios.length - 1, next));
+    const target = scenarios[next];
+    if (!target) return;
+    void setActive(target.id);
+    // Focus synchronously on the already-rendered node — a requestAnimationFrame
+    // here loses the race against the post-load re-render, leaving the focus ring
+    // stuck on the previous row while the active highlight moves.
+    const el = document.getElementById(`scenario-${target.id}`);
+    el?.focus();
+    el?.scrollIntoView({ block: "nearest" });
+  };
 
   return (
     <div className="rounded-lg border border-border bg-card p-4 space-y-3">
@@ -24,15 +90,22 @@ export function ScenarioPane() {
         <span className="text-xs text-muted-foreground">{scenarios.length}</span>
       </div>
       {error && <p className="text-xs text-red-500">{error}</p>}
-      <ul className="space-y-1 max-h-[70vh] overflow-y-auto pr-1">
+      <ul
+        onKeyDown={onKeyDown}
+        className={`space-y-1 max-h-[70vh] overflow-y-auto pr-1${
+          bump ? " animate-[scenarioBump_0.6s_ease-out]" : ""
+        }`}
+      >
         {scenarios.map((s) => {
           const isActive = s.id === activeId;
+          const ago = timeAgo(s.computed_at ?? createdAt, now);
           return (
             <li key={s.id}>
               <button
+                id={`scenario-${s.id}`}
                 type="button"
                 onClick={() => void setActive(s.id)}
-                disabled={loading}
+                aria-busy={loading && isActive}
                 title={
                   s.final_temperature_K != null
                     ? `T_final ≈ ${Math.round(s.final_temperature_K)} K` +
@@ -42,14 +115,21 @@ export function ScenarioPane() {
                     : undefined
                 }
                 className={[
-                  "w-full text-left rounded-md px-2 py-1.5 text-xs transition-colors",
-                  "border",
+                  "w-full text-left rounded-md px-2 py-1.5 text-xs transition-colors border",
+                  "focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400",
                   isActive
-                    ? "border-blue-500 bg-blue-500/10 text-foreground"
+                    ? "border-blue-500 bg-blue-500/20 text-foreground"
                     : "border-transparent hover:bg-muted text-foreground",
                 ].join(" ")}
               >
-                <div className="font-medium">{s.label}</div>
+                <div className="flex items-center justify-between gap-2">
+                  <span className="font-medium truncate">{s.label}</span>
+                  {ago && (
+                    <span className="shrink-0 text-[10px] text-muted-foreground">
+                      {ago}
+                    </span>
+                  )}
+                </div>
                 {s.reactor_mode && (
                   <div className="text-[10px] text-muted-foreground">
                     {s.reactor_mode}

--- a/frontend/src/components/panels/ScenarioPane.tsx
+++ b/frontend/src/components/panels/ScenarioPane.tsx
@@ -1,0 +1,65 @@
+import { useEffect } from "react";
+import { useScenarioStore } from "@/stores/scenarioStore";
+
+/**
+ * Right-side pane listing precomputed scenarios (trajectories) from the active
+ * HDF5 store. Selecting one loads its trajectory into the results view without
+ * rebuilding the network (all scenarios share one topology). Renders nothing
+ * when no store is available, so ordinary configs are unaffected.
+ */
+export function ScenarioPane() {
+  const { available, scenarios, activeId, loading, error, refresh, setActive } =
+    useScenarioStore();
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  if (!available || scenarios.length === 0) return null;
+
+  return (
+    <div className="rounded-lg border border-border bg-card p-4 space-y-3">
+      <div className="flex items-center justify-between">
+        <h3 className="font-semibold text-sm text-foreground">Scenarios</h3>
+        <span className="text-xs text-muted-foreground">{scenarios.length}</span>
+      </div>
+      {error && <p className="text-xs text-red-500">{error}</p>}
+      <ul className="space-y-1 max-h-[70vh] overflow-y-auto pr-1">
+        {scenarios.map((s) => {
+          const isActive = s.id === activeId;
+          return (
+            <li key={s.id}>
+              <button
+                type="button"
+                onClick={() => void setActive(s.id)}
+                disabled={loading}
+                title={
+                  s.final_temperature_K != null
+                    ? `T_final ≈ ${Math.round(s.final_temperature_K)} K` +
+                      (s.solid_carbon_yield_pct != null
+                        ? ` · C(s) ${s.solid_carbon_yield_pct.toFixed(1)}%`
+                        : "")
+                    : undefined
+                }
+                className={[
+                  "w-full text-left rounded-md px-2 py-1.5 text-xs transition-colors",
+                  "border",
+                  isActive
+                    ? "border-blue-500 bg-blue-500/10 text-foreground"
+                    : "border-transparent hover:bg-muted text-foreground",
+                ].join(" ")}
+              >
+                <div className="font-medium">{s.label}</div>
+                {s.reactor_mode && (
+                  <div className="text-[10px] text-muted-foreground">
+                    {s.reactor_mode}
+                  </div>
+                )}
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/src/components/panels/SimulateCard.tsx
+++ b/frontend/src/components/panels/SimulateCard.tsx
@@ -5,6 +5,7 @@ import { fetchGuiActions, runGuiAction } from "@/api/guiActions";
 import { startSimulation } from "@/api/simulations";
 import { checkSimulationCache } from "@/api/resultCache";
 import { Button } from "@/components/ui/Button";
+import { RunControl } from "./RunControl";
 import type { GuiActionMeta } from "@/types/guiAction";
 import { toast } from "sonner";
 import { SolverDetailsModal } from "./SolverDetailsModal";
@@ -273,7 +274,6 @@ export function SimulateCard() {
   );
 
   const runDisabled = isRunning || config.nodes.length === 0;
-  const runVariant = runDisabled ? "muted" : "success";
   const kinds = mode === "steady" ? STEADY_KINDS : TRANSIENT_KINDS;
 
   return (
@@ -349,15 +349,11 @@ export function SimulateCard() {
         onTimeStepChange={setTimeStep}
       />
 
-      <Button
-        id="run-simulation"
-        onClick={handleRun}
-        disabled={runDisabled}
-        variant={runVariant}
-        className="w-full"
-      >
-        {isRunning ? "Running..." : "Run Simulation (Ctrl+Enter)"}
-      </Button>
+      <RunControl
+        onRunSimulation={handleRun}
+        isRunning={isRunning}
+        runDisabled={runDisabled}
+      />
 
       {simulationId && (
         <Button

--- a/frontend/src/hooks/useScenarioFocus.ts
+++ b/frontend/src/hooks/useScenarioFocus.ts
@@ -13,6 +13,8 @@ import { useScenarioStore } from "@/stores/scenarioStore";
  */
 export function useScenarioFocus() {
   useEffect(() => {
+    // No EventSource in non-browser envs (jsdom/SSR) — skip cleanly.
+    if (typeof EventSource === "undefined") return;
     const source = new EventSource(SCENARIO_FOCUS_STREAM_URL);
 
     source.addEventListener("focus", (e: MessageEvent) => {

--- a/frontend/src/hooks/useScenarioFocus.ts
+++ b/frontend/src/hooks/useScenarioFocus.ts
@@ -1,0 +1,35 @@
+import { useEffect } from "react";
+import { SCENARIO_FOCUS_STREAM_URL } from "@/api/scenarios";
+import { useScenarioStore } from "@/stores/scenarioStore";
+
+/**
+ * Subscribe to the backend scenario-focus stream so an external tool (e.g. a
+ * standalone result dashboard) can drive this GUI to load a scenario live.
+ *
+ * On each ``focus`` event it calls the existing ``setActive`` sink — the same
+ * path the Scenario Pane uses — so the trajectory appears in the Plots tab with
+ * no page reload. Harmless when no scenario store is configured (the id simply
+ * won't resolve).
+ */
+export function useScenarioFocus() {
+  useEffect(() => {
+    const source = new EventSource(SCENARIO_FOCUS_STREAM_URL);
+
+    source.addEventListener("focus", (e: MessageEvent) => {
+      try {
+        const { scenario_id } = JSON.parse(e.data) as { scenario_id: string };
+        if (scenario_id) {
+          void useScenarioStore.getState().setActive(scenario_id);
+        }
+      } catch {
+        /* ignore malformed events */
+      }
+    });
+
+    source.onerror = () => {
+      // Transient disconnect — EventSource auto-reconnects.
+    };
+
+    return () => source.close();
+  }, []);
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -88,3 +88,10 @@ body {
 * {
   border-color: var(--color-border);
 }
+
+/* One-shot "bump" played when the Scenario Pane refreshes after a sweep. */
+@keyframes scenarioBump {
+  0% { transform: scale(0.985); opacity: 0.55; }
+  55% { transform: scale(1.012); }
+  100% { transform: scale(1); opacity: 1; }
+}

--- a/frontend/src/stores/layoutStore.ts
+++ b/frontend/src/stores/layoutStore.ts
@@ -1,0 +1,74 @@
+import { create } from "zustand";
+
+/** Persisted left/right sidebar collapse state and widths (Claude-desktop style). */
+const STORAGE_KEY = "boulder-layout";
+const LEFT_DEFAULT = 320;
+const RIGHT_DEFAULT = 250;
+const MIN_WIDTH = 180;
+const MAX_WIDTH = 600;
+
+interface LayoutState {
+  leftCollapsed: boolean;
+  rightCollapsed: boolean;
+  leftWidth: number;
+  rightWidth: number;
+  toggleLeft: () => void;
+  toggleRight: () => void;
+  setLeftWidth: (w: number) => void;
+  setRightWidth: (w: number) => void;
+}
+
+function clampWidth(w: number): number {
+  return Math.max(MIN_WIDTH, Math.min(MAX_WIDTH, Math.round(w)));
+}
+
+function load(): Partial<LayoutState> {
+  if (typeof window === "undefined") return {};
+  try {
+    return JSON.parse(localStorage.getItem(STORAGE_KEY) || "{}");
+  } catch {
+    return {};
+  }
+}
+
+function save(patch: Partial<LayoutState>): void {
+  if (typeof window === "undefined") return;
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ ...load(), ...patch }));
+  } catch {
+    /* ignore quota / disabled storage */
+  }
+}
+
+export const useLayoutStore = create<LayoutState>((set) => {
+  const init = load();
+  return {
+    leftCollapsed: Boolean(init.leftCollapsed),
+    rightCollapsed: Boolean(init.rightCollapsed),
+    leftWidth: clampWidth(init.leftWidth ?? LEFT_DEFAULT),
+    rightWidth: clampWidth(init.rightWidth ?? RIGHT_DEFAULT),
+
+    toggleLeft: () =>
+      set((s) => {
+        const leftCollapsed = !s.leftCollapsed;
+        save({ leftCollapsed });
+        return { leftCollapsed };
+      }),
+    toggleRight: () =>
+      set((s) => {
+        const rightCollapsed = !s.rightCollapsed;
+        save({ rightCollapsed });
+        return { rightCollapsed };
+      }),
+    setLeftWidth: (w) => {
+      const leftWidth = clampWidth(w);
+      save({ leftWidth });
+      set({ leftWidth });
+    },
+    setRightWidth: (w) => {
+      const rightWidth = clampWidth(w);
+      save({ rightWidth });
+      set({ rightWidth });
+    },
+  };
+});

--- a/frontend/src/stores/scenarioStore.ts
+++ b/frontend/src/stores/scenarioStore.ts
@@ -1,0 +1,70 @@
+import { create } from "zustand";
+import {
+  fetchScenario,
+  listScenarios,
+  type ScenarioMeta,
+} from "@/api/scenarios";
+import { useSimulationStore } from "./simulationStore";
+import { useSelectionStore } from "./selectionStore";
+
+interface ScenarioState {
+  available: boolean;
+  scenarios: ScenarioMeta[];
+  activeId: string | null;
+  loading: boolean;
+  error: string | null;
+
+  /** Fetch the scenario list for the active store (no-op-safe if none). */
+  refresh: () => Promise<void>;
+  /** Load a scenario's trajectory and push it into the simulation results. */
+  setActive: (id: string) => Promise<void>;
+}
+
+export const useScenarioStore = create<ScenarioState>((set) => ({
+  available: false,
+  scenarios: [],
+  activeId: null,
+  loading: false,
+  error: null,
+
+  refresh: async () => {
+    try {
+      const resp = await listScenarios();
+      set({
+        available: resp.available,
+        scenarios: resp.scenarios ?? [],
+      });
+    } catch {
+      // No store / API not ready: the pane simply stays hidden.
+      set({ available: false, scenarios: [] });
+    }
+  },
+
+  setActive: async (id) => {
+    set({ loading: true, error: null, activeId: id });
+    try {
+      const result = await fetchScenario(id);
+      // Same sink the cached-result path uses → swaps result data only, no
+      // network rebuild (the graph topology is unchanged).
+      useSimulationStore.getState().setResults(result);
+
+      // Auto-select the reactor node so the Plots tab shows the trajectory
+      // without the user having to click the (single) node first. Keep an
+      // existing valid selection if the user already picked a real reactor.
+      const series = result.reactors_series ?? {};
+      const ids = Object.keys(series);
+      const sel = useSelectionStore.getState();
+      const current = sel.selectedElement;
+      const currentValid =
+        current?.type === "node" &&
+        ids.includes(String((current.data as { id?: unknown }).id));
+      if (ids.length > 0 && !currentValid) {
+        sel.setSelectedElement({ type: "node", data: { id: ids[0] } });
+      }
+    } catch (e) {
+      set({ error: e instanceof Error ? e.message : String(e) });
+    } finally {
+      set({ loading: false });
+    }
+  },
+}));

--- a/frontend/src/stores/scenarioStore.ts
+++ b/frontend/src/stores/scenarioStore.ts
@@ -10,6 +10,8 @@ import { useSelectionStore } from "./selectionStore";
 interface ScenarioState {
   available: boolean;
   scenarios: ScenarioMeta[];
+  /** Unix seconds the store was written; drives the "computed X ago" label. */
+  createdAt?: number;
   activeId: string | null;
   loading: boolean;
   error: string | null;
@@ -33,6 +35,7 @@ export const useScenarioStore = create<ScenarioState>((set) => ({
       set({
         available: resp.available,
         scenarios: resp.scenarios ?? [],
+        createdAt: resp.created_at ?? undefined,
       });
     } catch {
       // No store / API not ready: the pane simply stays hidden.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ classifiers = [
 ]
 dependencies = [
   "cantera>=3.0.0",
+  "h5py>=3.0.0",
   "python-dotenv>=1.0.0",
   "PyYAML>=6.0",
   "types-PyYAML>=6.0.0",

--- a/tests/test_payload_store.py
+++ b/tests/test_payload_store.py
@@ -193,6 +193,35 @@ def test_spring_like_multireactor_mechanism_switch(tmp_path: Path):
     assert out["sankey_nodes"] == ["torch", "pfr", "C(s)"]
 
 
+def test_collection_composite_per_scenario(tmp_path: Path):
+    """Many composites in one file, namespaced by scenario id; appends don't wipe
+    siblings; a multi-reactor scenario round-trips."""
+    import h5py
+
+    p = tmp_path / "scenarios.h5"
+    s1 = _real_state_series(4, with_t=True)
+    write_payload(p, _payload({"reactor": s1}), MECH, group="T0_1273K", fresh=False)
+    # Second scenario, multi-reactor, appended — must not clobber the first.
+    s2a = _real_state_series(3, with_t=True)
+    s2b = _real_state_series(3, with_t=True)
+    write_payload(
+        p,
+        _payload({"torch": s2a, "pfr": s2b}, reactor_reports={"torch": {"q": 1}}),
+        MECH,
+        group="T0_1573K",
+        fresh=False,
+    )
+
+    with h5py.File(p, "r") as h:
+        assert "T0_1273K" in h and "T0_1573K" in h  # both scenarios present
+
+    g1 = read_payload(p, group="T0_1273K")
+    assert np.allclose(g1["reactors_series"]["reactor"]["T"], s1["T"])
+    g2 = read_payload(p, group="T0_1573K")
+    assert set(g2["reactors_series"]) == {"torch", "pfr"}
+    assert g2["reactor_reports"] == {"torch": {"q": 1}}
+
+
 def test_shared_builder(tmp_path: Path):
     gas = ct.Solution(MECH)
     n = 4

--- a/tests/test_payload_store.py
+++ b/tests/test_payload_store.py
@@ -1,0 +1,204 @@
+"""Round-trip tests for the composite HDF5 payload store (all three tiers)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import cantera as ct
+import numpy as np
+import pytest
+
+from boulder.payload_store import (
+    gui_payload_from_solution_array,
+    read_payload,
+    write_payload,
+)
+
+MECH = "gri30.yaml"
+
+
+def _real_state_series(n: int, with_t: bool) -> dict:
+    """A physically-real, normalised series built by actually setting the gas."""
+    gas = ct.Solution(MECH)
+    T = [1000.0 + 50 * i for i in range(n)]
+    P = [101325.0] * n
+    rows = []
+    for i in range(n):
+        gas.TPX = T[i], P[i], {"CH4": 1.0 + i, "O2": 2.0, "N2": 7.5}
+        rows.append(gas.X.copy())
+    Xmat = np.array(rows)
+    names = gas.species_names
+    series = {
+        "T": T,
+        "P": P,
+        "X": {sp: [float(Xmat[i, j]) for i in range(n)] for j, sp in enumerate(names)},
+    }
+    if with_t:
+        series["t"] = [1e-3 * i for i in range(n)]
+    return series
+
+
+def _payload(reactors: dict, **extra) -> dict:
+    return {
+        "status": "complete",
+        "is_complete": True,
+        "times": [0.0],
+        "reactors_series": reactors,
+        "reactor_reports": {},
+        "connection_reports": {},
+        "summary": [],
+        "sankey_links": None,
+        "sankey_nodes": None,
+        **extra,
+    }
+
+
+def test_solution_tier_trajectory(tmp_path: Path):
+    """A normalised state series WITH t → solution tier; Y derived; X exact."""
+    s = _real_state_series(6, with_t=True)
+    s["is_residence"] = True
+    p = tmp_path / "result.h5"
+    write_payload(p, _payload({"reactor": s}), MECH)
+    out = read_payload(p)
+    rt = out["reactors_series"]["reactor"]
+    assert np.allclose(rt["T"], s["T"]) and np.allclose(rt["P"], s["P"])
+    assert "t" in rt and np.allclose(rt["t"], s["t"])
+    assert np.allclose(rt["X"]["CH4"], s["X"]["CH4"])
+    assert abs(sum(v[0] for v in rt["Y"].values()) - 1.0) < 1e-9  # Y derived
+    assert rt["is_residence"] is True
+
+
+def test_solution_tier_steady_no_t(tmp_path: Path):
+    """A normalised steady series (no t) still uses solution tier (had_t:false)."""
+    s = _real_state_series(1, with_t=False)
+    p = tmp_path / "result.h5"
+    write_payload(p, _payload({"reactor": s}), MECH)
+    out = read_payload(p)
+    rt = out["reactors_series"]["reactor"]
+    assert "t" not in rt  # original had no time axis → not fabricated
+    assert np.allclose(rt["T"], s["T"])
+
+
+def test_arrays_tier_off_mechanism(tmp_path: Path):
+    """Species the mechanism can't represent → arrays tier, no Solution needed."""
+    s = {"T": [1200.0, 1300.0], "P": [1e5, 1e5],
+         "X": {"madeup_species": [0.4, 0.5], "other": [0.6, 0.5]},
+         "t": [0.0, 1.0], "is_psr": True}
+    p = tmp_path / "result.h5"
+    write_payload(p, _payload({"r": s}), MECH)
+    # No mechanism passed on read → arrays tier must not need one.
+    out = read_payload(p, mechanism_override="")
+    rt = out["reactors_series"]["r"]
+    assert np.allclose(rt["X"]["madeup_species"], [0.4, 0.5])
+    assert rt["is_psr"] is True and np.allclose(rt["t"], [0.0, 1.0])
+
+
+def test_arrays_tier_non_normalised_X(tmp_path: Path):
+    """In-mechanism but X rows don't sum to 1 → arrays tier (no silent renorm, R2)."""
+    s = {"T": [1200.0], "P": [1e5], "X": {"CH4": [0.4], "O2": [0.4]}, "t": [0.0]}
+    p = tmp_path / "result.h5"
+    write_payload(p, _payload({"r": s}), MECH)
+    out = read_payload(p)
+    rt = out["reactors_series"]["r"]
+    # Preserved exactly (0.4/0.4), NOT renormalised to 0.5/0.5.
+    assert np.allclose(rt["X"]["CH4"], [0.4]) and np.allclose(rt["X"]["O2"], [0.4])
+
+
+def test_raw_tier_non_state(tmp_path: Path):
+    """A non-state structure → raw tier, verbatim."""
+    s = {"weird": [1, 2, 3], "note": "spatial-ish"}
+    p = tmp_path / "result.h5"
+    write_payload(p, _payload({"r": s}), MECH)
+    out = read_payload(p)
+    assert out["reactors_series"]["r"] == s
+
+
+def test_spatial_series_stored_natively(tmp_path: Path):
+    """A SPRING-style spatial PFR profile (x, is_spatial, fbs_convergence) is a
+    state sequence: x rides as a per-state extra column (native, NOT raw JSON),
+    while the per-iteration fbs_convergence + flags ride in meta."""
+    import h5py
+
+    s = _real_state_series(4, with_t=False)
+    s["x"] = [0.0, 0.1, 0.2, 0.3]            # axial position [m], per-state
+    s["is_spatial"] = True
+    s["fbs_convergence"] = [12.0, 3.0, 0.5]  # per-FBS-iteration, NOT per-state
+    p = tmp_path / "result.h5"
+    write_payload(p, _payload({"pfr": s}), MECH)
+
+    with h5py.File(p, "r") as h:  # stored natively → a Cantera SolutionArray group
+        assert "r0" in h
+    out = read_payload(p)
+    rt = out["reactors_series"]["pfr"]
+    assert rt["x"] == s["x"]                  # position axis preserved as extra col
+    assert rt.get("is_spatial") is True       # flag preserved via meta
+    assert rt["fbs_convergence"] == s["fbs_convergence"]  # off-shape array via meta
+
+
+def test_derived_artifacts_preserved(tmp_path: Path):
+    """Sankey / reports / summary survive the round-trip."""
+    s = _real_state_series(3, with_t=True)
+    payload = _payload(
+        {"reactor": s},
+        sankey_nodes=["a", "b"],
+        sankey_links={"source": [0], "target": [1], "value": [1.0]},
+        reactor_reports={"reactor": {"note": "x"}},
+        code_str="# code",
+    )
+    p = tmp_path / "result.h5"
+    write_payload(p, payload, MECH)
+    out = read_payload(p)
+    assert out["sankey_nodes"] == ["a", "b"]
+    assert out["reactor_reports"] == {"reactor": {"note": "x"}}
+    assert out["code_str"] == "# code"
+
+
+def test_unresolved_mechanism_raises(tmp_path: Path):
+    """A solution-tier entry with an unloadable mechanism raises (caller handles, R1)."""
+    s = _real_state_series(3, with_t=True)
+    p = tmp_path / "result.h5"
+    write_payload(p, _payload({"reactor": s}), MECH)
+    with pytest.raises(Exception):
+        read_payload(p, mechanism_override="no_such_mechanism_xyz.yaml")
+
+
+def test_spring_like_multireactor_mechanism_switch(tmp_path: Path):
+    """SPRING shape: a multi-reactor, mechanism-switch network + reports/sankey.
+
+    One stage on the cache mechanism (gri30) → solution tier; a downstream stage
+    on a *different* species set (the mechanism can't represent it) → arrays tier,
+    restorable with NO Solution. Both round-trip; derived artifacts preserved.
+    """
+    torch = _real_state_series(4, with_t=True)          # gri30 → solution tier
+    pfr = {                                              # foreign species → arrays tier
+        "T": [1800.0, 1700.0, 1600.0],
+        "P": [1e5, 1e5, 1e5],
+        "X": {"C2H2": [0.3, 0.35, 0.4], "H2": [0.5, 0.5, 0.5], "C(s)": [0.2, 0.15, 0.1]},
+        "Y": {"C2H2": [0.3, 0.35, 0.4], "H2": [0.4, 0.4, 0.4], "C(s)": [0.3, 0.25, 0.2]},
+        "t": [0.0, 0.5, 1.0],
+    }
+    payload = _payload(
+        {"torch": torch, "pfr": pfr},
+        reactor_reports={"torch": {"T_out": 2000.0}, "pfr": {"C_yield": 0.42}},
+        sankey_nodes=["torch", "pfr", "C(s)"],
+        sankey_links={"source": [0, 1], "target": [1, 2], "value": [1.0, 0.4]},
+    )
+    p = tmp_path / "result.h5"
+    write_payload(p, payload, MECH)
+    out = read_payload(p)  # gri30 available; pfr (arrays) doesn't need it anyway
+    assert np.allclose(out["reactors_series"]["torch"]["T"], torch["T"])
+    assert np.allclose(out["reactors_series"]["pfr"]["X"]["C2H2"], pfr["X"]["C2H2"])
+    assert np.allclose(out["reactors_series"]["pfr"]["Y"]["H2"], pfr["Y"]["H2"])
+    assert out["reactor_reports"]["pfr"]["C_yield"] == 0.42
+    assert out["sankey_nodes"] == ["torch", "pfr", "C(s)"]
+
+
+def test_shared_builder(tmp_path: Path):
+    gas = ct.Solution(MECH)
+    n = 4
+    states = ct.SolutionArray(gas, shape=(n,), extra={"t": np.arange(n, dtype=float)})
+    states.TP = [1000.0] * n, [1e5] * n
+    gp = gui_payload_from_solution_array(states, "reactor")
+    assert gp["is_complete"] and "reactor" in gp["reactors_series"]
+    assert gp["reactors_series"]["reactor"]["is_residence"] is True
+    assert len(gp["times"]) == n

--- a/tests/test_payload_store.py
+++ b/tests/test_payload_store.py
@@ -18,7 +18,7 @@ MECH = "gri30.yaml"
 
 
 def _real_state_series(n: int, with_t: bool) -> dict:
-    """A physically-real, normalised series built by actually setting the gas."""
+    """Build a physically-real, normalised series by actually setting the gas."""
     gas = ct.Solution(MECH)
     T = [1000.0 + 50 * i for i in range(n)]
     P = [101325.0] * n
@@ -81,9 +81,13 @@ def test_solution_tier_steady_no_t(tmp_path: Path):
 
 def test_arrays_tier_off_mechanism(tmp_path: Path):
     """Species the mechanism can't represent → arrays tier, no Solution needed."""
-    s = {"T": [1200.0, 1300.0], "P": [1e5, 1e5],
-         "X": {"madeup_species": [0.4, 0.5], "other": [0.6, 0.5]},
-         "t": [0.0, 1.0], "is_psr": True}
+    s = {
+        "T": [1200.0, 1300.0],
+        "P": [1e5, 1e5],
+        "X": {"madeup_species": [0.4, 0.5], "other": [0.6, 0.5]},
+        "t": [0.0, 1.0],
+        "is_psr": True,
+    }
     p = tmp_path / "result.h5"
     write_payload(p, _payload({"r": s}), MECH)
     # No mechanism passed on read → arrays tier must not need one.
@@ -114,13 +118,15 @@ def test_raw_tier_non_state(tmp_path: Path):
 
 
 def test_spatial_series_stored_natively(tmp_path: Path):
-    """A SPRING-style spatial PFR profile (x, is_spatial, fbs_convergence) is a
-    state sequence: x rides as a per-state extra column (native, NOT raw JSON),
-    while the per-iteration fbs_convergence + flags ride in meta."""
+    """A SPRING-style spatial PFR profile is stored as a native state sequence.
+
+    x rides as a per-state extra column (native, NOT raw JSON), while the
+    per-iteration fbs_convergence + flags ride in meta.
+    """
     import h5py
 
     s = _real_state_series(4, with_t=False)
-    s["x"] = [0.0, 0.1, 0.2, 0.3]            # axial position [m], per-state
+    s["x"] = [0.0, 0.1, 0.2, 0.3]  # axial position [m], per-state
     s["is_spatial"] = True
     s["fbs_convergence"] = [12.0, 3.0, 0.5]  # per-FBS-iteration, NOT per-state
     p = tmp_path / "result.h5"
@@ -130,8 +136,8 @@ def test_spatial_series_stored_natively(tmp_path: Path):
         assert "r0" in h
     out = read_payload(p)
     rt = out["reactors_series"]["pfr"]
-    assert rt["x"] == s["x"]                  # position axis preserved as extra col
-    assert rt.get("is_spatial") is True       # flag preserved via meta
+    assert rt["x"] == s["x"]  # position axis preserved as extra col
+    assert rt.get("is_spatial") is True  # flag preserved via meta
     assert rt["fbs_convergence"] == s["fbs_convergence"]  # off-shape array via meta
 
 
@@ -169,12 +175,20 @@ def test_spring_like_multireactor_mechanism_switch(tmp_path: Path):
     on a *different* species set (the mechanism can't represent it) → arrays tier,
     restorable with NO Solution. Both round-trip; derived artifacts preserved.
     """
-    torch = _real_state_series(4, with_t=True)          # gri30 → solution tier
-    pfr = {                                              # foreign species → arrays tier
+    torch = _real_state_series(4, with_t=True)  # gri30 → solution tier
+    pfr = {  # foreign species → arrays tier
         "T": [1800.0, 1700.0, 1600.0],
         "P": [1e5, 1e5, 1e5],
-        "X": {"C2H2": [0.3, 0.35, 0.4], "H2": [0.5, 0.5, 0.5], "C(s)": [0.2, 0.15, 0.1]},
-        "Y": {"C2H2": [0.3, 0.35, 0.4], "H2": [0.4, 0.4, 0.4], "C(s)": [0.3, 0.25, 0.2]},
+        "X": {
+            "C2H2": [0.3, 0.35, 0.4],
+            "H2": [0.5, 0.5, 0.5],
+            "C(s)": [0.2, 0.15, 0.1],
+        },
+        "Y": {
+            "C2H2": [0.3, 0.35, 0.4],
+            "H2": [0.4, 0.4, 0.4],
+            "C(s)": [0.3, 0.25, 0.2],
+        },
         "t": [0.0, 0.5, 1.0],
     }
     payload = _payload(
@@ -187,15 +201,17 @@ def test_spring_like_multireactor_mechanism_switch(tmp_path: Path):
     write_payload(p, payload, MECH)
     out = read_payload(p)  # gri30 available; pfr (arrays) doesn't need it anyway
     assert np.allclose(out["reactors_series"]["torch"]["T"], torch["T"])
-    assert np.allclose(out["reactors_series"]["pfr"]["X"]["C2H2"], pfr["X"]["C2H2"])
-    assert np.allclose(out["reactors_series"]["pfr"]["Y"]["H2"], pfr["Y"]["H2"])
+    assert np.allclose(out["reactors_series"]["pfr"]["X"]["C2H2"], pfr["X"]["C2H2"])  # type: ignore[index]
+    assert np.allclose(out["reactors_series"]["pfr"]["Y"]["H2"], pfr["Y"]["H2"])  # type: ignore[index]
     assert out["reactor_reports"]["pfr"]["C_yield"] == 0.42
     assert out["sankey_nodes"] == ["torch", "pfr", "C(s)"]
 
 
 def test_collection_composite_per_scenario(tmp_path: Path):
-    """Many composites in one file, namespaced by scenario id; appends don't wipe
-    siblings; a multi-reactor scenario round-trips."""
+    """Many composites in one file, namespaced by scenario id.
+
+    Appends don't wipe siblings; a multi-reactor scenario round-trips.
+    """
     import h5py
 
     p = tmp_path / "scenarios.h5"

--- a/tests/test_payload_store.py
+++ b/tests/test_payload_store.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
 import cantera as ct
 import numpy as np
@@ -118,7 +119,7 @@ def test_raw_tier_non_state(tmp_path: Path):
 
 
 def test_spatial_series_stored_natively(tmp_path: Path):
-    """A SPRING-style spatial PFR profile is stored as a native state sequence.
+    """A spatial reactor profile is stored as a native state sequence.
 
     x rides as a per-state extra column (native, NOT raw JSON), while the
     per-iteration fbs_convergence + flags ride in meta.
@@ -168,15 +169,15 @@ def test_unresolved_mechanism_raises(tmp_path: Path):
         read_payload(p, mechanism_override="no_such_mechanism_xyz.yaml")
 
 
-def test_spring_like_multireactor_mechanism_switch(tmp_path: Path):
-    """SPRING shape: a multi-reactor, mechanism-switch network + reports/sankey.
+def test_multireactor_mechanism_switch(tmp_path: Path):
+    """A multi-reactor, mechanism-switch network + reports/sankey.
 
     One stage on the cache mechanism (gri30) → solution tier; a downstream stage
     on a *different* species set (the mechanism can't represent it) → arrays tier,
     restorable with NO Solution. Both round-trip; derived artifacts preserved.
     """
-    torch = _real_state_series(4, with_t=True)  # gri30 → solution tier
-    pfr = {  # foreign species → arrays tier
+    upstream = _real_state_series(4, with_t=True)  # gri30 → solution tier
+    downstream: dict[str, Any] = {  # foreign species → arrays tier
         "T": [1800.0, 1700.0, 1600.0],
         "P": [1e5, 1e5, 1e5],
         "X": {
@@ -192,19 +193,26 @@ def test_spring_like_multireactor_mechanism_switch(tmp_path: Path):
         "t": [0.0, 0.5, 1.0],
     }
     payload = _payload(
-        {"torch": torch, "pfr": pfr},
-        reactor_reports={"torch": {"T_out": 2000.0}, "pfr": {"C_yield": 0.42}},
-        sankey_nodes=["torch", "pfr", "C(s)"],
+        {"upstream": upstream, "downstream": downstream},
+        reactor_reports={
+            "upstream": {"T_out": 2000.0},
+            "downstream": {"C_yield": 0.42},
+        },
+        sankey_nodes=["upstream", "downstream", "C(s)"],
         sankey_links={"source": [0, 1], "target": [1, 2], "value": [1.0, 0.4]},
     )
     p = tmp_path / "result.h5"
     write_payload(p, payload, MECH)
-    out = read_payload(p)  # gri30 available; pfr (arrays) doesn't need it anyway
-    assert np.allclose(out["reactors_series"]["torch"]["T"], torch["T"])
-    assert np.allclose(out["reactors_series"]["pfr"]["X"]["C2H2"], pfr["X"]["C2H2"])  # type: ignore[index]
-    assert np.allclose(out["reactors_series"]["pfr"]["Y"]["H2"], pfr["Y"]["H2"])  # type: ignore[index]
-    assert out["reactor_reports"]["pfr"]["C_yield"] == 0.42
-    assert out["sankey_nodes"] == ["torch", "pfr", "C(s)"]
+    out = read_payload(p)  # gri30 available; downstream (arrays) doesn't need it
+    assert np.allclose(out["reactors_series"]["upstream"]["T"], upstream["T"])
+    assert np.allclose(
+        out["reactors_series"]["downstream"]["X"]["C2H2"], downstream["X"]["C2H2"]
+    )
+    assert np.allclose(
+        out["reactors_series"]["downstream"]["Y"]["H2"], downstream["Y"]["H2"]
+    )
+    assert out["reactor_reports"]["downstream"]["C_yield"] == 0.42
+    assert out["sankey_nodes"] == ["upstream", "downstream", "C(s)"]
 
 
 def test_collection_composite_per_scenario(tmp_path: Path):
@@ -222,7 +230,9 @@ def test_collection_composite_per_scenario(tmp_path: Path):
     s2b = _real_state_series(3, with_t=True)
     write_payload(
         p,
-        _payload({"torch": s2a, "pfr": s2b}, reactor_reports={"torch": {"q": 1}}),
+        _payload(
+            {"upstream": s2a, "downstream": s2b}, reactor_reports={"upstream": {"q": 1}}
+        ),
         MECH,
         group="T0_1573K",
         fresh=False,
@@ -234,8 +244,8 @@ def test_collection_composite_per_scenario(tmp_path: Path):
     g1 = read_payload(p, group="T0_1273K")
     assert np.allclose(g1["reactors_series"]["reactor"]["T"], s1["T"])
     g2 = read_payload(p, group="T0_1573K")
-    assert set(g2["reactors_series"]) == {"torch", "pfr"}
-    assert g2["reactor_reports"] == {"torch": {"q": 1}}
+    assert set(g2["reactors_series"]) == {"upstream", "downstream"}
+    assert g2["reactor_reports"] == {"upstream": {"q": 1}}
 
 
 def test_shared_builder(tmp_path: Path):

--- a/tests/test_result_cache.py
+++ b/tests/test_result_cache.py
@@ -163,7 +163,7 @@ class TestSaveLoadRoundTrip:
         fingerprint = "b" * 64
         entry = _entry_dir(tmp_path, fingerprint)
         entry.mkdir(parents=True)
-        (entry / "result.json").write_text("{}", encoding="utf-8")
+        (entry / "result.h5").write_bytes(b"")  # content irrelevant: COMPLETE is absent
         (entry / "meta.json").write_text(
             json.dumps({"cache_version": CACHE_VERSION}), encoding="utf-8"
         )

--- a/tests/test_sankey_links_for_api.py
+++ b/tests/test_sankey_links_for_api.py
@@ -59,7 +59,7 @@ def test_species_hex_colors_fallback_when_no_plugin():
 
 
 def test_sankey_links_for_api_species_use_registered_plugin_colors():
-    """Assert sankey_links_for_api resolves H2/CH4/Cs via the plugin slot, not bloc directly."""
+    """Assert sankey_links_for_api resolves H2/CH4/Cs via the plugin slot, not a host package directly."""
     custom = {"H2": "#aaaaaa", "CH4": "#bbbbbb", "Cs": "#cccccc"}
     plugins = BoulderPlugins()
     plugins.sankey_link_colors = custom

--- a/tests/test_scenario_focus.py
+++ b/tests/test_scenario_focus.py
@@ -34,32 +34,39 @@ def _make_store(path: Path, ids: list[str]) -> None:
 
 @contextmanager
 def _client_with_store(tmp_path: Path, ids: list[str]):
+    """Yield ``(client, app)`` with the store wired after startup.
+
+    The app handle (not ``client.app``, which is typed as the bare ASGI callable)
+    gives typed access to ``app.state``.
+    """
     store = tmp_path / "scenarios.h5"
     _make_store(store, ids)
-    with TestClient(create_app()) as client:
+    app = create_app()
+    with TestClient(app) as client:
         # Set *after* startup — the lifespan resets scenario_store_path on entry.
-        client.app.state.scenario_store_path = str(store)
-        yield client
+        app.state.scenario_store_path = str(store)
+        yield client, app
 
 
 def test_focus_valid_id_broadcasts(tmp_path: Path) -> None:
-    with _client_with_store(tmp_path, ["s1", "s2"]) as client:
+    with _client_with_store(tmp_path, ["s1", "s2"]) as (client, app):
         resp = client.post("/api/scenarios/focus", json={"scenario_id": "s2"})
         assert resp.status_code == 200
         assert resp.json() == {"ok": True, "scenario_id": "s2"}
-        assert client.app.state.focused_scenario == "s2"
+        assert app.state.focused_scenario == "s2"
 
 
 def test_focus_unknown_id_404(tmp_path: Path) -> None:
-    with _client_with_store(tmp_path, ["s1"]) as client:
+    with _client_with_store(tmp_path, ["s1"]) as (client, _app):
         resp = client.post("/api/scenarios/focus", json={"scenario_id": "nope"})
         assert resp.status_code == 404
         assert "nope" in resp.json()["detail"]
 
 
 def test_focus_no_store_404(tmp_path: Path) -> None:
-    with TestClient(create_app()) as client:
-        client.app.state.scenario_store_path = None
+    app = create_app()
+    with TestClient(app) as client:
+        app.state.scenario_store_path = None
         resp = client.post("/api/scenarios/focus", json={"scenario_id": "s1"})
         assert resp.status_code == 404
 
@@ -70,9 +77,9 @@ def test_focus_broadcasts_to_subscribers(tmp_path: Path) -> None:
     Avoids consuming the (infinite) SSE body via TestClient — the stream's
     behaviour is exercised end-to-end by the Playwright check instead.
     """
-    with _client_with_store(tmp_path, ["s1", "s2"]) as client:
+    with _client_with_store(tmp_path, ["s1", "s2"]) as (client, app):
         queue: asyncio.Queue = asyncio.Queue()
-        client.app.state.scenario_focus_subscribers.add(queue)
+        app.state.scenario_focus_subscribers.add(queue)
 
         assert (
             client.post("/api/scenarios/focus", json={"scenario_id": "s2"}).status_code

--- a/tests/test_scenario_focus.py
+++ b/tests/test_scenario_focus.py
@@ -74,8 +74,9 @@ def test_focus_broadcasts_to_subscribers(tmp_path: Path) -> None:
         queue: asyncio.Queue = asyncio.Queue()
         client.app.state.scenario_focus_subscribers.add(queue)
 
-        assert client.post(
-            "/api/scenarios/focus", json={"scenario_id": "s2"}
-        ).status_code == 200
+        assert (
+            client.post("/api/scenarios/focus", json={"scenario_id": "s2"}).status_code
+            == 200
+        )
 
         assert queue.get_nowait() == "s2"

--- a/tests/test_scenario_focus.py
+++ b/tests/test_scenario_focus.py
@@ -1,0 +1,81 @@
+"""Tests for the scenario-focus remote-control channel.
+
+``POST /api/scenarios/focus`` validates the id against the active store and
+broadcasts it; ``GET /api/scenarios/focus/stream`` (SSE) emits the current focus
+to a (possibly late-joining) subscriber. These let an external dashboard drive
+the open GUI to load a scenario.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from contextlib import contextmanager
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("fastapi")
+pytest.importorskip("h5py")
+
+import h5py  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+
+from boulder.api.main import create_app  # noqa: E402
+
+
+def _make_store(path: Path, ids: list[str]) -> None:
+    """Minimal composite store: one group per id, each with a payload_json."""
+    with h5py.File(str(path), "w") as handle:
+        for sid in ids:
+            grp = handle.create_group(sid)
+            grp.create_dataset("payload_json", data=json.dumps({}).encode("utf-8"))
+
+
+@contextmanager
+def _client_with_store(tmp_path: Path, ids: list[str]):
+    store = tmp_path / "scenarios.h5"
+    _make_store(store, ids)
+    with TestClient(create_app()) as client:
+        # Set *after* startup — the lifespan resets scenario_store_path on entry.
+        client.app.state.scenario_store_path = str(store)
+        yield client
+
+
+def test_focus_valid_id_broadcasts(tmp_path: Path) -> None:
+    with _client_with_store(tmp_path, ["s1", "s2"]) as client:
+        resp = client.post("/api/scenarios/focus", json={"scenario_id": "s2"})
+        assert resp.status_code == 200
+        assert resp.json() == {"ok": True, "scenario_id": "s2"}
+        assert client.app.state.focused_scenario == "s2"
+
+
+def test_focus_unknown_id_404(tmp_path: Path) -> None:
+    with _client_with_store(tmp_path, ["s1"]) as client:
+        resp = client.post("/api/scenarios/focus", json={"scenario_id": "nope"})
+        assert resp.status_code == 404
+        assert "nope" in resp.json()["detail"]
+
+
+def test_focus_no_store_404(tmp_path: Path) -> None:
+    with TestClient(create_app()) as client:
+        client.app.state.scenario_store_path = None
+        resp = client.post("/api/scenarios/focus", json={"scenario_id": "s1"})
+        assert resp.status_code == 404
+
+
+def test_focus_broadcasts_to_subscribers(tmp_path: Path) -> None:
+    """A POST /focus pushes the id onto every registered SSE subscriber queue.
+
+    Avoids consuming the (infinite) SSE body via TestClient — the stream's
+    behaviour is exercised end-to-end by the Playwright check instead.
+    """
+    with _client_with_store(tmp_path, ["s1", "s2"]) as client:
+        queue: asyncio.Queue = asyncio.Queue()
+        client.app.state.scenario_focus_subscribers.add(queue)
+
+        assert client.post(
+            "/api/scenarios/focus", json={"scenario_id": "s2"}
+        ).status_code == 200
+
+        assert queue.get_nowait() == "s2"

--- a/tests/test_staged_solver.py
+++ b/tests/test_staged_solver.py
@@ -1146,7 +1146,7 @@ class TestInterfaceReservoirSolve:
 def test_refresh_terminal_outlet_sink_copies_upstream_state():
     """Legacy OutletSink shim: _refresh_terminal_sinks copies upstream reactor phase.
 
-    Remove with OutletSink deprecation.  SPRING_A4-style chains use inter-stage
+    Remove with OutletSink deprecation.  Multi-stage chains use inter-stage
     stream-point diamonds (_update_stream_point) instead and do not hit this path.
     """
     from boulder.staged_solver import _refresh_terminal_sinks
@@ -1196,8 +1196,8 @@ def test_refresh_terminal_outlet_sink_copies_upstream_state():
 def test_terminal_outlet_sink_matches_upstream_reactor_after_solve():
     """Legacy OutletSink: terminal sink thermo matches upstream after staged solve.
 
-    Remove with OutletSink deprecation.  Not exercised by SPRING_A4 (psr_outlet
-    stream-point diamond is refreshed via _update_stream_point).
+    Remove with OutletSink deprecation.  Not exercised by multi-stage chains
+    (the stream-point diamond is refreshed via _update_stream_point).
     """
     cfg = normalize_config(
         {

--- a/tests/test_staged_viz_flow.py
+++ b/tests/test_staged_viz_flow.py
@@ -15,7 +15,7 @@ asserts that the final global conservation pass now resolves every
 remaining unset MFC against the full cross-stage topology, including:
 
 (a) a two-stage linear chain,
-(b) a multi-inlet mixer shaped like SPRING_A3, and
+(b) a multi-inlet mixer, and
 (c) a staged PressureController whose master lives in an earlier stage.
 """
 
@@ -134,16 +134,15 @@ def test_staged_two_stage_inter_stage_flow_resolved() -> None:
 
 
 # ---------------------------------------------------------------------------
-# (b) multi-inlet mixer (SPRING_A3-shaped)
+# (b) multi-inlet mixer
 # ---------------------------------------------------------------------------
 
 
 def _multi_inlet_mixer() -> Dict[str, Any]:
     """Two feeds in stage 1 into a mixer in stage 2 that feeds a sink in stage 3.
 
-    Mirrors the SPRING_A3 shape: the mixer has two MFC inlets and one
-    MFC outlet with no explicit rate; the outlet must resolve to the
-    sum of the two inlet rates.
+    The mixer has two MFC inlets and one MFC outlet with no explicit rate;
+    the outlet must resolve to the sum of the two inlet rates.
     """
     return {
         "phases": {"gas": {"mechanism": "gri30.yaml"}},

--- a/tests/test_sweep_runset.py
+++ b/tests/test_sweep_runset.py
@@ -1,0 +1,39 @@
+"""Run-set size accounting for the Run Sweep API (scenario: ⊎ sweep:, no host import)."""
+
+from __future__ import annotations
+
+from boulder.api.routes.sweep import _run_set_size
+
+
+def test_sweep_only_counts_cartesian():
+    raw = {"sweep": {"T": {"values": [1, 2, 3]}, "P": {"values": [10, 20]}}}
+    assert _run_set_size(raw) == 6  # 3 × 2
+
+
+def test_scenario_only_counts_entries():
+    raw = {"scenario": {"a": {}, "b": {}, "c": {}}}
+    assert _run_set_size(raw) == 3
+
+
+def test_union_not_cartesian():
+    raw = {
+        "sweep": {"T": {"values": [1, 2]}},
+        "scenario": {"hot": {}, "cold": {}},
+    }
+    # 2 global sweep points + 2 scenarios = 4 (not 2×2).
+    assert _run_set_size(raw) == 4
+
+
+def test_scenario_local_sweep_multiplies_only_itself():
+    raw = {
+        "scenario": {
+            "plain": {},
+            "swept": {"sweep": {"T": {"values": [1, 2, 3]}}},
+        }
+    }
+    # plain (1) + swept's inner sweep (3) = 4.
+    assert _run_set_size(raw) == 4
+
+
+def test_empty_is_zero():
+    assert _run_set_size({}) == 0

--- a/tests/test_transient_capture.py
+++ b/tests/test_transient_capture.py
@@ -1,0 +1,65 @@
+"""The live transient trajectory capture (single-reactor Run Simulation)."""
+
+from __future__ import annotations
+
+from boulder.cantera_converter import DualCanteraConverter
+
+NODE = {
+    "id": "reactor",
+    "type": "IdealGasConstPressureMoleReactor",
+    "properties": {
+        "energy": "on",
+        "initial": {
+            "temperature": "1400 K",
+            "pressure": "1 atm",
+            "composition": "CH4:1, O2:2, N2:7.52",
+        },
+    },
+}
+
+
+def _converter_with_reactor():
+    conv = DualCanteraConverter(mechanism="gri30.yaml")
+    conv.build_isolated_reactor(NODE)  # populates conv.reactors["reactor"]
+    return conv
+
+
+def test_capture_linear_grid_multipoint():
+    conv = _converter_with_reactor()
+    config = {
+        "nodes": [NODE],
+        "settings": {"solver": {"grid": {"start": 0.0, "stop": 0.5, "dt": 0.05}}},
+    }
+    traj = conv._capture_transient_trajectory(config)
+    assert traj is not None
+    s = traj["reactor"]
+    assert len(s["T"]) > 5  # a real trajectory, not a single point
+    assert len(s["t"]) == len(s["T"]) == len(s["P"])
+    assert s["is_residence"] is True
+    assert "CH4" in s["X"] and len(s["X"]["CH4"]) == len(s["T"])
+    # Ignition: temperature must rise across the window.
+    assert s["T"][-1] > s["T"][0] + 100.0
+
+
+def test_capture_explicit_list_grid():
+    conv = _converter_with_reactor()
+    config = {"nodes": [NODE], "settings": {"solver": {"grid": [0.01, 0.1, 0.5, 1.0]}}}
+    traj = conv._capture_transient_trajectory(config)
+    assert traj is not None
+    # t0 sample + the 4 grid points.
+    assert len(traj["reactor"]["t"]) == 5
+
+
+def test_no_grid_returns_none():
+    conv = _converter_with_reactor()
+    assert conv._capture_transient_trajectory({"nodes": [NODE], "settings": {}}) is None
+
+
+def test_isolation_throwaway_converter():
+    """Capture must not perturb the caller converter's reactor/network state."""
+    conv = _converter_with_reactor()
+    before = conv.reactors["reactor"].phase.T
+    conv._capture_transient_trajectory(
+        {"nodes": [NODE], "settings": {"solver": {"grid": {"stop": 0.5, "dt": 0.1}}}}
+    )
+    assert conv.reactors["reactor"].phase.T == before  # untouched

--- a/tests/test_transient_capture.py
+++ b/tests/test_transient_capture.py
@@ -1,13 +1,20 @@
-"""The live transient trajectory capture (single-reactor Run Simulation)."""
+"""Solve-once transient trajectory capture for a live Run Simulation.
+
+The staged ``advance_grid`` solve steps the reactor through every grid time; a
+full-state recorder captures those steps (via the existing record() hook), so the
+GUI shows the real T(t) without any re-integration — the network is solved once.
+"""
 
 from __future__ import annotations
 
-from boulder.cantera_converter import DualCanteraConverter
+import pytest
 
-NODE = {
+from boulder.cantera_converter import DualCanteraConverter
+from boulder.config import normalize_config
+
+REACTOR = {
     "id": "reactor",
-    "type": "IdealGasConstPressureMoleReactor",
-    "properties": {
+    "IdealGasConstPressureMoleReactor": {
         "energy": "on",
         "initial": {
             "temperature": "1400 K",
@@ -18,48 +25,49 @@ NODE = {
 }
 
 
-def _converter_with_reactor():
-    conv = DualCanteraConverter(mechanism="gri30.yaml")
-    conv.build_isolated_reactor(NODE)  # populates conv.reactors["reactor"]
-    return conv
-
-
-def test_capture_linear_grid_multipoint():
-    conv = _converter_with_reactor()
-    config = {
-        "nodes": [NODE],
-        "settings": {"solver": {"grid": {"start": 0.0, "stop": 0.5, "dt": 0.05}}},
-    }
-    traj = conv._capture_transient_trajectory(config)
-    assert traj is not None
-    s = traj["reactor"]
-    assert len(s["T"]) > 5  # a real trajectory, not a single point
-    assert len(s["t"]) == len(s["T"]) == len(s["P"])
-    assert s["is_residence"] is True
-    assert "CH4" in s["X"] and len(s["X"]["CH4"]) == len(s["T"])
-    # Ignition: temperature must rise across the window.
-    assert s["T"][-1] > s["T"][0] + 100.0
-
-
-def test_capture_explicit_list_grid():
-    conv = _converter_with_reactor()
-    config = {"nodes": [NODE], "settings": {"solver": {"grid": [0.01, 0.1, 0.5, 1.0]}}}
-    traj = conv._capture_transient_trajectory(config)
-    assert traj is not None
-    # t0 sample + the 4 grid points.
-    assert len(traj["reactor"]["t"]) == 5
-
-
-def test_no_grid_returns_none():
-    conv = _converter_with_reactor()
-    assert conv._capture_transient_trajectory({"nodes": [NODE], "settings": {}}) is None
-
-
-def test_isolation_throwaway_converter():
-    """Capture must not perturb the caller converter's reactor/network state."""
-    conv = _converter_with_reactor()
-    before = conv.reactors["reactor"].phase.T
-    conv._capture_transient_trajectory(
-        {"nodes": [NODE], "settings": {"solver": {"grid": {"stop": 0.5, "dt": 0.1}}}}
+def _config(solver: dict) -> dict:
+    return normalize_config(
+        {
+            "phases": {"gas": {"mechanism": "gri30.yaml"}},
+            "settings": {"solver": solver},
+            "network": [REACTOR],
+        }
     )
-    assert conv.reactors["reactor"].phase.T == before  # untouched
+
+
+def _run(config: dict, sim_time: float, step: float) -> dict:
+    conv = DualCanteraConverter(mechanism="gri30.yaml")
+    conv.build_network(config)
+    results, _ = conv.run_streaming_simulation(
+        simulation_time=sim_time, time_step=step, config=config
+    )
+    return results
+
+
+def test_transient_run_yields_multipoint_trajectory():
+    # Fine grid that straddles the ignition delay (ignition < 50 ms at 1400 K).
+    config = _config({"kind": "advance_grid", "grid": {"start": 0.0, "stop": 0.1, "dt": 0.002}})
+    results = _run(config, 0.1, 0.002)
+    s = results["reactors"]["reactor"]
+    assert len(s["T"]) > 5  # a real T(t), not a single converged point
+    assert len(s["t"]) == len(s["T"])
+    assert s.get("is_residence") is True
+    # The ignition rise is captured across the checkpoints (pre- to post-ignition).
+    assert max(s["T"]) - min(s["T"]) > 100.0
+    assert max(s["T"]) > 2000.0  # reacted
+
+
+def test_steady_run_stays_single_point():
+    config = _config({"kind": "advance_to_steady_state"})
+    results = _run(config, 1.0, 0.1)
+    # No transient stepping → recorder empty → the converged snapshot is kept.
+    assert len(results["reactors"]["reactor"]["T"]) == 1
+
+
+def test_recorder_present_only_records_when_transient():
+    """The recorder is installed but captures nothing for a steady solve."""
+    config = _config({"kind": "advance_to_steady_state"})
+    conv = DualCanteraConverter(mechanism="gri30.yaml")
+    conv.build_network(config)
+    assert conv._trajectory_recorder is not None
+    assert conv._trajectory_recorder.series() == {}

--- a/tests/test_transient_capture.py
+++ b/tests/test_transient_capture.py
@@ -7,8 +7,6 @@ GUI shows the real T(t) without any re-integration — the network is solved onc
 
 from __future__ import annotations
 
-import pytest
-
 from boulder.cantera_converter import DualCanteraConverter
 from boulder.config import normalize_config
 
@@ -46,7 +44,9 @@ def _run(config: dict, sim_time: float, step: float) -> dict:
 
 def test_transient_run_yields_multipoint_trajectory():
     # Fine grid that straddles the ignition delay (ignition < 50 ms at 1400 K).
-    config = _config({"kind": "advance_grid", "grid": {"start": 0.0, "stop": 0.1, "dt": 0.002}})
+    config = _config(
+        {"kind": "advance_grid", "grid": {"start": 0.0, "stop": 0.1, "dt": 0.002}}
+    )
     results = _run(config, 0.1, 0.002)
     s = results["reactors"]["reactor"]
     assert len(s["T"]) > 5  # a real T(t), not a single converged point


### PR DESCRIPTION
## Summary

Adds a **scenario-inspector pane** to the GUI and reworks result **caching** onto a single
composite-HDF5 format, plus the surrounding run-set (`scenario:` / `sweep:`) machinery, a
solve-once transient capture, and a live dashboard↔GUI focus channel. All four CI jobs
(pre-commit, unit-tests, type-check, frontend-tests) are green, and Boulder stays host-agnostic.

- [x] Add collapsible right pane to visualize previous scenarios
- [x] Update caching mechanism (unified composite-HDF5 store)

## Core changes

### GUI — scenario inspector & panes
- `565f42a` feat(gui): scenario-inspector pane, run-sweep, collapsible/draggable panes
- `6f5a85b` feat(scenarios): live scenario-focus channel (external dashboard → GUI)

### Result serialization (composite HDF5)
- `aad6f71` feat(serialization): unify result storage on composite HDF5 + native transient capture
- `776b01e` feat(payload-store): group-prefixed composites for a multi-scenario collection
- `27c1eb0` feat(scenarios): composite-only scenario store (multi-reactor capable)
- `e84f609` refactor(transient): solve-once trajectory capture via recorder (no re-integration)

### Inline run-set: `scenario:` / `sweep:`
- `3353b06` feat(stone): recognize inline `scenario:`/`sweep:` keys; drop legacy `scenarios:`
- `5bebfa3` feat(plugins): config_transforms hook — derive STONE fields at normalize time
- `42f7084` feat(sweep-api): recognize `scenario:` + `sweep:` with union run-set count
- `f064f88` feat(sweep-api): host `sweep_runner` hook to execute a scenario/sweep run-set
- `8fc67e3` feat(cli): `--sweep` in Boulder CLI (delegates to host `sweep_runner`)
- `02efac5` feat(sweep): `--sweep` is GUI Run-Sweep mode (headless only with `--headless`)

### Fixes
- `0b6520f` fix(simulations): don't clobber an explicit `solver.grid` with `{stop,dt}`
- `6ab9cf2` fix(units): don't unit-coerce the descriptive `metadata` block
- `7da308a` fix(staged): alias inter-stage MFC ids on the runner viz-build path

### CI / quality / host-agnostic
- `baeee87` fix(deps): declare `h5py` + satisfy qa (ruff/format)
- `82deab5` fix(ci): green type-check, frontend-tests, and remaining qa lint
- `2e5673d` chore: keep Boulder host-agnostic

### Misc
- `65664ba` feat: generalize use of `energy: on/off` in YAMLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
