### PR TITLE
Adaptations for Cantera network examples

### DIFF
--- a/boulder/api/main.py
+++ b/boulder/api/main.py
@@ -56,6 +56,9 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     from ..verbose_utils import ensure_boulder_console_logging
 
     ensure_boulder_console_logging()
+    from ..graphviz_utils import ensure_graphviz_on_path
+
+    ensure_graphviz_on_path()
 
     # Startup: register built-in plugins and create global converter
     from ..cantera_converter import DualCanteraConverter

--- a/boulder/cantera_converter.py
+++ b/boulder/cantera_converter.py
@@ -611,7 +611,9 @@ class DualCanteraConverter:
             mech_path, mech_phase = parse_mechanism_spec(self.mechanism)
             resolved_mechanism = self.resolve_mechanism(mech_path)
             cache_key = (
-                f"{resolved_mechanism}#{mech_phase}" if mech_phase else resolved_mechanism
+                f"{resolved_mechanism}#{mech_phase}"
+                if mech_phase
+                else resolved_mechanism
             )
             spec = (
                 f"{resolved_mechanism}#{mech_phase}"

--- a/boulder/cantera_converter.py
+++ b/boulder/cantera_converter.py
@@ -606,12 +606,23 @@ class DualCanteraConverter:
         self.mechanism = mechanism or CANTERA_MECHANISM
         self.plugins = plugins or get_plugins()
         try:
-            resolved_mechanism = self.resolve_mechanism(self.mechanism)
-            self.gas = ct.Solution(resolved_mechanism)
+            from .ctutils import create_solution_from_spec, parse_mechanism_spec
+
+            mech_path, mech_phase = parse_mechanism_spec(self.mechanism)
+            resolved_mechanism = self.resolve_mechanism(mech_path)
+            cache_key = (
+                f"{resolved_mechanism}#{mech_phase}" if mech_phase else resolved_mechanism
+            )
+            spec = (
+                f"{resolved_mechanism}#{mech_phase}"
+                if mech_phase
+                else resolved_mechanism
+            )
+            self.gas = create_solution_from_spec(spec, resolver=lambda path: path)
         except Exception as e:
             raise ValueError(f"Failed to load mechanism '{self.mechanism}': {e}")
         # Cache of mechanisms -> Solution to support per-node overrides
-        self._gases_by_mech: Dict[str, ct.Solution] = {resolved_mechanism: self.gas}
+        self._gases_by_mech: Dict[str, ct.Solution] = {cache_key: self.gas}
         self.reactors: Dict[str, ct.ReactorBase] = {}
         self.reactor_meta: Dict[str, Dict[str, Any]] = {}
         self.connections: Dict[str, ct.FlowDevice] = {}
@@ -814,12 +825,25 @@ class DualCanteraConverter:
 
         Uses ``resolve_mechanism`` so subclass overrides are honored for both
         the top-level mechanism and per-node mechanism switches.
+
+        Mechanism names may include an optional phase suffix after ``#``, e.g.
+        ``nDodecane_Reitz.yaml#nDodecane_IG``.
         """
+        from .ctutils import create_solution_from_spec, parse_mechanism_spec
+
         resolved = self.resolve_mechanism(mech_name)
         if resolved in self._gases_by_mech:
             return self._gases_by_mech[resolved]
-        gas_obj = ct.Solution(resolved)
-        self._gases_by_mech[resolved] = gas_obj
+        mech_path, phase = parse_mechanism_spec(resolved)
+        mech_path = self.resolve_mechanism(mech_path)
+        cache_key = f"{mech_path}#{phase}" if phase else mech_path
+        if cache_key in self._gases_by_mech:
+            return self._gases_by_mech[cache_key]
+        gas_obj = create_solution_from_spec(
+            f"{mech_path}#{phase}" if phase else mech_path,
+            resolver=lambda path: path,
+        )
+        self._gases_by_mech[cache_key] = gas_obj
         return gas_obj
 
     def _upstream_reservoir_tpy(
@@ -1016,6 +1040,8 @@ class DualCanteraConverter:
             self._mfc_topology[cid] = (src, tgt)
             mfc = ct.MassFlowController(self.reactors[src], self.reactors[tgt])
             mfr_spec = props.get("mass_flow_rate")
+            if mfr_spec is None and props.get("closure"):
+                mfr_spec = props
             if mfr_spec is not None:
                 if isinstance(mfr_spec, dict):
                     if "closure" in mfr_spec:
@@ -2283,6 +2309,7 @@ class DualCanteraConverter:
                     self.last_network,
                     show_species=available_species,
                     verbose=False,
+                    mechanism=self.mechanism,
                     if_no_species="ignore",
                 )
 
@@ -2303,15 +2330,7 @@ class DualCanteraConverter:
             logger.error(f"Traceback: {traceback.format_exc()}")
             results["sankey_links"] = None
             results["sankey_nodes"] = None
-
-            # Propagate Sankey errors to the UI error system
-            sankey_error_msg = f"Sankey diagram generation failed: {str(e)}"
-            if "error_message" in results:
-                results["error_message"] = (
-                    f"{results['error_message']}\n\n{sankey_error_msg}"
-                )
-            else:
-                results["error_message"] = sankey_error_msg
+            # Sankey is optional post-processing; do not fail an otherwise successful solve.
 
         # Evaluate custom output summary if configured
         try:

--- a/boulder/cantera_converter.py
+++ b/boulder/cantera_converter.py
@@ -658,10 +658,29 @@ class DualCanteraConverter:
         self._schedule_callbacks: List[Callable] = []
 
     def parse_composition(self, comp_str: str) -> Dict[str, float]:
-        comp_dict = {}
-        for pair in comp_str.split(","):
-            species, value = pair.split(":")
-            comp_dict[species.strip()] = float(value)
+        """Parse a ``"species:value,species:value,..."`` composition string.
+
+        A handful of real mechanisms (e.g. ``n-heptane-NUIG-2016.yaml``) have
+        species names that themselves contain a literal comma (``C6H101-3,3``),
+        so naively splitting on every ``,`` before every ``:`` misparses them.
+        Values are always plain floats, so a fragment is only a complete entry
+        once the text after its last ``:`` parses as one; until then the next
+        comma-separated fragment is folded into the same (comma-bearing) name.
+        """
+        comp_dict: Dict[str, float] = {}
+        buf: Optional[str] = None
+        for fragment in comp_str.split(","):
+            buf = fragment if buf is None else f"{buf},{fragment}"
+            if ":" not in buf:
+                continue
+            name, _, value = buf.rpartition(":")
+            try:
+                comp_dict[name.strip()] = float(value.strip())
+            except ValueError:
+                continue  # value isn't numeric yet; more of the name follows
+            buf = None
+        if buf is not None:
+            raise ValueError(f"Malformed composition string: {comp_str!r}")
         return comp_dict
 
     # ------------------------------------------------------------------

--- a/boulder/cli.py
+++ b/boulder/cli.py
@@ -26,6 +26,10 @@ try:
 except ImportError:
     pass
 
+from boulder.graphviz_utils import ensure_graphviz_on_path
+
+ensure_graphviz_on_path()
+
 
 def is_port_in_use(host: str, port: int) -> bool:
     """Check if a port is already in use."""

--- a/boulder/ctutils.py
+++ b/boulder/ctutils.py
@@ -2,10 +2,33 @@
 
 import inspect
 from pathlib import Path
+from typing import Callable, Optional
 
 import cantera as ct
 import numpy as np
 import pandas as pd
+
+
+def parse_mechanism_spec(name: str) -> tuple[str, Optional[str]]:
+    """Split ``mechanism.yaml#phase_name`` into file path and optional phase."""
+    if "#" in name:
+        path, phase = name.split("#", 1)
+        return path, phase or None
+    return name, None
+
+
+def create_solution_from_spec(
+    name: str,
+    *,
+    resolver: Optional[Callable[[str], str]] = None,
+) -> ct.Solution:
+    """Create a :class:`~cantera.Solution`, honoring an optional ``#phase`` suffix."""
+    path, phase = parse_mechanism_spec(name)
+    if resolver is not None:
+        path = resolver(path)
+    if phase:
+        return ct.Solution(path, phase)
+    return ct.Solution(path)
 
 
 def get_mechanism_path(mechanism_str) -> str:
@@ -153,10 +176,16 @@ def heating_values(fuel, mechanism="gri30.yaml", return_unit="J/kg"):
         return np.nan, np.nan
 
     # complete combustion products
+    def _elem_frac(symbol: str) -> float:
+        try:
+            return float(gas.elemental_mole_fraction(symbol))
+        except ct.CanteraError:
+            return 0.0
+
     X_products = {
-        "CO2": gas.elemental_mole_fraction("C"),
-        "H2O": 0.5 * gas.elemental_mole_fraction("H"),
-        "N2": 0.5 * gas.elemental_mole_fraction("N"),
+        "CO2": _elem_frac("C"),
+        "H2O": 0.5 * _elem_frac("H"),
+        "N2": 0.5 * _elem_frac("N"),
     }
 
     # Get water properties (to compute HHV)

--- a/boulder/download_script_emitter.py
+++ b/boulder/download_script_emitter.py
@@ -268,6 +268,11 @@ class CanteraScriptEmitter:
         elif ntype == "IdealGasReactor":
             energy_kw = energy_ctor_suffix(props)
             out.append(f"{var} = ct.IdealGasReactor(gas_{var}, clone=True{energy_kw})")
+        elif ntype == "IdealGasMoleReactor":
+            energy_kw = energy_ctor_suffix(props)
+            out.append(
+                f"{var} = ct.IdealGasMoleReactor(gas_{var}, clone=True{energy_kw})"
+            )
         elif ntype == "ConstPressureReactor":
             energy_kw = energy_ctor_suffix(props)
             out.append(
@@ -621,10 +626,25 @@ class CanteraScriptEmitter:
             "inlet_states = {}",
             "",
             "def _parse_composition(comp_str):",
-            "    return {",
-            "        sp.strip(): float(val)",
-            "        for sp, val in (pair.split(':') for pair in comp_str.split(','))",
-            "    }",
+            "    # Some mechanisms (e.g. n-heptane-NUIG-2016.yaml) have species",
+            "    # names that themselves contain a ',' (e.g. 'C6H101-3,3'), so",
+            "    # splitting on every ',' before every ':' would misparse them.",
+            "    # Values are always plain floats, so a comma-separated fragment",
+            "    # is only a complete entry once the text after its last ':'",
+            "    # parses as one.",
+            "    comp = {}",
+            "    buf = None",
+            "    for fragment in comp_str.split(','):",
+            "        buf = fragment if buf is None else f'{buf},{fragment}'",
+            "        if ':' not in buf:",
+            "            continue",
+            "        name, _, value = buf.rpartition(':')",
+            "        try:",
+            "            comp[name.strip()] = float(value.strip())",
+            "        except ValueError:",
+            "            continue",
+            "        buf = None",
+            "    return comp",
             "",
             "def _apply_flow_conservation():",
             "    pending = set(_unresolved_mfc_ids)",

--- a/boulder/graphviz_utils.py
+++ b/boulder/graphviz_utils.py
@@ -1,0 +1,67 @@
+"""Helpers for locating Graphviz binaries bundled with the active Python env."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import sys
+from pathlib import Path
+
+_DOT_NAMES = ("dot.exe", "dot") if os.name == "nt" else ("dot",)
+
+
+def _graphviz_bin_dirs() -> list[Path]:
+    """Return candidate directories that may contain the ``dot`` executable."""
+    prefixes: list[Path] = []
+    conda_prefix = os.environ.get("CONDA_PREFIX", "").strip()
+    if conda_prefix:
+        prefixes.append(Path(conda_prefix))
+    prefixes.append(Path(sys.prefix))
+
+    dirs: list[Path] = []
+    seen: set[Path] = set()
+    for prefix in prefixes:
+        for sub in ("Library/bin", "bin"):
+            candidate = (prefix / sub).resolve()
+            if candidate in seen:
+                continue
+            seen.add(candidate)
+            dirs.append(candidate)
+    return dirs
+
+
+def _find_dot_executable() -> Path | None:
+    for directory in _graphviz_bin_dirs():
+        for name in _DOT_NAMES:
+            dot_path = directory / name
+            if dot_path.is_file():
+                return dot_path
+    return None
+
+
+def ensure_graphviz_on_path() -> Path | None:
+    """Prepend the Graphviz binary directory to ``PATH`` when ``dot`` is missing.
+
+    Conda installs ``dot`` under ``$CONDA_PREFIX/Library/bin`` (Windows) or
+    ``$CONDA_PREFIX/bin`` (Unix).  GUI launches and IDE terminals often run
+    Python without those directories on ``PATH`` even though ``python-graphviz``
+    is installed in the active environment.
+
+    Returns
+    -------
+    Path | None
+        Resolved path to ``dot`` when found, else ``None``.
+    """
+    found = shutil.which("dot")
+    if found:
+        return Path(found)
+
+    dot_path = _find_dot_executable()
+    if dot_path is None:
+        return None
+
+    directory = str(dot_path.parent)
+    path = os.environ.get("PATH", "")
+    if directory not in path.split(os.pathsep):
+        os.environ["PATH"] = directory + os.pathsep + path
+    return dot_path.resolve()

--- a/boulder/network_plugin.py
+++ b/boulder/network_plugin.py
@@ -7,6 +7,7 @@ structure using the network.draw() method.
 import base64
 from typing import Any, Dict, List, Optional
 
+from .graphviz_utils import ensure_graphviz_on_path
 from .live_simulation import get_live_simulation
 from .output_pane_plugins import OutputPaneContext, OutputPanePlugin
 
@@ -109,6 +110,14 @@ class NetworkPlugin(OutputPanePlugin):
         """
         try:
             import graphviz  # noqa: F401
+
+            dot_path = ensure_graphviz_on_path()
+            if dot_path is None:
+                return (
+                    None,
+                    "Graphviz 'dot' executable not found. Install graphviz in the "
+                    "active environment (conda: graphviz and python-graphviz).",
+                )
 
             if theme == "dark":
                 graph_attr = {"rankdir": "LR", "bgcolor": "#020817"}

--- a/boulder/sim2stone.py
+++ b/boulder/sim2stone.py
@@ -732,11 +732,14 @@ def _build_signals_bindings_blocks(
 
     # --- signals from AST-detected Func1 assignments ---
     for det_sig in ast_result.signals:
-        block: Dict[str, Any] = {"id": det_sig.signal_id, "kind": det_sig.kind}
-        for k, v in det_sig.params.items():
-            if not k.startswith("_"):
-                block[k] = v
-        block["_derived_via"] = det_sig.derived_via
+        params = {
+            k: v for k, v in det_sig.params.items() if not k.startswith("_")
+        }
+        block: Dict[str, Any] = {
+            "id": det_sig.signal_id,
+            det_sig.kind: params,
+            "_derived_via": det_sig.derived_via,
+        }
         signals.append(block)
 
     # --- bindings from AST-detected reduced_electric_field assignments ---
@@ -816,10 +819,15 @@ def _solver_kind_from_ast(
 
     if kind == "advance_grid":
         n_steps = params.get("n_steps")
-        step_size = params.get("step_size")
+        step_size = params.get("step_size") or params.get("dt_max") or params.get("dt")
+        t_end = params.get("t_end") or params.get("t_total")
         if n_steps is not None and step_size is not None:
             stop = float(n_steps) * float(step_size)
             return kind, {"grid": {"start": 0.0, "stop": stop, "dt": float(step_size)}}
+        if t_end is not None and step_size is not None:
+            return kind, {
+                "grid": {"start": 0.0, "stop": float(t_end), "dt": float(step_size)}
+            }
         if step_size is not None:
             # No n_steps but we have step_size; emit partial grid
             return kind, {"grid": {"start": 0.0, "dt": float(step_size)}}

--- a/boulder/sim2stone.py
+++ b/boulder/sim2stone.py
@@ -468,18 +468,20 @@ def sim_to_internal_config(
             except (AttributeError, ValueError, TypeError):
                 pass
 
-            if isinstance(r, ct.ConstPressureReactor):
+            if hasattr(r, "energy_enabled"):
+                # Every Cantera reactor kind (not just ConstPressureReactor)
+                # exposes energy_enabled; emit it whenever it reads False so an
+                # isothermal (energy="off") reactor round-trips through STONE.
                 # Use quoted strings so YAML parsers can't coerce "on"/"off" to booleans.
                 from ruamel.yaml.scalarstring import (
                     DoubleQuotedScalarString,  # noqa: PLC0415
                 )
 
                 try:
-                    props["energy"] = DoubleQuotedScalarString(
-                        "on" if r.energy_enabled else "off"
-                    )
+                    if not r.energy_enabled:
+                        props["energy"] = DoubleQuotedScalarString("off")
                 except Exception:
-                    props["energy"] = DoubleQuotedScalarString("on")
+                    pass
 
             # Mechanism: node-level override first, then infer from thermo
             if isinstance(mech_override, str) and mech_override:
@@ -828,6 +830,14 @@ def _solver_kind_from_ast(
             return kind, {
                 "grid": {"start": 0.0, "stop": float(t_end), "dt": float(step_size)}
             }
+        if t_end is not None:
+            # No explicit step_size: the source used an adaptive-step loop
+            # (e.g. ``while t < t_end: t = sim.step()``) with no fixed dt of
+            # its own. Emit a fixed-dt grid that integrates to the same end
+            # time (and thus the same physical end state) at reasonable
+            # output resolution.
+            dt = float(t_end) / 500.0
+            return kind, {"grid": {"start": 0.0, "stop": float(t_end), "dt": dt}}
         if step_size is not None:
             # No n_steps but we have step_size; emit partial grid
             return kind, {"grid": {"start": 0.0, "dt": float(step_size)}}

--- a/boulder/sim2stone.py
+++ b/boulder/sim2stone.py
@@ -734,9 +734,7 @@ def _build_signals_bindings_blocks(
 
     # --- signals from AST-detected Func1 assignments ---
     for det_sig in ast_result.signals:
-        params = {
-            k: v for k, v in det_sig.params.items() if not k.startswith("_")
-        }
+        params = {k: v for k, v in det_sig.params.items() if not k.startswith("_")}
         block: Dict[str, Any] = {
             "id": det_sig.signal_id,
             det_sig.kind: params,

--- a/boulder/sim2stone_ast.py
+++ b/boulder/sim2stone_ast.py
@@ -596,9 +596,7 @@ def _detect_continuation(tree: ast.AST) -> Optional[DetectedContinuation]:
 # ---------------------------------------------------------------------------
 
 
-def _loop_stop_threshold(
-    loop: ast.While, env: Dict[str, float]
-) -> Optional[float]:
+def _loop_stop_threshold(loop: ast.While, env: Dict[str, float]) -> Optional[float]:
     """Resolve a ``while <x> < <threshold>:`` loop's threshold to a float.
 
     Matches both ``while t < max_simulation_time:`` and
@@ -690,17 +688,16 @@ def _detect_solver_hint(tree: ast.AST) -> Optional[DetectedSolver]:
         if not isinstance(node, ast.Expr):
             continue
         call = node.value
-        if not (
-            isinstance(call, ast.Call)
-            and isinstance(call.func, ast.Attribute)
-        ):
+        if not (isinstance(call, ast.Call) and isinstance(call.func, ast.Attribute)):
             continue
         if call.func.attr == "advance_to_steady_state":
             return DetectedSolver(
                 kind="advance_to_steady_state", params={}, derived_via="ast_match"
             )
         if call.func.attr == "solve_steady":
-            return DetectedSolver(kind="solve_steady", params={}, derived_via="ast_match")
+            return DetectedSolver(
+                kind="solve_steady", params={}, derived_via="ast_match"
+            )
 
     return None
 
@@ -711,7 +708,7 @@ def _detect_advance_timing(tree: ast.AST) -> Dict[str, Any]:
     Looks for:
     - Named assignments: ``t_total``, ``t_end``, ``dt_max``, ``dt_chunk``, ``n_steps``, ``dt``
     - AugAssign increments inside For loops: ``time += 4e-4`` → ``step_size``
-  """
+    """
     timing: Dict[str, Any] = {}
     env: Dict[str, float] = {}
     tracked = ("t_total", "t_end", "dt_max", "dt_chunk", "n_steps", "step_size", "dt")
@@ -730,10 +727,10 @@ def _detect_advance_timing(tree: ast.AST) -> Dict[str, Any]:
                 timing[vname] = float(v)
 
     # Detect ``time += dt_value`` inside For loops
-    for node in ast.walk(tree):
-        if not isinstance(node, ast.For):
+    for for_node in ast.walk(tree):
+        if not isinstance(for_node, ast.For):
             continue
-        for stmt in ast.walk(node):
+        for stmt in ast.walk(for_node):
             if not isinstance(stmt, ast.AugAssign):
                 continue
             if not isinstance(stmt.op, ast.Add):

--- a/boulder/sim2stone_ast.py
+++ b/boulder/sim2stone_ast.py
@@ -596,28 +596,59 @@ def _detect_continuation(tree: ast.AST) -> Optional[DetectedContinuation]:
 # ---------------------------------------------------------------------------
 
 
+def _loop_stop_threshold(
+    loop: ast.While, env: Dict[str, float]
+) -> Optional[float]:
+    """Resolve a ``while <x> < <threshold>:`` loop's threshold to a float.
+
+    Matches both ``while t < max_simulation_time:`` and
+    ``while reactor_network.time < max_simulation_time:`` — the left side
+    (name or attribute access) is unconstrained, only the threshold matters.
+    """
+    test = loop.test
+    if (
+        isinstance(test, ast.Compare)
+        and len(test.ops) == 1
+        and isinstance(test.ops[0], (ast.Lt, ast.LtE))
+    ):
+        return _eval_const_extended(test.comparators[0], env)
+    return None
+
+
 def _detect_solver_hint(tree: ast.AST) -> Optional[DetectedSolver]:
     """Derive solver hint from the main simulation loop.
 
     Patterns:
     - ``while t < t_total: ... sim.advance(sim.time + dt) ...``
       → ``advance_grid`` or ``micro_step``
+    - ``while t < max_simulation_time: t = sim.step() ...``
+      → ``advance_grid`` (adaptive-step transient march to a fixed end time;
+      Cantera's own step size varies, so sim2stone emits a fixed-``dt``
+      grid that integrates to the same end time and physical end state)
     - ``for n in range(n_steps): ... sim.advance(time) ...``
       → ``advance_grid``
     - ``sim.advance_to_steady_state()`` or ``sim.solve_steady()`` at top level
       → ``solve_steady`` (but solve_steady in a while loop → handled by
       continuation detection)
     """
+    scalar_env = _collect_scalar_assignments(tree)
+
     # Walk over all While loops to find transient advance loops
     for node in ast.walk(tree):
         if not isinstance(node, ast.While):
             continue
-        # Check for sim.advance call (not solve_steady)
+        # Check for sim.advance / sim.step calls (not solve_steady)
         has_advance = any(
             isinstance(s, ast.Expr)
             and isinstance(s.value, ast.Call)
             and isinstance(s.value.func, ast.Attribute)
             and s.value.func.attr == "advance"
+            for s in ast.walk(node)
+        )
+        has_step = any(
+            isinstance(s, ast.Call)
+            and isinstance(s.func, ast.Attribute)
+            and s.func.attr == "step"
             for s in ast.walk(node)
         )
         has_reinitialize = any(
@@ -627,12 +658,15 @@ def _detect_solver_hint(tree: ast.AST) -> Optional[DetectedSolver]:
             and s.value.func.attr == "reinitialize"
             for s in ast.walk(node)
         )
-        if has_advance:
+        if has_advance or has_step:
             # Micro-step if there is also a reinitialize (chunk-boundary update)
             kind = "micro_step" if has_reinitialize else "advance_grid"
             extra: Dict[str, Any] = {}
             if has_reinitialize:
                 extra["reinitialize_between_chunks"] = True
+            stop = _loop_stop_threshold(node, scalar_env)
+            if stop is not None:
+                extra.setdefault("t_end", stop)
             return DetectedSolver(kind=kind, params=extra, derived_via="ast_match")
 
     # Walk over For loops (for n in range(n_steps))

--- a/boulder/sim2stone_ast.py
+++ b/boulder/sim2stone_ast.py
@@ -651,19 +651,22 @@ def _detect_solver_hint(tree: ast.AST) -> Optional[DetectedSolver]:
                 kind="advance_grid", params={}, derived_via="ast_match"
             )
 
-    # Top-level advance_to_steady_state
+    # Top-level steady solvers
     for node in ast.walk(tree):
         if not isinstance(node, ast.Expr):
             continue
         call = node.value
-        if (
+        if not (
             isinstance(call, ast.Call)
             and isinstance(call.func, ast.Attribute)
-            and call.func.attr == "advance_to_steady_state"
         ):
+            continue
+        if call.func.attr == "advance_to_steady_state":
             return DetectedSolver(
                 kind="advance_to_steady_state", params={}, derived_via="ast_match"
             )
+        if call.func.attr == "solve_steady":
+            return DetectedSolver(kind="solve_steady", params={}, derived_via="ast_match")
 
     return None
 
@@ -672,20 +675,25 @@ def _detect_advance_timing(tree: ast.AST) -> Dict[str, Any]:
     """Extract timing scalars from module-level assignments and for-loop increments.
 
     Looks for:
-    - Named assignments: ``t_total``, ``dt_max``, ``dt_chunk``, ``n_steps``, ``dt``
+    - Named assignments: ``t_total``, ``t_end``, ``dt_max``, ``dt_chunk``, ``n_steps``, ``dt``
     - AugAssign increments inside For loops: ``time += 4e-4`` → ``step_size``
-    """
+  """
     timing: Dict[str, Any] = {}
-    for node in ast.walk(tree):
+    env: Dict[str, float] = {}
+    tracked = ("t_total", "t_end", "dt_max", "dt_chunk", "n_steps", "step_size", "dt")
+
+    body = tree.body if isinstance(tree, ast.Module) else []
+    for node in body:
         if not isinstance(node, ast.Assign):
             continue
         if len(node.targets) != 1 or not isinstance(node.targets[0], ast.Name):
             continue
         vname = node.targets[0].id
-        if vname in ("t_total", "dt_max", "dt_chunk", "n_steps", "step_size", "dt"):
-            v = _eval_const(node.value)
-            if v is not None:
-                timing[vname] = v
+        v = _eval_const_extended(node.value, env)
+        if v is not None and isinstance(v, (int, float)):
+            env[vname] = float(v)
+            if vname in tracked:
+                timing[vname] = float(v)
 
     # Detect ``time += dt_value`` inside For loops
     for node in ast.walk(tree):

--- a/boulder/staged_solver.py
+++ b/boulder/staged_solver.py
@@ -1309,11 +1309,11 @@ def _collect_stage_states(
     # Resolve mechanism and create template
     mech = stage.mechanism
     try:
-        mech = converter.resolve_mechanism(mech)
-    except Exception:
-        pass
-    try:
-        gas_template = ct.Solution(mech)
+        from .ctutils import create_solution_from_spec
+
+        gas_template = create_solution_from_spec(
+            mech, resolver=converter.resolve_mechanism
+        )
     except Exception as exc:
         raise RuntimeError(
             f"Cannot create Solution for stage '{stage.id}' mechanism '{mech}': {exc}"
@@ -1411,11 +1411,9 @@ def _extract_gas_state(
     converter: "DualCanteraConverter",
 ) -> ct.Solution:
     """Return a new ``ct.Solution`` carrying the reactor's current thermo state."""
-    try:
-        mechanism = converter.resolve_mechanism(mechanism)
-    except Exception:
-        pass
-    gas = ct.Solution(mechanism)
+    from .ctutils import create_solution_from_spec
+
+    gas = create_solution_from_spec(mechanism, resolver=converter.resolve_mechanism)
     gas.TPY = reactor.phase.T, reactor.phase.P, reactor.phase.Y
     return gas
 

--- a/environment.yml
+++ b/environment.yml
@@ -11,7 +11,8 @@ dependencies:
 - plotly
 - pint
 - pydantic
-- python-graphviz   # installs Python package as well as the graphviz & dot commands
+- graphviz          # dot, neato, … (Graphviz system binaries)
+- python-graphviz   # Python bindings; uses dot from graphviz package above
 - nodejs            # for the React frontend build (includes npm)
 - pip:
   - fastapi>=0.110.0

--- a/frontend/src/api/scenarios.ts
+++ b/frontend/src/api/scenarios.ts
@@ -12,6 +12,8 @@ export interface ScenarioMeta {
   solid_carbon_yield_pct?: number;
   /** Unix seconds when this scenario was computed (per-scenario; newer stores). */
   computed_at?: number;
+  /** Extra numeric KPI attrs a sweep runner may attach (e.g. "final_X_CO"). */
+  [key: string]: unknown;
 }
 
 export interface ScenarioListResponse {

--- a/frontend/src/components/graph/ReactorGraph.tsx
+++ b/frontend/src/components/graph/ReactorGraph.tsx
@@ -1278,6 +1278,12 @@ export function ReactorGraph() {
       userZoomingEnabled: true,
     });
 
+    // Test/tooling hook only (e.g. scripts/capture_screenshots.py driving
+    // node selection via cy.$id(id).trigger("tap") instead of guessing pixel
+    // coordinates on the canvas, whose layout varies per network). Not read
+    // anywhere in application code.
+    (window as unknown as { __boulderCy?: typeof cy }).__boulderCy = cy;
+
     cy.on("tap", "node", (e: EventObject) => {
       const data = e.target.data();
       if (data.isGroup) {

--- a/frontend/src/components/graph/ReactorGraph.tsx
+++ b/frontend/src/components/graph/ReactorGraph.tsx
@@ -540,7 +540,9 @@ export function ReactorGraph() {
   //      config.connections (same _outlet alias collapsing as alignLayoutLanes).
   //   2. Find the longest source-to-sink path (DP on topo order).  Tie-break:
   //      prefer reactor-type nodes (non-Reservoir / non-OutletSink) over boundary
-  //      nodes; then stable declaration order.  This path becomes "main_flow".
+  //      nodes; then stable declaration order.  Feed Reservoirs on that path are
+  //      demoted to branches so parallel inlets (e.g. air + fuel → mixer) do not
+  //      share the horizontal spine.
   //   3. All other nodes are "auto_branch".  Each branch node is anchored to its
   //      closest spine neighbor: prefer the spine node it connects INTO; fall back
   //      to the spine node that connects INTO it.
@@ -728,10 +730,13 @@ export function ReactorGraph() {
         cur = pathPrev.get(cur) ?? null;
       }
 
-      // Assign lanes.
+      // Assign lanes.  Feed reservoirs never sit on the main-flow spine even when
+      // they appear on the longest path (parallel MFC inlets anchor as branches).
       const lanes = new Map<string, string>();
       for (const id of candidateIds) {
-        lanes.set(id, spineSet.has(id) ? LAYOUT_LANE_MAIN : "auto_branch");
+        const t = cy.getElementById(id).data("type") as string | undefined;
+        const onSpine = spineSet.has(id) && t !== "Reservoir";
+        lanes.set(id, onSpine ? LAYOUT_LANE_MAIN : "auto_branch");
       }
 
       // Assign anchors: for each branch node, find the closest spine neighbor.
@@ -809,6 +814,30 @@ export function ReactorGraph() {
       if (typeof ord === "number" && Number.isFinite(ord)) nodeToOrder.set(node.id, ord);
       const anchor = node.metadata?.layout_anchor;
       if (typeof anchor === "string" && anchor.trim()) nodeToAnchor.set(node.id, anchor.trim());
+    }
+    // Parallel feed reservoirs should not share the main-flow spine: only the
+    // first (lowest layout_order) stays on main_flow; extras anchor above/below
+    // their downstream reactor so inlet edges do not cross sibling feeds.
+    const mainFeedReservoirs: string[] = [];
+    for (const node of config.nodes) {
+      if (node.metadata?.skip_viz) continue;
+      if (nodeToLane.get(node.id) !== LAYOUT_LANE_MAIN) continue;
+      if (node.type !== "Reservoir") continue;
+      const feedsMain = config.connections.some(
+        (conn) =>
+          conn.source === node.id &&
+          nodeToLane.get(conn.target) === LAYOUT_LANE_MAIN,
+      );
+      if (feedsMain) mainFeedReservoirs.push(node.id);
+    }
+    if (mainFeedReservoirs.length > 1) {
+      mainFeedReservoirs.sort(
+        (a, b) => (nodeToOrder.get(a) ?? Infinity) - (nodeToOrder.get(b) ?? Infinity),
+      );
+      for (const id of mainFeedReservoirs.slice(1)) {
+        nodeToLane.set(id, `feed_${id}`);
+        if (!nodeToYOffset.has(id)) nodeToYOffset.set(id, 160);
+      }
     }
     // When no explicit layout_lane is declared, infer the main-flow spine and
     // branch nodes from the network topology so simple multi-stage models
@@ -1078,6 +1107,34 @@ export function ReactorGraph() {
         }
       }
     }
+    // Stagger parallel branch nodes that share the same anchor when no explicit
+    // layout_y_offset is set (e.g. two feed reservoirs into one mixer).
+    const declOrder = new Map<string, number>();
+    config.nodes.forEach((node, i) => declOrder.set(node.id, i));
+    const branchesByAnchor = new Map<string, string[]>();
+    cy.nodes().forEach((n) => {
+      if (n.data("isGroup") || n.data("stream_point")) return;
+      const id = n.id();
+      const lane = nodeToLane.get(id);
+      if (lane === LAYOUT_LANE_MAIN) return;
+      if (!lane && !nodeToYOffset.has(id)) return;
+      if (nodeToYOffset.has(id)) return;
+      const anchorId = nonMainToTarget.get(id);
+      if (!anchorId) return;
+      if (!branchesByAnchor.has(anchorId)) branchesByAnchor.set(anchorId, []);
+      branchesByAnchor.get(anchorId)!.push(id);
+    });
+    const staggeredYOffset = new Map<string, number>();
+    const STAGGER_STEP = Math.abs(LAYOUT_LANE_DEFAULT_OFFSET);
+    branchesByAnchor.forEach((ids) => {
+      if (ids.length < 2) return;
+      ids.sort((a, b) => (declOrder.get(a) ?? 999) - (declOrder.get(b) ?? 999));
+      ids.forEach((branchId, idx) => {
+        const sign = idx % 2 === 0 ? -1 : 1;
+        const tier = Math.floor(idx / 2) + 1;
+        staggeredYOffset.set(branchId, sign * STAGGER_STEP * tier);
+      });
+    });
     cy.nodes().forEach((n) => {
       if (n.data("isGroup")) return;
       const id = n.id();
@@ -1088,7 +1145,9 @@ export function ReactorGraph() {
       if (!lane && !hasYOffset) return;
       if (n.data("stream_point")) return; // stream-point outlets handled in Step 3.6
 
-      const yOffset = nodeToYOffset.has(id) ? nodeToYOffset.get(id)! : LAYOUT_LANE_DEFAULT_OFFSET;
+      const yOffset = nodeToYOffset.has(id)
+        ? nodeToYOffset.get(id)!
+        : (staggeredYOffset.get(id) ?? LAYOUT_LANE_DEFAULT_OFFSET);
       const xOffset = nodeToXOffset.get(id) ?? 0;
       const targetId = nonMainToTarget.get(id);
       const targetX = targetId

--- a/frontend/src/components/panels/PropertiesPanel.test.tsx
+++ b/frontend/src/components/panels/PropertiesPanel.test.tsx
@@ -24,7 +24,7 @@ let mockSelectedElement: {
   type: "node" | "edge";
   data: Record<string, unknown>;
 } | null = null;
-let mockConfig = {
+let mockConfig: Record<string, unknown> = {
   nodes: [
     {
       id: "reactor_1",
@@ -141,5 +141,36 @@ describe("PropertiesPanel delete confirmation", () => {
     expect(screen.queryByText("Delete node?")).not.toBeInTheDocument();
     expect(mockRemoveConnection).toHaveBeenCalledWith("mfc_1");
     expect(mockClearSelection).toHaveBeenCalled();
+  });
+
+  it("unfolds nested initial conditions for display", () => {
+    mockConfig = {
+      nodes: [
+        {
+          id: "cpr_0",
+          type: "IdealGasConstPressureReactor",
+          properties: {
+            volume: 2.35,
+            initial: {
+              temperature: 1001.0,
+              pressure: 101325.0,
+              composition: "H2:2,O2:1,N2:4",
+            },
+          },
+        },
+      ],
+      connections: [],
+    } as Record<string, unknown>;
+    mockSelectedElement = {
+      type: "node",
+      data: { id: "cpr_0", type: "IdealGasConstPressureReactor" },
+    };
+
+    render(<PropertiesPanel />);
+
+    expect(screen.getByText("727.85 °C")).toBeInTheDocument();
+    expect(screen.getByText("101325")).toBeInTheDocument();
+    expect(screen.getByText("H2:2,O2:1,N2:4")).toBeInTheDocument();
+    expect(screen.queryByText("initial")).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/panels/PropertiesPanel.test.tsx
+++ b/frontend/src/components/panels/PropertiesPanel.test.tsx
@@ -169,7 +169,7 @@ describe("PropertiesPanel delete confirmation", () => {
     render(<PropertiesPanel />);
 
     expect(screen.getByText("727.85 °C")).toBeInTheDocument();
-    expect(screen.getByText("101325")).toBeInTheDocument();
+    expect(screen.getByText("101,325.00")).toBeInTheDocument();
     expect(screen.getByText("H2:2,O2:1,N2:4")).toBeInTheDocument();
     expect(screen.queryByText("initial")).not.toBeInTheDocument();
   });

--- a/frontend/src/components/panels/PropertiesPanel.tsx
+++ b/frontend/src/components/panels/PropertiesPanel.tsx
@@ -7,6 +7,22 @@ import { Button } from "@/components/ui/Button";
 import { ConfirmDeleteNodeModal } from "@/components/modals/ConfirmDeleteNodeModal";
 import { toast } from "sonner";
 
+function unfoldInitialConditions(
+  properties: Record<string, unknown>,
+): Record<string, unknown> {
+  const flat = { ...properties };
+  const initial = flat.initial;
+  if (initial && typeof initial === "object" && !Array.isArray(initial)) {
+    delete flat.initial;
+    for (const [key, value] of Object.entries(initial as Record<string, unknown>)) {
+      if (!(key in flat)) {
+        flat[key] = value;
+      }
+    }
+  }
+  return flat;
+}
+
 export function PropertiesPanel() {
   const selectedElement = useSelectionStore((s) => s.selectedElement);
   const config = useConfigStore((s) => s.config);
@@ -75,6 +91,7 @@ export function PropertiesPanel() {
     : config.connections.find((c) => c.id === id);
 
   const properties = entity ? (entity.properties as Record<string, unknown>) : {};
+  const displayProperties = unfoldInitialConditions(properties);
 
   // Stream-point nodes (inter-stage diamonds) and legacy terminal OutletSink nodes
   // are computed from upstream reactors.  OutletSink + terminal_sink is deprecated;
@@ -109,7 +126,7 @@ export function PropertiesPanel() {
   // Start editing
   const handleEdit = () => {
     const vals: Record<string, string> = {};
-    for (const [key, value] of Object.entries(properties)) {
+    for (const [key, value] of Object.entries(displayProperties)) {
       if (key === "temperature" && typeof value === "number") {
         vals[key] = String(kelvinToCelsius(value).toFixed(2));
       } else {
@@ -192,7 +209,7 @@ export function PropertiesPanel() {
         <div className="border-t border-border pt-2 mt-1">
           <p className="text-xs text-muted-foreground mb-1.5">Initial conditions</p>
           <div className="divide-y divide-border">
-            {Object.entries(properties)
+            {Object.entries(displayProperties)
               .filter(([key]) => isFieldVisible(key))
               .map(([key, value]) => (
             <div key={key} className="py-1.5 flex items-center justify-between gap-2">
@@ -241,7 +258,7 @@ export function PropertiesPanel() {
               )}
             </div>
           ))}
-          {Object.keys(properties).length === 0 && (
+          {Object.keys(displayProperties).length === 0 && (
             <p className="text-xs text-muted-foreground py-1 italic">No properties</p>
           )}
           </div>

--- a/frontend/src/components/panels/RunControl.test.tsx
+++ b/frontend/src/components/panels/RunControl.test.tsx
@@ -1,0 +1,79 @@
+/**
+ * Asserts RunControl split-button modes: Run Simulation, Force Run, and Run Sweep.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { RunControl } from "./RunControl";
+
+vi.mock("@/api/sweep", () => ({
+  getSweepInfo: vi.fn().mockResolvedValue({ can_run: false, reason: "No sweep" }),
+  getSweepStatus: vi.fn(),
+  startSweep: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}));
+
+vi.mock("@/stores/scenarioStore", () => ({
+  useScenarioStore: (selector: (s: unknown) => unknown) =>
+    selector({ refresh: vi.fn() }),
+}));
+
+describe("RunControl", () => {
+  const onRunSimulation = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows Force Run in the menu and switches the primary label without Ctrl+Enter", () => {
+    render(
+      <RunControl
+        onRunSimulation={onRunSimulation}
+        isRunning={false}
+        runDisabled={false}
+      />,
+    );
+
+    fireEvent.click(screen.getByLabelText("Choose run action"));
+    expect(screen.getByRole("menuitemradio", { name: /force run/i })).toBeInTheDocument();
+    expect(screen.getByText("Solve ignoring cache")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("menuitemradio", { name: /force run/i }));
+    expect(screen.getByRole("button", { name: "Force Run" })).toBeInTheDocument();
+    expect(screen.queryByText(/ctrl\+enter/i)).not.toBeInTheDocument();
+  });
+
+  it("calls onRunSimulation(true) when Force Run mode is selected and primary is clicked", () => {
+    render(
+      <RunControl
+        onRunSimulation={onRunSimulation}
+        isRunning={false}
+        runDisabled={false}
+      />,
+    );
+
+    fireEvent.click(screen.getByLabelText("Choose run action"));
+    fireEvent.click(screen.getByRole("menuitemradio", { name: /force run/i }));
+    fireEvent.click(screen.getByRole("button", { name: "Force Run" }));
+
+    expect(onRunSimulation).toHaveBeenCalledOnce();
+    expect(onRunSimulation).toHaveBeenCalledWith(true);
+  });
+
+  it("calls onRunSimulation(false) for the default Run Simulation mode", () => {
+    render(
+      <RunControl
+        onRunSimulation={onRunSimulation}
+        isRunning={false}
+        runDisabled={false}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /run simulation/i }));
+    expect(onRunSimulation).toHaveBeenCalledWith(false);
+  });
+});

--- a/frontend/src/components/panels/RunControl.tsx
+++ b/frontend/src/components/panels/RunControl.tsx
@@ -5,10 +5,10 @@ import { Button } from "@/components/ui/Button";
 import { getSweepInfo, getSweepStatus, startSweep, type SweepInfo } from "@/api/sweep";
 import { useScenarioStore } from "@/stores/scenarioStore";
 
-type RunMode = "sim" | "sweep";
+type RunMode = "sim" | "force_sim" | "sweep";
 
 interface RunControlProps {
-  onRunSimulation: () => void;
+  onRunSimulation: (force?: boolean) => void;
   isRunning: boolean;
   runDisabled: boolean;
 }
@@ -55,8 +55,13 @@ export function RunControl({ onRunSimulation, isRunning, runDisabled }: RunContr
   }, [loadSweepInfo]);
 
   const canSweep = Boolean(sweep?.can_run);
-  // If the chosen mode is no longer valid, fall back to simulation.
-  const effectiveMode: RunMode = runMode === "sweep" && canSweep ? "sweep" : "sim";
+  // If sweep is unavailable, fall back to simulation (force_sim is kept as-is).
+  const effectiveMode: RunMode =
+    runMode === "sweep" && canSweep
+      ? "sweep"
+      : runMode === "force_sim"
+        ? "force_sim"
+        : "sim";
 
   const handleRunSweep = useCallback(() => {
     setSweeping(true);
@@ -99,10 +104,14 @@ export function RunControl({ onRunSimulation, isRunning, runDisabled }: RunContr
       if (!canSweep || sweeping || isRunning) return;
       appliedAutorun.current = true;
       handleRunSweep();
+    } else if (effectiveMode === "force_sim") {
+      if (runDisabled) return;
+      appliedAutorun.current = true;
+      onRunSimulation(true);
     } else {
       if (runDisabled) return; // wait until the config is loaded and idle
       appliedAutorun.current = true;
-      onRunSimulation();
+      onRunSimulation(false);
     }
   }, [
     sweep,
@@ -120,9 +129,13 @@ export function RunControl({ onRunSimulation, isRunning, runDisabled }: RunContr
       ? sweeping
         ? `Sweeping… ${progress.current}/${progress.total}`
         : `Run Sweep (${sweep?.n_scenarios ?? 0} scenarios)`
-      : isRunning
-        ? "Running…"
-        : "Run Simulation (Ctrl+Enter)";
+      : effectiveMode === "force_sim"
+        ? isRunning
+          ? "Running…"
+          : "Force Run"
+        : isRunning
+          ? "Running…"
+          : "Run Simulation (Ctrl+Enter)";
 
   const primaryDisabled =
     effectiveMode === "sweep" ? sweeping || isRunning || !canSweep : runDisabled;
@@ -130,7 +143,7 @@ export function RunControl({ onRunSimulation, isRunning, runDisabled }: RunContr
 
   const onPrimary = () => {
     if (effectiveMode === "sweep") handleRunSweep();
-    else onRunSimulation();
+    else onRunSimulation(effectiveMode === "force_sim");
   };
 
   return (
@@ -172,6 +185,15 @@ export function RunControl({ onRunSimulation, isRunning, runDisabled }: RunContr
               description="Solve the single reactor as configured."
               onClick={() => {
                 setRunMode("sim");
+                setMenuOpen(false);
+              }}
+            />
+            <RunModeItem
+              active={effectiveMode === "force_sim"}
+              title="Force Run"
+              description="Solve ignoring cache"
+              onClick={() => {
+                setRunMode("force_sim");
                 setMenuOpen(false);
               }}
             />

--- a/frontend/src/components/panels/ScenarioPane.tsx
+++ b/frontend/src/components/panels/ScenarioPane.tsx
@@ -1,5 +1,6 @@
 import { type KeyboardEvent, useEffect, useRef, useState } from "react";
 import { useScenarioStore } from "@/stores/scenarioStore";
+import { SweepResultsPlot } from "./SweepResultsPlot";
 
 /** Compact relative-time label, e.g. "just now", "2 min ago", "3 h ago". */
 function timeAgo(tsSeconds: number | undefined, nowMs: number): string {
@@ -84,7 +85,9 @@ export function ScenarioPane() {
   };
 
   return (
-    <div className="rounded-lg border border-border bg-card p-4 space-y-3">
+    <div className="space-y-3">
+      <SweepResultsPlot scenarios={scenarios} />
+      <div className="rounded-lg border border-border bg-card p-4 space-y-3">
       <div className="flex items-center justify-between">
         <h3 className="font-semibold text-sm text-foreground">Scenarios</h3>
         <span className="text-xs text-muted-foreground">{scenarios.length}</span>
@@ -140,6 +143,7 @@ export function ScenarioPane() {
           );
         })}
       </ul>
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/panels/ScenarioPane.tsx
+++ b/frontend/src/components/panels/ScenarioPane.tsx
@@ -86,64 +86,64 @@ export function ScenarioPane() {
 
   return (
     <div className="space-y-3">
-      <SweepResultsPlot scenarios={scenarios} />
       <div className="rounded-lg border border-border bg-card p-4 space-y-3">
-      <div className="flex items-center justify-between">
-        <h3 className="font-semibold text-sm text-foreground">Scenarios</h3>
-        <span className="text-xs text-muted-foreground">{scenarios.length}</span>
-      </div>
-      {error && <p className="text-xs text-red-500">{error}</p>}
-      <ul
-        onKeyDown={onKeyDown}
-        className={`space-y-1 max-h-[70vh] overflow-y-auto pr-1${
-          bump ? " animate-[scenarioBump_0.6s_ease-out]" : ""
-        }`}
-      >
-        {scenarios.map((s) => {
-          const isActive = s.id === activeId;
-          const ago = timeAgo(s.computed_at ?? createdAt, now);
-          return (
-            <li key={s.id}>
-              <button
-                id={`scenario-${s.id}`}
-                type="button"
-                onClick={() => void setActive(s.id)}
-                aria-busy={loading && isActive}
-                title={
-                  s.final_temperature_K != null
-                    ? `T_final ≈ ${Math.round(s.final_temperature_K)} K` +
-                      (s.solid_carbon_yield_pct != null
-                        ? ` · C(s) ${s.solid_carbon_yield_pct.toFixed(1)}%`
-                        : "")
-                    : undefined
-                }
-                className={[
-                  "w-full text-left rounded-md px-2 py-1.5 text-xs transition-colors border",
-                  "focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400",
-                  isActive
-                    ? "border-blue-500 bg-blue-500/20 text-foreground"
-                    : "border-transparent hover:bg-muted text-foreground",
-                ].join(" ")}
-              >
-                <div className="flex items-center justify-between gap-2">
-                  <span className="font-medium truncate">{s.label}</span>
-                  {ago && (
-                    <span className="shrink-0 text-[10px] text-muted-foreground">
-                      {ago}
-                    </span>
-                  )}
-                </div>
-                {s.reactor_mode && (
-                  <div className="text-[10px] text-muted-foreground">
-                    {s.reactor_mode}
+        <div className="flex items-center justify-between">
+          <h3 className="font-semibold text-sm text-foreground">Scenarios</h3>
+          <span className="text-xs text-muted-foreground">{scenarios.length}</span>
+        </div>
+        {error && <p className="text-xs text-red-500">{error}</p>}
+        <ul
+          onKeyDown={onKeyDown}
+          className={`space-y-1 max-h-[70vh] overflow-y-auto pr-1${
+            bump ? " animate-[scenarioBump_0.6s_ease-out]" : ""
+          }`}
+        >
+          {scenarios.map((s) => {
+            const isActive = s.id === activeId;
+            const ago = timeAgo(s.computed_at ?? createdAt, now);
+            return (
+              <li key={s.id}>
+                <button
+                  id={`scenario-${s.id}`}
+                  type="button"
+                  onClick={() => void setActive(s.id)}
+                  aria-busy={loading && isActive}
+                  title={
+                    s.final_temperature_K != null
+                      ? `T_final ≈ ${Math.round(s.final_temperature_K)} K` +
+                        (s.solid_carbon_yield_pct != null
+                          ? ` · C(s) ${s.solid_carbon_yield_pct.toFixed(1)}%`
+                          : "")
+                      : undefined
+                  }
+                  className={[
+                    "w-full text-left rounded-md px-2 py-1.5 text-xs transition-colors border",
+                    "focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400",
+                    isActive
+                      ? "border-blue-500 bg-blue-500/20 text-foreground"
+                      : "border-transparent hover:bg-muted text-foreground",
+                  ].join(" ")}
+                >
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="font-medium truncate">{s.label}</span>
+                    {ago && (
+                      <span className="shrink-0 text-[10px] text-muted-foreground">
+                        {ago}
+                      </span>
+                    )}
                   </div>
-                )}
-              </button>
-            </li>
-          );
-        })}
-      </ul>
+                  {s.reactor_mode && (
+                    <div className="text-[10px] text-muted-foreground">
+                      {s.reactor_mode}
+                    </div>
+                  )}
+                </button>
+              </li>
+            );
+          })}
+        </ul>
       </div>
+      <SweepResultsPlot scenarios={scenarios} />
     </div>
   );
 }

--- a/frontend/src/components/panels/SimulateCard.test.tsx
+++ b/frontend/src/components/panels/SimulateCard.test.tsx
@@ -29,7 +29,18 @@ vi.mock("@/api/simulations", () => ({
   startSimulation: vi.fn().mockResolvedValue({ simulation_id: "test-123" }),
 }));
 
+vi.mock("@/api/resultCache", () => ({
+  checkSimulationCache: vi.fn().mockResolvedValue({
+    cached: true,
+    result: { time: [0], reactors: {} },
+    meta: { created_at: Date.now() / 1000 },
+  }),
+}));
+
 const mockStartSimulation = startSimulation as ReturnType<typeof vi.fn>;
+
+import { checkSimulationCache } from "@/api/resultCache";
+const mockCheckSimulationCache = checkSimulationCache as ReturnType<typeof vi.fn>;
 
 vi.mock("sonner", () => ({
   toast: { error: vi.fn(), success: vi.fn() },
@@ -252,5 +263,17 @@ describe("SimulateCard", () => {
     const [, simTime, timeStep] = mockStartSimulation.mock.calls[0];
     expect(typeof simTime).toBe("number");
     expect(typeof timeStep).toBe("number");
+  });
+
+  it("Force Run skips cache lookup and starts a fresh simulation", async () => {
+    mockConfig = { nodes: [{ id: "r1", type: "IdealGasReactor", properties: {} }], connections: [] };
+    render(<SimulateCard />);
+    fireEvent.click(screen.getByLabelText("Choose run action"));
+    fireEvent.click(screen.getByRole("menuitemradio", { name: /force run/i }));
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Force Run" }));
+    });
+    expect(mockCheckSimulationCache).not.toHaveBeenCalled();
+    expect(mockStartSimulation).toHaveBeenCalledOnce();
   });
 });

--- a/frontend/src/components/panels/SimulateCard.tsx
+++ b/frontend/src/components/panels/SimulateCard.tsx
@@ -194,7 +194,7 @@ export function SimulateCard() {
     );
   }, [config]);
 
-  const handleRun = useCallback(async () => {
+  const handleRun = useCallback(async (force = false) => {
     if (config.nodes.length === 0) {
       toast.error("Add at least one reactor before simulating");
       return;
@@ -203,29 +203,32 @@ export function SimulateCard() {
     // Check whether a cached result already exists for the current config.
     // This avoids re-running the full simulation when nothing has changed.
     // Transient runs pass their time/step overrides so the server-side
-    // fingerprint matches what an actual run would have saved.
-    try {
-      const cfgRaw = config as unknown as Record<string, unknown>;
-      const phases = cfgRaw.phases as Record<string, unknown> | undefined;
-      const gas = phases?.gas as Record<string, unknown> | undefined;
-      const mechStr = (gas?.mechanism as string | undefined) ?? null;
+    // fingerprint matches what an actual run would have saved. Force Run
+    // skips this lookup.
+    if (!force) {
+      try {
+        const cfgRaw = config as unknown as Record<string, unknown>;
+        const phases = cfgRaw.phases as Record<string, unknown> | undefined;
+        const gas = phases?.gas as Record<string, unknown> | undefined;
+        const mechStr = (gas?.mechanism as string | undefined) ?? null;
 
-      const cacheResp = await checkSimulationCache(
-        cfgRaw,
-        mechStr,
-        mode === "transient" ? parseFloat(simTime) : undefined,
-        mode === "transient" ? parseFloat(timeStep) : undefined,
-      );
-      if (cacheResp.cached) {
-        setResults(cacheResp.result);
-        const created = cacheResp.meta.created_at;
-        const ageMin = Math.round((Date.now() / 1000 - created) / 60);
-        const ageStr = ageMin < 2 ? "just now" : `${ageMin} min ago`;
-        toast.success(`Loaded cached results from ${ageStr}. Re-run skipped.`);
-        return;
+        const cacheResp = await checkSimulationCache(
+          cfgRaw,
+          mechStr,
+          mode === "transient" ? parseFloat(simTime) : undefined,
+          mode === "transient" ? parseFloat(timeStep) : undefined,
+        );
+        if (cacheResp.cached) {
+          setResults(cacheResp.result);
+          const created = cacheResp.meta.created_at;
+          const ageMin = Math.round((Date.now() / 1000 - created) / 60);
+          const ageStr = ageMin < 2 ? "just now" : `${ageMin} min ago`;
+          toast.success(`Loaded cached results from ${ageStr}. Re-run skipped.`);
+          return;
+        }
+      } catch {
+        // Cache check failed (no config path, network error, etc.) — proceed normally.
       }
-    } catch {
-      // Cache check failed (no config path, network error, etc.) — proceed normally.
     }
 
     beginSimulationRun();

--- a/frontend/src/components/panels/SweepResultsPlot.tsx
+++ b/frontend/src/components/panels/SweepResultsPlot.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import Plot from "react-plotly.js";
 import { useThemeStore } from "@/stores/themeStore";
 import type { ScenarioMeta } from "@/api/scenarios";
@@ -7,48 +7,153 @@ interface Props {
   scenarios: ScenarioMeta[];
 }
 
-const KPI_PREFIX = "final_X_";
+interface YGroup {
+  id: string;
+  label: string;
+  /** Attr keys plotted together as separate traces under this Y choice. */
+  keys: { key: string; traceName: string }[];
+}
+
+/** Bookkeeping attrs every scenario carries that are never plot axis candidates. */
+const NON_AXIS_KEYS = new Set(["order", "computed_at", "schema_version"]);
+
+const FRIENDLY_LABELS: Record<string, string> = {
+  t0_K: "Temperature (K)",
+  final_temperature_K: "Final temperature (K)",
+};
+
+function friendlyLabel(key: string): string {
+  if (FRIENDLY_LABELS[key]) return FRIENDLY_LABELS[key];
+  return key
+    .replace(/^final_/, "")
+    .replace(/_/g, " ")
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+/** Numeric attr keys present on at least one scenario, excluding bookkeeping fields. */
+function numericKeys(scenarios: ScenarioMeta[]): string[] {
+  const keys = new Set<string>();
+  for (const s of scenarios) {
+    for (const [key, value] of Object.entries(s)) {
+      if (typeof value === "number" && !NON_AXIS_KEYS.has(key)) keys.add(key);
+    }
+  }
+  return Array.from(keys).sort();
+}
+
+/** Group numeric keys (minus the chosen X key) into Y-axis choices: species sharing
+ * a "final_X_"/"final_Y_" prefix are grouped as one Mole/Mass Fractions choice with
+ * one trace per species; everything else is its own single-trace choice. */
+function buildYGroups(keys: string[], xKey: string): YGroup[] {
+  const moleSpecies: { key: string; traceName: string }[] = [];
+  const massSpecies: { key: string; traceName: string }[] = [];
+  const singles: YGroup[] = [];
+
+  for (const key of keys) {
+    if (key === xKey) continue;
+    const mole = key.match(/^final_X_(.+)$/);
+    const mass = key.match(/^final_Y_(.+)$/);
+    if (mole) {
+      moleSpecies.push({ key, traceName: mole[1] });
+    } else if (mass) {
+      massSpecies.push({ key, traceName: mass[1] });
+    } else {
+      singles.push({ id: key, label: friendlyLabel(key), keys: [{ key, traceName: friendlyLabel(key) }] });
+    }
+  }
+
+  const groups: YGroup[] = [];
+  if (moleSpecies.length > 0) {
+    groups.push({ id: "mole_fractions", label: "Mole Fractions", keys: moleSpecies });
+  }
+  if (massSpecies.length > 0) {
+    groups.push({ id: "mass_fractions", label: "Mass Fractions", keys: massSpecies });
+  }
+  groups.push(...singles);
+  return groups;
+}
 
 /**
- * Sweep-results chart: swept KPIs (e.g. final mole fractions) vs. the swept
- * parameter (t0_K), across every scenario in the active store — the
- * parameter-sweep equivalent of upstream Cantera examples' "species vs.
- * temperature" plots (e.g. continuous_reactor.py). Lives in the Scenario
+ * Sweep-results chart: pick an X axis (the swept parameter, e.g. temperature)
+ * and a Y axis (a KPI or KPI family, e.g. mole fractions) and plot every
+ * scenario in the active store — the parameter-sweep equivalent of upstream
+ * Cantera examples' "species vs. temperature" plots (e.g.
+ * continuous_reactor.py). Lives below the Scenarios list in the Scenario
  * (sweep) pane, not the main Plots tab: a sweep produces one point per run,
  * not a single reactor's time/space trajectory.
  *
- * Renders nothing when the store has no scenarios or no KPI attrs (e.g. a
- * plain multi-case store with no sweep runner attaching final_X_* attrs).
+ * Renders nothing when the store has fewer than two numeric attrs to plot
+ * against each other (e.g. a plain multi-case store with no sweep KPIs).
  */
 export function SweepResultsPlot({ scenarios }: Props) {
   const theme = useThemeStore((s) => s.theme);
 
-  const { xValues, series } = useMemo(() => {
-    const withX = scenarios.filter((s) => typeof s.t0_K === "number");
-    const sorted = [...withX].sort((a, b) => (a.t0_K ?? 0) - (b.t0_K ?? 0));
-    const kpiKeys = new Set<string>();
-    for (const s of sorted) {
-      for (const key of Object.keys(s)) {
-        if (key.startsWith(KPI_PREFIX) && typeof s[key] === "number") {
-          kpiKeys.add(key);
-        }
-      }
-    }
-    const x = sorted.map((s) => s.t0_K as number);
-    const traces = Array.from(kpiKeys)
-      .sort()
-      .map((key) => ({
-        name: key.slice(KPI_PREFIX.length),
-        y: sorted.map((s) => (s[key] as number | undefined) ?? null),
-      }));
-    return { xValues: x, series: traces };
-  }, [scenarios]);
+  const keys = useMemo(() => numericKeys(scenarios), [scenarios]);
+  const [xKey, setXKey] = useState<string | null>(null);
+  const [yGroupId, setYGroupId] = useState<string | null>(null);
 
-  if (xValues.length === 0 || series.length === 0) return null;
+  const effectiveXKey = xKey && keys.includes(xKey) ? xKey : (keys.includes("t0_K") ? "t0_K" : keys[0]);
+  const yGroups = useMemo(
+    () => (effectiveXKey ? buildYGroups(keys, effectiveXKey) : []),
+    [keys, effectiveXKey],
+  );
+  const effectiveYGroup =
+    yGroups.find((g) => g.id === yGroupId) ?? yGroups[0] ?? null;
+
+  const { xValues, series } = useMemo(() => {
+    if (!effectiveXKey || !effectiveYGroup) return { xValues: [], series: [] };
+    const withX = scenarios.filter((s) => typeof s[effectiveXKey] === "number");
+    const sorted = [...withX].sort(
+      (a, b) => (a[effectiveXKey] as number) - (b[effectiveXKey] as number),
+    );
+    const x = sorted.map((s) => s[effectiveXKey] as number);
+    const traces = effectiveYGroup.keys.map(({ key, traceName }) => ({
+      name: traceName,
+      y: sorted.map((s) => (s[key] as number | undefined) ?? null),
+    }));
+    return { xValues: x, series: traces };
+  }, [scenarios, effectiveXKey, effectiveYGroup]);
+
+  if (keys.length < 2 || !effectiveXKey || !effectiveYGroup || xValues.length === 0) {
+    return null;
+  }
+
+  const selectClass =
+    "rounded-md border border-border bg-background px-2 py-1 text-xs text-foreground";
 
   return (
     <div className="rounded-lg border border-border bg-card p-4 space-y-2">
       <h3 className="font-semibold text-sm text-foreground">Sweep results</h3>
+      <div className="flex flex-col gap-1.5">
+        <label className="flex items-center gap-1.5 text-[10px] text-muted-foreground">
+          X axis
+          <select
+            className={`${selectClass} flex-1`}
+            value={effectiveXKey}
+            onChange={(e) => setXKey(e.target.value)}
+          >
+            {keys.map((k) => (
+              <option key={k} value={k}>
+                {friendlyLabel(k)}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="flex items-center gap-1.5 text-[10px] text-muted-foreground">
+          Y axis
+          <select
+            className={`${selectClass} flex-1`}
+            value={effectiveYGroup.id}
+            onChange={(e) => setYGroupId(e.target.value)}
+          >
+            {yGroups.map((g) => (
+              <option key={g.id} value={g.id}>
+                {g.label}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
       <Plot
         data={series.map((s) => ({
           x: xValues,
@@ -66,11 +171,11 @@ export function SweepResultsPlot({ scenarios }: Props) {
           showlegend: true,
           legend: { x: 1, xanchor: "right" as const, y: 1 },
           xaxis: {
-            title: { text: "Swept temperature (K)" },
+            title: { text: friendlyLabel(effectiveXKey) },
             gridcolor: theme === "dark" ? "#333" : "#e0e0e0",
           },
           yaxis: {
-            title: { text: "Mole fraction" },
+            title: { text: effectiveYGroup.label },
             gridcolor: theme === "dark" ? "#333" : "#e0e0e0",
           },
         }}

--- a/frontend/src/components/panels/SweepResultsPlot.tsx
+++ b/frontend/src/components/panels/SweepResultsPlot.tsx
@@ -1,0 +1,83 @@
+import { useMemo } from "react";
+import Plot from "react-plotly.js";
+import { useThemeStore } from "@/stores/themeStore";
+import type { ScenarioMeta } from "@/api/scenarios";
+
+interface Props {
+  scenarios: ScenarioMeta[];
+}
+
+const KPI_PREFIX = "final_X_";
+
+/**
+ * Sweep-results chart: swept KPIs (e.g. final mole fractions) vs. the swept
+ * parameter (t0_K), across every scenario in the active store — the
+ * parameter-sweep equivalent of upstream Cantera examples' "species vs.
+ * temperature" plots (e.g. continuous_reactor.py). Lives in the Scenario
+ * (sweep) pane, not the main Plots tab: a sweep produces one point per run,
+ * not a single reactor's time/space trajectory.
+ *
+ * Renders nothing when the store has no scenarios or no KPI attrs (e.g. a
+ * plain multi-case store with no sweep runner attaching final_X_* attrs).
+ */
+export function SweepResultsPlot({ scenarios }: Props) {
+  const theme = useThemeStore((s) => s.theme);
+
+  const { xValues, series } = useMemo(() => {
+    const withX = scenarios.filter((s) => typeof s.t0_K === "number");
+    const sorted = [...withX].sort((a, b) => (a.t0_K ?? 0) - (b.t0_K ?? 0));
+    const kpiKeys = new Set<string>();
+    for (const s of sorted) {
+      for (const key of Object.keys(s)) {
+        if (key.startsWith(KPI_PREFIX) && typeof s[key] === "number") {
+          kpiKeys.add(key);
+        }
+      }
+    }
+    const x = sorted.map((s) => s.t0_K as number);
+    const traces = Array.from(kpiKeys)
+      .sort()
+      .map((key) => ({
+        name: key.slice(KPI_PREFIX.length),
+        y: sorted.map((s) => (s[key] as number | undefined) ?? null),
+      }));
+    return { xValues: x, series: traces };
+  }, [scenarios]);
+
+  if (xValues.length === 0 || series.length === 0) return null;
+
+  return (
+    <div className="rounded-lg border border-border bg-card p-4 space-y-2">
+      <h3 className="font-semibold text-sm text-foreground">Sweep results</h3>
+      <Plot
+        data={series.map((s) => ({
+          x: xValues,
+          y: s.y,
+          type: "scatter" as const,
+          mode: "lines+markers" as const,
+          name: s.name,
+        }))}
+        layout={{
+          paper_bgcolor: "transparent",
+          plot_bgcolor: "transparent",
+          font: { color: theme === "dark" ? "#ccc" : "#333", size: 11 },
+          margin: { t: 10, b: 40, l: 50, r: 10 },
+          height: 220,
+          showlegend: true,
+          legend: { x: 1, xanchor: "right" as const, y: 1 },
+          xaxis: {
+            title: { text: "Swept temperature (K)" },
+            gridcolor: theme === "dark" ? "#333" : "#e0e0e0",
+          },
+          yaxis: {
+            title: { text: "Mole fraction" },
+            gridcolor: theme === "dark" ? "#333" : "#e0e0e0",
+          },
+        }}
+        config={{ displaylogo: false, responsive: true }}
+        style={{ width: "100%" }}
+        useResizeHandler
+      />
+    </div>
+  );
+}

--- a/tests/test_cantera_script_emitter.py
+++ b/tests/test_cantera_script_emitter.py
@@ -133,8 +133,11 @@ class TestIdealGasMoleReactorEmission:
     """
 
     def test_emits_ideal_gas_mole_reactor_constructor(self):
-        """Exercise ``_emit_reactor`` directly (the ``emit()`` wrapper only
-        emits real reactor code when given a pre-built stage plan)."""
+        """Exercise ``_emit_reactor`` directly.
+
+        The ``emit()`` wrapper only emits real reactor code when given a
+        pre-built stage plan.
+        """
         from types import SimpleNamespace
 
         from boulder.download_script_emitter import CanteraScriptEmitter

--- a/tests/test_cantera_script_emitter.py
+++ b/tests/test_cantera_script_emitter.py
@@ -122,6 +122,42 @@ class TestBackwardCompatWrapper:
         assert isinstance(lines, list)
 
 
+class TestIdealGasMoleReactorEmission:
+    """IdealGasMoleReactor must emit like the other reactor kinds, not raise.
+
+    Regression: the runtime solve path (create_reactor_from_node) has
+    supported IdealGasMoleReactor since it gained an ``energy`` kwarg, but
+    the --download code emitter's _emit_reactor had no matching branch and
+    fell through to "Unsupported reactor type" for any config using it (e.g.
+    the continuous_reactor CSTR example, which needs energy="off").
+    """
+
+    def test_emits_ideal_gas_mole_reactor_constructor(self):
+        """Exercise ``_emit_reactor`` directly (the ``emit()`` wrapper only
+        emits real reactor code when given a pre-built stage plan)."""
+        from types import SimpleNamespace
+
+        from boulder.download_script_emitter import CanteraScriptEmitter
+
+        node: Dict[str, Any] = {
+            "id": "r1",
+            "type": "IdealGasMoleReactor",
+            "properties": {
+                "temperature": 925,
+                "pressure": 101325,
+                "composition": "CH4:0.1, O2:0.2, N2:0.7",
+                "energy": "off",
+                "volume": 1.0,
+            },
+        }
+        stage = SimpleNamespace(mechanism="gri30.yaml")
+
+        lines = CanteraScriptEmitter()._emit_reactor(node, stage, conns=[])
+        joined = "\n".join(lines)
+        assert "ct.IdealGasMoleReactor(" in joined
+        assert "Unsupported reactor type" not in joined
+
+
 class TestScriptLinesForRunner:
     """Verify script_lines_for_runner is importable as a module-level function."""
 

--- a/tests/test_graphviz_utils.py
+++ b/tests/test_graphviz_utils.py
@@ -22,7 +22,9 @@ def test_ensure_graphviz_on_path_restores_dot_from_env_prefix():
     old_path = os.environ.get("PATH")
     old_prefix = os.environ.get("CONDA_PREFIX")
     os.environ["PATH"] = os.pathsep.join(
-        p for p in (old_path or "").split(os.pathsep) if "miniconda3" not in p and "conda" not in p
+        p
+        for p in (old_path or "").split(os.pathsep)
+        if "conda" not in p and "mamba" not in p
     )
     os.environ["CONDA_PREFIX"] = conda_prefix
     try:
@@ -54,7 +56,9 @@ def test_network_diagram_works_after_path_restore():
     old_path = os.environ.get("PATH")
     old_prefix = os.environ.get("CONDA_PREFIX")
     os.environ["PATH"] = os.pathsep.join(
-        p for p in (old_path or "").split(os.pathsep) if "miniconda3" not in p and "conda" not in p
+        p
+        for p in (old_path or "").split(os.pathsep)
+        if "conda" not in p and "mamba" not in p
     )
     os.environ["CONDA_PREFIX"] = conda_prefix
     try:

--- a/tests/test_graphviz_utils.py
+++ b/tests/test_graphviz_utils.py
@@ -1,0 +1,74 @@
+"""Tests for Graphviz PATH discovery helpers."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import sys
+
+import pytest
+
+from boulder.graphviz_utils import ensure_graphviz_on_path
+
+
+def test_ensure_graphviz_on_path_restores_dot_from_env_prefix():
+    """Asserts ensure_graphviz_on_path prepends the env bin dir when dot is absent from PATH."""
+    conda_prefix = os.environ.get("CONDA_PREFIX") or sys.prefix
+    lib_bin = os.path.join(conda_prefix, "Library", "bin", "dot.exe")
+    unix_bin = os.path.join(conda_prefix, "bin", "dot")
+    if not (os.path.isfile(lib_bin) or os.path.isfile(unix_bin)):
+        pytest.skip("graphviz dot not installed in this environment")
+
+    old_path = os.environ.get("PATH")
+    old_prefix = os.environ.get("CONDA_PREFIX")
+    os.environ["PATH"] = os.pathsep.join(
+        p for p in (old_path or "").split(os.pathsep) if "miniconda3" not in p and "conda" not in p
+    )
+    os.environ["CONDA_PREFIX"] = conda_prefix
+    try:
+        assert shutil.which("dot") is None
+        dot_path = ensure_graphviz_on_path()
+        assert dot_path is not None
+        assert shutil.which("dot") is not None
+    finally:
+        if old_path is not None:
+            os.environ["PATH"] = old_path
+        if old_prefix is not None:
+            os.environ["CONDA_PREFIX"] = old_prefix
+        elif "CONDA_PREFIX" in os.environ:
+            del os.environ["CONDA_PREFIX"]
+
+
+def test_network_diagram_works_after_path_restore():
+    """Asserts NetworkPlugin can render when dot is restored from the active env prefix."""
+    conda_prefix = os.environ.get("CONDA_PREFIX") or sys.prefix
+    lib_bin = os.path.join(conda_prefix, "Library", "bin", "dot.exe")
+    unix_bin = os.path.join(conda_prefix, "bin", "dot")
+    if not (os.path.isfile(lib_bin) or os.path.isfile(unix_bin)):
+        pytest.skip("graphviz dot not installed in this environment")
+
+    import cantera as ct
+
+    from boulder.network_plugin import NetworkPlugin
+
+    old_path = os.environ.get("PATH")
+    old_prefix = os.environ.get("CONDA_PREFIX")
+    os.environ["PATH"] = os.pathsep.join(
+        p for p in (old_path or "").split(os.pathsep) if "miniconda3" not in p and "conda" not in p
+    )
+    os.environ["CONDA_PREFIX"] = conda_prefix
+    try:
+        gas = ct.Solution("gri30.yaml")
+        reactor = ct.IdealGasReactor(gas, clone=False)
+        network = ct.ReactorNet([reactor])
+        plugin = NetworkPlugin()
+        encoded_image, error_message = plugin._generate_network_diagram(network)
+        assert encoded_image is not None, error_message
+        assert error_message is None
+    finally:
+        if old_path is not None:
+            os.environ["PATH"] = old_path
+        if old_prefix is not None:
+            os.environ["CONDA_PREFIX"] = old_prefix
+        elif "CONDA_PREFIX" in os.environ:
+            del os.environ["CONDA_PREFIX"]

--- a/tests/test_parse_composition.py
+++ b/tests/test_parse_composition.py
@@ -1,0 +1,55 @@
+"""Regression test: composition strings with comma-bearing species names.
+
+Some real Cantera mechanisms (e.g. ``n-heptane-NUIG-2016.yaml``, the
+n-heptane oxidation mechanism from Zhang et al. 2016) include species names
+that themselves contain a literal comma, such as ``C6H101-3,3`` or
+``C8H141-5,3``. Cantera's own composition-string parser (``Phase.X = "..."``)
+handles this correctly. ``DualCanteraConverter.parse_composition`` previously
+did not: it split on every ``,`` first and then every ``:``, which silently
+misparsed any composition string containing such a species and raised
+``ValueError: not enough values to unpack``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from boulder.cantera_converter import DualCanteraConverter
+
+
+@pytest.fixture()
+def converter() -> DualCanteraConverter:
+    return DualCanteraConverter(mechanism="gri30.yaml")
+
+
+def test_parse_composition_simple(converter: DualCanteraConverter) -> None:
+    assert converter.parse_composition("H2:0.667, O2:0.333") == {
+        "H2": pytest.approx(0.667),
+        "O2": pytest.approx(0.333),
+    }
+
+
+def test_parse_composition_species_name_with_comma(
+    converter: DualCanteraConverter,
+) -> None:
+    """A species name containing ',' must not be split as an entry separator."""
+    parsed = converter.parse_composition("C6H101-3,3:5.27465e-08,O2:0.0275,HE:0.9675")
+    assert parsed == {
+        "C6H101-3,3": pytest.approx(5.27465e-08),
+        "O2": pytest.approx(0.0275),
+        "HE": pytest.approx(0.9675),
+    }
+
+
+def test_parse_composition_multiple_comma_species(
+    converter: DualCanteraConverter,
+) -> None:
+    """Several comma-bearing species names in the same string, back to back."""
+    parsed = converter.parse_composition(
+        "C8H141-5,3:1e-06,C8H131-5,3,SA:2e-07,NC7H16:0.005"
+    )
+    assert parsed == {
+        "C8H141-5,3": pytest.approx(1e-06),
+        "C8H131-5,3,SA": pytest.approx(2e-07),
+        "NC7H16": pytest.approx(0.005),
+    }

--- a/tests/test_sim2stone_ast.py
+++ b/tests/test_sim2stone_ast.py
@@ -274,6 +274,40 @@ class TestDetectSolverHint:
         assert solver is not None
         assert solver.kind == "micro_step"
 
+    def test_while_step_loop_advance_grid(self) -> None:
+        """while t < max_simulation_time: t = net.step() -> advance_grid.
+
+        Regression: continuous_reactor.py (and other upstream scripts) march
+        to a fixed end time via net.step() (adaptive internal steps), not
+        net.advance(t) — previously undetected, silently falling through to
+        no solver hint (defaulting to advance_to_steady_state, a different
+        algorithm than the source actually used).
+        """
+        src = """
+        max_simulation_time = 50.0
+        t = 0.0
+        while t < max_simulation_time:
+            t = reactor_network.step()
+        """
+        tree = _parse(src)
+        solver = _detect_solver_hint(tree)
+        assert solver is not None
+        assert solver.kind == "advance_grid"
+        assert solver.params["t_end"] == pytest.approx(50.0)
+
+    def test_while_step_loop_threshold_from_bare_name(self) -> None:
+        """The loop's own `x < threshold` comparator resolves the stop time
+        regardless of what the loop variable/threshold are named."""
+        src = """
+        t_stop_value = 12.5
+        while t < t_stop_value:
+            t = net.step()
+        """
+        tree = _parse(src)
+        solver = _detect_solver_hint(tree)
+        assert solver is not None
+        assert solver.params["t_end"] == pytest.approx(12.5)
+
     def test_advance_timing_extracted(self) -> None:
         """n_steps and step_size (from for loop AugAssign) are detected."""
         src = """

--- a/tests/test_sim2stone_ast.py
+++ b/tests/test_sim2stone_ast.py
@@ -275,7 +275,7 @@ class TestDetectSolverHint:
         assert solver.kind == "micro_step"
 
     def test_while_step_loop_advance_grid(self) -> None:
-        """while t < max_simulation_time: t = net.step() -> advance_grid.
+        """While t < max_simulation_time: t = net.step() -> advance_grid.
 
         Regression: continuous_reactor.py (and other upstream scripts) march
         to a fixed end time via net.step() (adaptive internal steps), not
@@ -296,8 +296,11 @@ class TestDetectSolverHint:
         assert solver.params["t_end"] == pytest.approx(50.0)
 
     def test_while_step_loop_threshold_from_bare_name(self) -> None:
-        """The loop's own `x < threshold` comparator resolves the stop time
-        regardless of what the loop variable/threshold are named."""
+        """The loop's own threshold resolves the stop time.
+
+        Matches ``x < threshold`` regardless of what the loop variable and
+        the threshold are named.
+        """
         src = """
         t_stop_value = 12.5
         while t < t_stop_value:
@@ -429,7 +432,7 @@ class TestExtractFromVendoredScripts:
         assert result.bindings == []
 
     def test_while_time_lt_tend_advance_grid(self, tmp_path) -> None:
-        """while sim.time < t_end with dt_max emits advance_grid timing params."""
+        """While sim.time < t_end with dt_max emits advance_grid timing params."""
         script = tmp_path / "reactor1_like.py"
         script.write_text(
             "dt_max = 1e-5\n"

--- a/tests/test_sim2stone_ast.py
+++ b/tests/test_sim2stone_ast.py
@@ -394,6 +394,23 @@ class TestExtractFromVendoredScripts:
         assert result.signals == []
         assert result.bindings == []
 
+    def test_while_time_lt_tend_advance_grid(self, tmp_path) -> None:
+        """while sim.time < t_end with dt_max emits advance_grid timing params."""
+        script = tmp_path / "reactor1_like.py"
+        script.write_text(
+            "dt_max = 1e-5\n"
+            "t_end = 100 * dt_max\n"
+            "sim = object()\n"
+            "while sim.time < t_end:\n"
+            "    sim.advance(sim.time + dt_max)\n",
+            encoding="utf-8",
+        )
+        result = extract_from_source(str(script))
+        assert result.solver is not None
+        assert result.solver.kind == "advance_grid"
+        assert result.solver.params["dt_max"] == pytest.approx(1e-5)
+        assert result.solver.params["t_end"] == pytest.approx(1e-3)
+
     def test_nonexistent_file_returns_empty(self) -> None:
         """extract_from_source on a missing file returns empty result."""
         result = extract_from_source("/does/not/exist.py")

--- a/tests/test_sim2stone_energy_mode.py
+++ b/tests/test_sim2stone_energy_mode.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import cantera as ct  # type: ignore
+
+from boulder.config import load_yaml_string_with_comments, normalize_config
+from boulder.sim2stone import sim_to_stone_yaml
+
+
+def test_sim2stone_preserves_energy_off_on_ideal_gas_mole_reactor() -> None:
+    """An isothermal (energy="off") IdealGasMoleReactor must round-trip.
+
+    Regression: sim2stone only emitted the ``energy:`` property for
+    ``ct.ConstPressureReactor`` instances, so a CSTR built as
+    ``ct.IdealGasMoleReactor(gas, energy="off")`` (e.g. the continuous_reactor
+    upstream example) silently lost its isothermal setting on conversion —
+    the emitted YAML solved as an adiabatic reactor instead.
+    """
+    gas = ct.Solution("gri30.yaml")
+    gas.TPX = 925.0, ct.one_atm, "CH4:0.1, O2:0.2, N2:0.7"
+
+    r = ct.IdealGasMoleReactor(gas, energy="off", volume=1.0, name="R1")
+    sim = ct.ReactorNet([r])
+
+    yaml_str = sim_to_stone_yaml(sim, default_mechanism="gri30.yaml")
+    normalized = normalize_config(load_yaml_string_with_comments(yaml_str))
+
+    (node,) = [n for n in normalized["nodes"] if n["id"] == "R1"]
+    assert str(node["properties"].get("energy")).lower() == "off"
+
+
+def test_sim2stone_omits_energy_when_default_on() -> None:
+    """An energy-on reactor (the default) should not clutter the YAML."""
+    gas = ct.Solution("gri30.yaml")
+    gas.TPX = 300.0, ct.one_atm, "CH4:1"
+
+    r = ct.IdealGasReactor(gas, name="R1")
+    sim = ct.ReactorNet([r])
+
+    yaml_str = sim_to_stone_yaml(sim, default_mechanism="gri30.yaml")
+    normalized = normalize_config(load_yaml_string_with_comments(yaml_str))
+
+    (node,) = [n for n in normalized["nodes"] if n["id"] == "R1"]
+    assert node["properties"].get("energy") in (None, "on")

--- a/tests/test_sim2stone_step_loop_solver.py
+++ b/tests/test_sim2stone_step_loop_solver.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import cantera as ct  # type: ignore
+import pytest
+
+from boulder.config import load_yaml_string_with_comments, normalize_config
+from boulder.sim2stone import sim_to_stone_yaml
+
+
+def test_step_loop_source_emits_advance_grid_matching_original_end_time(
+    tmp_path: Path,
+) -> None:
+    """A ``while t < t_end: t = net.step()`` source emits advance_grid.
+
+    Regression: sim2stone previously only recognized ``net.advance(...)``
+    inside a transient while-loop; a script using the equally common
+    ``net.step()`` idiom (e.g. upstream's continuous_reactor.py) got no
+    solver hint at all and silently defaulted to ``advance_to_steady_state``
+    — a different integration algorithm than the source actually used. The
+    emitted grid's ``stop`` must match the source's own end-time threshold,
+    whatever that threshold variable is named.
+    """
+    script = tmp_path / "step_loop_source.py"
+    script.write_text(
+        "max_simulation_time = 50.0\n"
+        "t = 0.0\n"
+        "while t < max_simulation_time:\n"
+        "    t = reactor_network.step()\n",
+        encoding="utf-8",
+    )
+
+    gas = ct.Solution("gri30.yaml")
+    gas.TPX = 300.0, ct.one_atm, "CH4:1"
+    r = ct.IdealGasReactor(gas, name="R1")
+    sim = ct.ReactorNet([r])
+
+    yaml_str = sim_to_stone_yaml(
+        sim, default_mechanism="gri30.yaml", source_file=str(script)
+    )
+    normalized = normalize_config(load_yaml_string_with_comments(yaml_str))
+
+    solver = normalized["settings"]["solver"]
+    assert solver["kind"] == "advance_grid"
+    assert solver["grid"]["stop"] == pytest.approx(50.0)


### PR DESCRIPTION
## Summary

Backend/converter changes needed to make the [Boulder examples catalog](https://github.com/parks4/boulder_examples) generate and run faithfully from vendored upstream Cantera reactor scripts, discovered while adapting the full example set (including a CSTR temperature-sweep example, `continuous_reactor.py`).

### sim2stone / converter fixes

- **Composition-string parsing** (`cantera_converter.py`, `download_script_emitter.py`): a handful of real mechanisms (e.g. `n-heptane-NUIG-2016.yaml`) have species names that themselves contain a literal comma (`C6H101-3,3`). The naive `split(",")` → `split(":")` parser silently misparsed these and raised `ValueError`. Both the live converter and the `--download` code emitter's generated `_parse_composition` helper now accumulate comma-separated fragments until the text after the last `:` parses as a float, so comma-bearing species names round-trip correctly.
- **`IdealGasMoleReactor` in downloaded scripts** (`download_script_emitter.py`): the runtime solve path has supported this reactor kind since it gained an `energy=` kwarg, but `--download` code generation had no matching branch and raised `"Unsupported reactor type"`.
- **`energy="off"` detection** (`sim2stone.py`): only checked for `ConstPressureReactor`; any other isothermal reactor kind (e.g. `IdealGasMoleReactor`) silently lost that setting on conversion to STONE.
- **AST solver-pattern detection** (`sim2stone_ast.py`): `while t < t_end: t = net.step()` (adaptive internal stepping) is now recognized as `advance_grid`, alongside the existing explicit `net.advance()` loop detection. The loop's own `x < threshold` comparator resolves the end time directly — no dependency on the threshold variable being named `t_end`/`t_total`/etc. When the source has no fixed step size of its own (as with `.step()`), a fixed-`dt` grid is synthesized (`dt = t_end / 500`) that integrates to the same end time and physical end state.
- **Graphviz PATH test fix** (`tests/test_graphviz_utils.py`): the PATH-stripping precondition only excluded `conda`/`miniconda3` substrings, so it left micromamba-based CI runners' Graphviz on PATH (e.g. `/home/runner/micromamba/envs/DEVELOP/bin/dot`), making the "dot is absent" assertion fail. Broadened to also exclude `mamba`.
- Fixed a pre-existing `mypy` error (`sim2stone_ast.py`, reused loop variable widened from `stmt` to `AST`) and a docstring indentation/formatting issue caught by `ruff`.

### Frontend: Sweep-results plot

Added a "Sweep results" chart to the right-hand **Scenario pane** (`ScenarioPane.tsx`, new `SweepResultsPlot.tsx`): plots any `final_X_<species>` KPI attrs a sweep runner attaches to each scenario against the swept parameter (`t0_K`) — the parameter-sweep equivalent of upstream Cantera examples' "value vs. temperature" plots (e.g. `continuous_reactor.py`'s NC7H16/CO/O2-vs-temperature plot). Lives in the Scenario pane, not the main Plots tab, since a sweep produces one point per run rather than a single reactor's time/space trajectory.

## Test plan

- [x] `pre-commit run --all-files` (ruff, ruff-format, blackdoc, mdformat, gitleaks, etc.) — all green
- [x] `mypy . --exclude docs/cantera_examples` — clean
- [x] Full `pytest` suite (587 tests) — all passing, no regressions
- [x] `tsc --noEmit` on the frontend — clean
- [x] Manual GUI verification: loaded a CSTR example using `IdealGasMoleReactor` + `energy="off"` + a residence-time-closure `MassFlowController`, ran its scenario sweep end-to-end via `/api/sweep/run`, confirmed the Scenario pane renders the new sweep-results chart alongside the scenario list

🤖 Generated with [Claude Code](https://claude.com/claude-code)
