### PR TITLE
GUI support for plugin stage networks: streaming series, staged-solve timeline, schema-driven properties

### DIFF
--- a/boulder/api/routes/gui_actions.py
+++ b/boulder/api/routes/gui_actions.py
@@ -59,14 +59,19 @@ def _build_context(request: Request, body: Optional[GuiActionRunRequest] = None)
     cache_fingerprint = preloaded_fingerprint
 
     if body is not None and body.config is not None and isinstance(config, dict):
+        from .simulations import normalize_config_for_fingerprint
+
         converter_cls = getattr(request.app.state, "converter_class", None)
         mechanism = resolve_mechanism_for_fingerprint(
             config, converter_class=converter_cls
         )
         cache_root = cache_dir_for(preloaded_config_path)
+        # Fingerprint the config exactly as check-cache and the run do —
+        # a raw-config lookup would disagree with them for any config the
+        # normalization transforms.
         fingerprint, cached = lookup_cached_result(
             cache_root,
-            dict(config),
+            normalize_config_for_fingerprint(config),
             mechanism=mechanism,
             preloaded_result=preloaded_result,
         )

--- a/boulder/api/routes/plugins.py
+++ b/boulder/api/routes/plugins.py
@@ -40,6 +40,7 @@ async def list_plugins() -> List[Dict[str, Any]]:
                     "supported_node_types": getattr(
                         plugin, "supported_node_types", None
                     ),
+                    "preferred": getattr(plugin, "preferred", False),
                 }
             )
         return result

--- a/boulder/api/routes/simulations.py
+++ b/boulder/api/routes/simulations.py
@@ -6,6 +6,7 @@ Cantera reactor network simulations.
 
 from __future__ import annotations
 
+import copy
 import logging
 import time
 import uuid
@@ -122,6 +123,25 @@ def _resolve_run_grid(
             solver_block["grid"] = {"stop": simulation_time, "dt": time_step}
         # else: explicit list grid — leave it untouched.
     return simulation_time, time_step
+
+
+def normalize_config_for_fingerprint(
+    config: Dict[str, Any],
+    simulation_time: Optional[float] = None,
+    time_step: Optional[float] = None,
+) -> Dict[str, Any]:
+    """Copy of ``config`` transformed exactly as a run fingerprints it.
+
+    The worker fingerprints the pre-build config AFTER default-group
+    synthesis and after any explicit time/step overrides were injected into
+    ``settings.solver.grid`` — every cache lookup must apply the same
+    transforms or identical configs hash differently. The input is left
+    untouched.
+    """
+    normalized = copy.deepcopy(config)
+    synthesize_default_group(normalized)
+    _resolve_run_grid(normalized, simulation_time, time_step)
+    return normalized
 
 
 # ---------------------------------------------------------------------------
@@ -316,13 +336,10 @@ async def check_simulation_cache(
         resolve_mechanism_for_fingerprint,
     )
 
-    # Normalize exactly like a run would: the worker fingerprints the
-    # pre-build config AFTER default-group synthesis and after any explicit
-    # time/step overrides were injected into settings.solver.grid — so the
-    # lookup must apply the same transforms (transient re-runs included).
-    config = dict(body.config)
-    synthesize_default_group(config)
-    _resolve_run_grid(config, body.simulation_time, body.time_step)
+    # Normalize exactly like a run would (transient re-runs included).
+    config = normalize_config_for_fingerprint(
+        body.config, body.simulation_time, body.time_step
+    )
     converter_cls = getattr(request.app.state, "converter_class", None)
     mechanism = resolve_mechanism_for_fingerprint(
         config,

--- a/boulder/api/routes/simulations.py
+++ b/boulder/api/routes/simulations.py
@@ -74,6 +74,56 @@ def _require_positive(value: float, name: str) -> None:
         raise HTTPException(status_code=422, detail=f"{name} must be > 0")
 
 
+def _resolve_run_grid(
+    config: Dict[str, Any],
+    body_simulation_time: Optional[float],
+    body_time_step: Optional[float],
+) -> tuple[float, float]:
+    """Resolve the run time/step and inject explicit overrides into the config.
+
+    Request-body overrides write into ``settings.solver.grid`` (in place) so
+    the normaliser / staged solver see them directly. This is the single
+    normalization both the run path and the cache check use: the cache
+    fingerprint is computed from the pre-build config, so a cache lookup must
+    transform the submitted config exactly like a run would.
+    """
+    settings = config.get("settings", {}) or {}
+    settings_simulation_time = float(
+        settings.get("end_time", settings.get("max_time", 10.0))
+    )
+    settings_time_step = float(settings.get("dt", settings.get("time_step", 1.0)))
+    simulation_time = (
+        body_simulation_time
+        if body_simulation_time is not None
+        else settings_simulation_time
+    )
+    time_step = body_time_step if body_time_step is not None else settings_time_step
+    _require_positive(time_step, "time_step")
+
+    # When the caller passes explicit time/step overrides, propagate them
+    # into settings.solver.grid so the new kind-dispatcher picks them up.
+    if body_simulation_time is not None or body_time_step is not None:
+        if not isinstance(config.get("settings"), dict):
+            config["settings"] = {}
+        solver_block = config["settings"].setdefault("solver", {})
+        # Only inject grid defaults when no transient kind already specified.
+        existing_kind = solver_block.get("kind", "")
+        if existing_kind not in TRANSIENT_SOLVER_KINDS:
+            solver_block.setdefault("kind", "advance_grid")
+        # Respect an already-declared grid (e.g. an explicit list of save
+        # times, or a {start,stop,dt} dict) — it is authoritative. Only
+        # synthesize a {stop,dt} grid from the time/step overrides when none
+        # exists yet (avoids indexing a list grid as a dict).
+        existing_grid = solver_block.get("grid")
+        if isinstance(existing_grid, dict):
+            existing_grid["stop"] = simulation_time
+            existing_grid["dt"] = time_step
+        elif existing_grid is None:
+            solver_block["grid"] = {"stop": simulation_time, "dt": time_step}
+        # else: explicit list grid — leave it untouched.
+    return simulation_time, time_step
+
+
 # ---------------------------------------------------------------------------
 # Endpoints
 # ---------------------------------------------------------------------------
@@ -127,42 +177,12 @@ async def start_simulation(
         if config_path is not None:
             converter._download_config_path = config_path
 
-        # Extract simulation parameters.  Request-body overrides write into
-        # settings.solver so the normaliser / staged solver see them directly.
-        settings = config.get("settings", {}) or {}
-        settings_simulation_time = float(
-            settings.get("end_time", settings.get("max_time", 10.0))
+        # Extract simulation parameters and inject explicit overrides into
+        # settings.solver (shared with the cache check, which must fingerprint
+        # the exact config a run would save).
+        simulation_time, time_step = _resolve_run_grid(
+            config, body.simulation_time, body.time_step
         )
-        settings_time_step = float(settings.get("dt", settings.get("time_step", 1.0)))
-        simulation_time = (
-            body.simulation_time
-            if body.simulation_time is not None
-            else settings_simulation_time
-        )
-        time_step = body.time_step if body.time_step is not None else settings_time_step
-        _require_positive(time_step, "time_step")
-
-        # When the caller passes explicit time/step overrides, propagate them
-        # into settings.solver.grid so the new kind-dispatcher picks them up.
-        if body.simulation_time is not None or body.time_step is not None:
-            if not isinstance(config.get("settings"), dict):
-                config["settings"] = {}
-            solver_block = config["settings"].setdefault("solver", {})
-            # Only inject grid defaults when no transient kind already specified.
-            existing_kind = solver_block.get("kind", "")
-            if existing_kind not in TRANSIENT_SOLVER_KINDS:
-                solver_block.setdefault("kind", "advance_grid")
-            # Respect an already-declared grid (e.g. an explicit list of save
-            # times, or a {start,stop,dt} dict) — it is authoritative. Only
-            # synthesize a {stop,dt} grid from the time/step overrides when none
-            # exists yet (avoids indexing a list grid as a dict).
-            existing_grid = solver_block.get("grid")
-            if isinstance(existing_grid, dict):
-                existing_grid["stop"] = simulation_time
-                existing_grid["dt"] = time_step
-            elif existing_grid is None:
-                solver_block["grid"] = {"stop": simulation_time, "dt": time_step}
-            # else: explicit list grid — leave it untouched.
 
         # Create a fresh worker for this simulation.
         # Pass app.state so the worker can update preloaded_result after the
@@ -296,7 +316,13 @@ async def check_simulation_cache(
         resolve_mechanism_for_fingerprint,
     )
 
+    # Normalize exactly like a run would: the worker fingerprints the
+    # pre-build config AFTER default-group synthesis and after any explicit
+    # time/step overrides were injected into settings.solver.grid — so the
+    # lookup must apply the same transforms (transient re-runs included).
     config = dict(body.config)
+    synthesize_default_group(config)
+    _resolve_run_grid(config, body.simulation_time, body.time_step)
     converter_cls = getattr(request.app.state, "converter_class", None)
     mechanism = resolve_mechanism_for_fingerprint(
         config,

--- a/boulder/api/routes/ui.py
+++ b/boulder/api/routes/ui.py
@@ -33,6 +33,23 @@ async def set_theme(body: ThemeBody, request: Request) -> Dict[str, Any]:
     return {"theme": theme}
 
 
+@router.get("/kind-schema/{kind}")
+async def get_kind_schema(kind: str) -> Dict[str, Any]:
+    """JSON schema for a node or connection kind (``schema: null`` if none).
+
+    Serves the declarative Pydantic schemas plugins register for their
+    kinds; the property panel uses it for field descriptions (tooltips),
+    enum options (dropdowns) and conditional visibility.
+    """
+    from ...schema_registry import get_kind_schema_json
+
+    try:
+        schema = get_kind_schema_json(kind)
+    except Exception:  # noqa: BLE001 - introspection must never break the UI
+        schema = None
+    return {"kind": kind, "schema": schema}
+
+
 @router.get("/branding")
 async def get_branding() -> Dict[str, Any]:
     """Return the host branding set by a plugin (name/version), if any.

--- a/boulder/cantera_converter.py
+++ b/boulder/cantera_converter.py
@@ -242,6 +242,65 @@ def _select_network_class_for_stage(
     return resolved, net_kw
 
 
+def _series_from_stage_states(
+    states: Any, scalars: Optional[Dict[str, Any]] = None
+) -> Optional[Dict[str, Any]]:
+    """Flatten a stage network's ``.states`` SolutionArray into a GUI series.
+
+    A :class:`~boulder.stage_network.CustomStageNetwork` that integrates its
+    whole stage internally (its own macro-grid, a single ``advance`` call)
+    records the real trajectory in :attr:`~boulder.stage_network.CustomStageNetwork.states`.
+    The per-step trajectory recorder cannot see such a solve (it observes only
+    the outer reactor state at each grid step), so this surfaces the recorded
+    profile as the reactor's time series for the plots and output panes.
+
+    Returns ``None`` when there is no usable (>= 2 point) trajectory. Any extra
+    SolutionArray columns (e.g. plugin-specific ``T_e``/``n_e``) and the
+    network's JSON-serialisable ``scalars`` are carried through verbatim so
+    downstream panes can consume them.
+    """
+    if states is None:
+        return None
+    try:
+        t_col = [float(v) for v in states.t]
+    except Exception:  # noqa: BLE001 — any non-conforming states object: skip
+        return None
+    if len(t_col) < 2:
+        return None
+
+    # Core state variables come straight from the array; ``to_pandas`` is used
+    # only to enumerate the plugin-specific extra columns (``T_e``, ``n_e``, ...)
+    # since their names are not known ahead of time.
+    series: Dict[str, Any] = {
+        "t": t_col,
+        "T": [float(v) for v in states.T],
+        "P": [float(v) for v in states.P],
+    }
+    try:
+        names = list(states.species_names)
+        x_mat = np.atleast_2d(np.asarray(states.X, dtype=float))
+        if x_mat.shape[0] == len(t_col):
+            series["X"] = {
+                sp: [float(x_mat[i, j]) for i in range(x_mat.shape[0])]
+                for j, sp in enumerate(names)
+            }
+    except Exception:  # noqa: BLE001 — species optional; core variables suffice
+        pass
+    try:
+        frame = states.to_pandas()
+    except Exception:  # noqa: BLE001 — extras optional
+        frame = None
+    if frame is not None:
+        for col in frame.columns:
+            if col in series or col in ("density", "D") or col.startswith(("X_", "Y_")):
+                continue
+            series[col] = [float(v) for v in frame[col].tolist()]
+
+    for key, value in (scalars or {}).items():
+        series.setdefault(key, value)
+    return series
+
+
 def resolve_unset_flow_rates(
     mfc_topology: Dict[str, Tuple[str, str]],
     flow_rates: Dict[str, float],
@@ -1978,6 +2037,41 @@ class DualCanteraConverter:
                 ):
                     reactors_series[_rid] = _series
                     times[:] = _series["t"]
+
+            # CustomStageNetwork trajectory: a stage network that integrates its
+            # whole stage internally (one ``advance`` call over its own grid)
+            # records the real profile in ``.states`` — the per-step recorder
+            # above cannot capture it. Surface it as the reactor series so the
+            # built-in plots and plugin panes show the full trajectory.
+            _staged = getattr(self, "_staged_trajectory", None)
+            for _net in getattr(_staged, "networks", {}).values() if _staged else ():
+                _net_states = getattr(_net, "states", None)
+                _flat = _series_from_stage_states(
+                    _net_states, getattr(_net, "scalars", None)
+                )
+                if _flat is None:
+                    continue
+                _states_species = list(getattr(_net_states, "species_names", []))
+                for _r in getattr(_net, "reactors", []):
+                    if isinstance(_r, ct.Reservoir):
+                        continue
+                    # The stage records ONE profile: attach it only to the
+                    # reactor(s) whose phase it describes (matched by species
+                    # set), never to co-staged reactors on other mechanisms.
+                    _r_species = list(
+                        getattr(getattr(_r, "phase", None), "species_names", [])
+                    )
+                    if _states_species and _r_species != _states_species:
+                        continue
+                    _rid = getattr(_r, "name", "") or str(id(_r))
+                    _existing = reactors_series.get(_rid)
+                    if _existing is not None and _existing.get("is_spatial"):
+                        continue
+                    _cur_len = len((_existing or {}).get("t", []) or [])
+                    if len(_flat["t"]) > _cur_len:
+                        reactors_series[_rid] = _flat
+                        if len(_flat["t"]) > len(times):
+                            times[:] = _flat["t"]
 
             if progress_callback:
                 progress_callback(

--- a/boulder/download_script_emitter.py
+++ b/boulder/download_script_emitter.py
@@ -166,7 +166,7 @@ class CanteraScriptEmitter:
             if src_node.get("type") in _RESERVOIR_TYPES:
                 sv = self._vn(str(src_id))
                 return [
-                    f"_up = {sv}.thermo",
+                    f"_up = {sv}.phase",
                     f"gas_{var}.TPY = _up.T, _up.P, _up.Y",
                 ]
         return []

--- a/boulder/output_pane_plugins.py
+++ b/boulder/output_pane_plugins.py
@@ -73,6 +73,16 @@ class OutputPanePlugin(ABC):
         """
         return None
 
+    @property
+    def preferred(self) -> bool:
+        """Open this pane by default when a run completes.
+
+        When True and the user has neither picked a results tab nor selected
+        an element, the GUI auto-selects the first node this plugin supports
+        and activates its tab instead of the generic default.
+        """
+        return False
+
     def is_available(self, context: OutputPaneContext) -> bool:
         """Check if this plugin should be available given the current context.
 

--- a/boulder/sankey.py
+++ b/boulder/sankey.py
@@ -107,7 +107,7 @@ def _get_available_species_for_sankey_from_sim(sim) -> List[str]:
         all_available_species = set()
         for reactor in all_reactors:
             try:
-                reactor_species = set(reactor.thermo.species_names)
+                reactor_species = set(reactor.phase.species_names)
                 all_available_species.update(reactor_species)
             except Exception as e:
                 logger.debug(f"Could not get species from reactor {reactor.name}: {e}")
@@ -362,7 +362,7 @@ def generate_sankey_input_from_sim(
                 )  # kg/s0 - convert to Python float
                 if flow_type == "enthalpy":
                     upstream_enthalpy = float(
-                        outlet.upstream.thermo.enthalpy_mass
+                        outlet.upstream.phase.enthalpy_mass
                     )  # J/kg
                     energy_rate = flow_rate * upstream_enthalpy  # J/s = W
                     assert energy_rate > 0
@@ -377,7 +377,7 @@ def generate_sankey_input_from_sim(
                     from .ctutils import heating_values
 
                     lhv, hhv = heating_values(
-                        outlet.upstream.thermo, mechanism=mechanism
+                        outlet.upstream.phase, mechanism=mechanism
                     )  # J/kg
                     # TODO define temperature reference when computing HHV
                     # (and make it consistent with the one used in sensible enthalpy)
@@ -406,7 +406,7 @@ def generate_sankey_input_from_sim(
                             raise NotImplementedError(f"{s} not implemented yet")
 
                         # Check if species exists in the upstream reactor
-                        if s not in outlet.upstream.thermo.species_names:
+                        if s not in outlet.upstream.phase.species_names:
                             if if_no_species == "ignore":
                                 # Skip this species silently
                                 continue
@@ -423,9 +423,9 @@ def generate_sankey_input_from_sim(
                                 # Default to ignore for unknown options
                                 continue
 
-                        species_index = outlet.upstream.thermo.species_index(s)
+                        species_index = outlet.upstream.phase.species_index(s)
                         energy_rate_s = float(
-                            flow_rate * outlet.upstream.thermo.Y[species_index] * hhv_s
+                            flow_rate * outlet.upstream.phase.Y[species_index] * hhv_s
                         )  # J/s = W - convert to Python float
                         # remove energy rate of this species from the remaining energy rate:
                         energy_rate -= energy_rate_s
@@ -444,9 +444,9 @@ def generate_sankey_input_from_sim(
                     # ----------------------------------------
                     from .ctutils import get_STP_properties_IUPAC
 
-                    _, enthalpy_STP = get_STP_properties_IUPAC(outlet.upstream.thermo)
+                    _, enthalpy_STP = get_STP_properties_IUPAC(outlet.upstream.phase)
                     sensible_enthalpy = float(
-                        outlet.upstream.thermo.enthalpy_mass - enthalpy_STP
+                        outlet.upstream.phase.enthalpy_mass - enthalpy_STP
                     )  # J/kg
 
                     sensible_energy_rate = flow_rate * sensible_enthalpy  # J/s = W

--- a/boulder/schema_registry.py
+++ b/boulder/schema_registry.py
@@ -233,6 +233,34 @@ def get_schema_entry(kind: str) -> Optional[ReactorSchemaEntry]:
     return _SCHEMA_REGISTRY.get(kind)
 
 
+_CONNECTION_SCHEMAS: Dict[str, Type[Any]] = {}
+
+
+def register_connection_schema(kind: str, schema: Type[Any]) -> None:
+    """Register a Pydantic schema describing a *connection* kind's properties.
+
+    Connections (edges) have no :class:`ReactorSchemaEntry`; this lighter
+    registry lets plugins document their edge kinds so the GUI property
+    panel can render field descriptions, enum options and conditional
+    visibility (``json_schema_extra={"visible_when": {field: value}}``).
+    """
+    _CONNECTION_SCHEMAS[kind] = schema
+
+
+def get_kind_schema_json(kind: str) -> Optional[Dict[str, Any]]:
+    """JSON schema of a node *or* connection kind (None when unknown).
+
+    The single lookup the GUI needs: reactor kinds resolve through the
+    :class:`ReactorSchemaEntry` registry, connection kinds through
+    :func:`register_connection_schema`.
+    """
+    entry = _SCHEMA_REGISTRY.get(kind)
+    schema = entry.schema if entry is not None else _CONNECTION_SCHEMAS.get(kind)
+    if schema is None or not hasattr(schema, "model_json_schema"):
+        return None
+    return schema.model_json_schema()
+
+
 def registered_kinds() -> List[str]:
     """Return the list of reactor kinds that have a registered schema entry."""
     return sorted(_SCHEMA_REGISTRY.keys())

--- a/boulder/scopes.py
+++ b/boulder/scopes.py
@@ -87,8 +87,8 @@ def resolve_scope_variable(
 
             def _read_mole_fraction(_r=reactor, _s=species) -> float:
                 try:
-                    idx = _r.thermo.species_index(_s)
-                    return float(_r.thermo.X[idx])
+                    idx = _r.phase.species_index(_s)
+                    return float(_r.phase.X[idx])
                 except Exception:
                     return float("nan")
 
@@ -99,8 +99,8 @@ def resolve_scope_variable(
 
             def _read_mass_fraction(_r=reactor, _s=species) -> float:
                 try:
-                    idx = _r.thermo.species_index(_s)
-                    return float(_r.thermo.Y[idx])
+                    idx = _r.phase.species_index(_s)
+                    return float(_r.phase.Y[idx])
                 except Exception:
                     return float("nan")
 
@@ -109,7 +109,7 @@ def resolve_scope_variable(
         # Scalar reactor attributes
         _REACTOR_ATTRS = {
             "T": lambda r: float(r.T),
-            "P": lambda r: float(r.thermo.P),
+            "P": lambda r: float(r.phase.P),
             "V": lambda r: float(r.volume) if hasattr(r, "volume") else float("nan"),
             "mass": lambda r: float(r.mass) if hasattr(r, "mass") else float("nan"),
         }

--- a/boulder/sim2stone.py
+++ b/boulder/sim2stone.py
@@ -237,6 +237,10 @@ def _mechanism_from_thermo(thermo: ct.ThermoPhase) -> Optional[str]:
         val = getattr(thermo, attr, None)
         if not isinstance(val, str) or not val:
             continue
+        if val == "<unknown>":
+            # Cantera's placeholder for Solutions created in memory (from
+            # species lists / other phases): there is no input file to name.
+            continue
         p = Path(val)
         parts = p.parts
         parts_lower = tuple(x.lower() for x in parts)
@@ -259,7 +263,7 @@ def _composition_to_string(thermo: ct.ThermoPhase, min_fraction: float = 1e-12) 
     Parameters
     ----------
     thermo
-        A Cantera ThermoPhase (e.g., ``reactor.thermo``).
+        A Cantera ThermoPhase (e.g., ``reactor.phase``).
     min_fraction
         Species with mole fraction below this threshold are omitted to keep the
         output readable.
@@ -481,7 +485,7 @@ def sim_to_internal_config(
             if isinstance(mech_override, str) and mech_override:
                 props["mechanism"] = mech_override
             else:
-                guessed = _mechanism_from_thermo(r.thermo)
+                guessed = _mechanism_from_thermo(r.phase)
                 if guessed:
                     props["mechanism"] = guessed
 

--- a/frontend/src/api/kindSchema.ts
+++ b/frontend/src/api/kindSchema.ts
@@ -1,0 +1,58 @@
+import { apiFetch } from "./client";
+
+/** JSON-schema fragment for one property of a node/connection kind. */
+export interface FieldMeta {
+  description?: string;
+  /** Allowed values (from Literal/Enum fields) — rendered as a dropdown. */
+  options?: string[];
+  /** Show the field only while every referenced sibling has the given value. */
+  visibleWhen?: Record<string, unknown>;
+}
+
+interface KindSchemaResponse {
+  kind: string;
+  schema: {
+    properties?: Record<string, Record<string, unknown>>;
+  } | null;
+}
+
+/** Pull the enum options out of a JSON-schema property (incl. Optional[...]). */
+function extractOptions(prop: Record<string, unknown>): string[] | undefined {
+  if (Array.isArray(prop.enum)) return prop.enum.map(String);
+  if (prop.const !== undefined) return [String(prop.const)];
+  const anyOf = prop.anyOf;
+  if (Array.isArray(anyOf)) {
+    for (const variant of anyOf as Record<string, unknown>[]) {
+      const nested = extractOptions(variant);
+      if (nested) return nested;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Field metadata for a node/connection kind, keyed by property name.
+ * Resolves to null when the kind has no registered schema.
+ */
+export async function fetchKindFieldMeta(
+  kind: string,
+): Promise<Record<string, FieldMeta> | null> {
+  const body = await apiFetch<KindSchemaResponse>(
+    `/ui/kind-schema/${encodeURIComponent(kind)}`,
+  );
+  const props = body.schema?.properties;
+  if (!props) return null;
+  const fields: Record<string, FieldMeta> = {};
+  for (const [key, raw] of Object.entries(props)) {
+    fields[key] = {
+      description:
+        typeof raw.description === "string" ? raw.description : undefined,
+      options: extractOptions(raw),
+      visibleWhen:
+        raw.visible_when && typeof raw.visible_when === "object"
+          ? (raw.visible_when as Record<string, unknown>)
+          : undefined,
+    };
+  }
+  return fields;
+}

--- a/frontend/src/api/resultCache.ts
+++ b/frontend/src/api/resultCache.ts
@@ -39,10 +39,20 @@ export function fetchCachedResult() {
 export function checkSimulationCache(
   config: Record<string, unknown>,
   mechanism?: string | null,
+  simulationTime?: number,
+  timeStep?: number,
 ): Promise<CacheCheckResponse> {
   return apiFetch<CacheCheckResponse>("/simulations/check-cache", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ config, mechanism: mechanism ?? null }),
+    body: JSON.stringify({
+      config,
+      mechanism: mechanism ?? null,
+      // Transient run overrides: the server injects these into
+      // settings.solver exactly like a run would, so the fingerprint
+      // matches what the worker saved.
+      simulation_time: simulationTime ?? null,
+      time_step: timeStep ?? null,
+    }),
   });
 }

--- a/frontend/src/components/panels/PropertiesPanel.tsx
+++ b/frontend/src/components/panels/PropertiesPanel.tsx
@@ -1,7 +1,8 @@
-import { useState, useCallback } from "react";
+import { useState } from "react";
 import { useSelectionStore } from "@/stores/selectionStore";
 import { useConfigStore } from "@/stores/configStore";
 import { kelvinToCelsius, celsiusToKelvin, formatNumber, labelWithUnit } from "@/lib/units";
+import { useKindSchema } from "@/hooks/useKindSchema";
 import { Button } from "@/components/ui/Button";
 import { ConfirmDeleteNodeModal } from "@/components/modals/ConfirmDeleteNodeModal";
 import { toast } from "sonner";
@@ -17,6 +18,15 @@ export function PropertiesPanel() {
   const [isEditing, setIsEditing] = useState(false);
   const [editValues, setEditValues] = useState<Record<string, string>>({});
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+
+  // Field metadata from the kind's registered schema (descriptions, enum
+  // options, conditional visibility). Fetched before any early return so
+  // the hook order stays stable.
+  const schemaKind =
+    selectedElement && !selectedElement.data.isGroup
+      ? String(selectedElement.data.type ?? "")
+      : "";
+  const schemaMeta = useKindSchema(schemaKind);
 
   if (!selectedElement) {
     return (
@@ -72,6 +82,29 @@ export function PropertiesPanel() {
   const isStreamPoint = isNode && Boolean(properties.stream_point);
   const isTerminalSink = isNode && Boolean(properties.terminal_sink);
   const isComputedStream = isStreamPoint || isTerminalSink;
+
+  // A field with visible_when metadata is shown only while every referenced
+  // sibling holds the required value (e.g. nb_reflections only for the
+  // "series" reflection model). Evaluated against the live edit values while
+  // editing so toggling the controlling field reveals its dependents.
+  const isFieldVisible = (key: string): boolean => {
+    const cond = schemaMeta?.[key]?.visibleWhen;
+    if (!cond) return true;
+    return Object.entries(cond).every(([dep, expected]) => {
+      const current = isEditing ? editValues[dep] : properties[dep];
+      return String(current ?? "") === String(expected);
+    });
+  };
+
+  // Tooltip text: the schema description, plus the enum options if any.
+  const fieldTooltip = (key: string): string | undefined => {
+    const meta = schemaMeta?.[key];
+    if (!meta) return undefined;
+    const parts: string[] = [];
+    if (meta.description) parts.push(meta.description);
+    if (meta.options) parts.push(`Options: ${meta.options.join(" | ")}`);
+    return parts.length ? parts.join("\n") : undefined;
+  };
 
   // Start editing
   const handleEdit = () => {
@@ -159,19 +192,42 @@ export function PropertiesPanel() {
         <div className="border-t border-border pt-2 mt-1">
           <p className="text-xs text-muted-foreground mb-1.5">Initial conditions</p>
           <div className="divide-y divide-border">
-            {Object.entries(properties).map(([key, value]) => (
+            {Object.entries(properties)
+              .filter(([key]) => isFieldVisible(key))
+              .map(([key, value]) => (
             <div key={key} className="py-1.5 flex items-center justify-between gap-2">
-              <span className="text-xs text-muted-foreground truncate">
+              <span
+                className={`text-xs text-muted-foreground truncate ${
+                  fieldTooltip(key) ? "cursor-help underline decoration-dotted" : ""
+                }`}
+                title={fieldTooltip(key)}
+              >
                 {labelWithUnit(key)}
               </span>
               {isEditing ? (
-                <input
-                  value={editValues[key] ?? ""}
-                  onChange={(e) =>
-                    setEditValues((prev) => ({ ...prev, [key]: e.target.value }))
-                  }
-                  className="w-28 text-xs px-1.5 py-1 rounded bg-input border border-border text-foreground"
-                />
+                schemaMeta?.[key]?.options ? (
+                  <select
+                    value={editValues[key] ?? ""}
+                    onChange={(e) =>
+                      setEditValues((prev) => ({ ...prev, [key]: e.target.value }))
+                    }
+                    className="w-28 text-xs px-1.5 py-1 rounded bg-input border border-border text-foreground"
+                  >
+                    {schemaMeta[key].options!.map((opt) => (
+                      <option key={opt} value={opt}>
+                        {opt}
+                      </option>
+                    ))}
+                  </select>
+                ) : (
+                  <input
+                    value={editValues[key] ?? ""}
+                    onChange={(e) =>
+                      setEditValues((prev) => ({ ...prev, [key]: e.target.value }))
+                    }
+                    className="w-28 text-xs px-1.5 py-1 rounded bg-input border border-border text-foreground"
+                  />
+                )
               ) : (
                 <span className="text-xs font-mono text-foreground">
                   {key === "temperature" && typeof value === "number"

--- a/frontend/src/components/panels/SimulateCard.tsx
+++ b/frontend/src/components/panels/SimulateCard.tsx
@@ -197,26 +197,30 @@ export function SimulateCard() {
 
     // Check whether a cached result already exists for the current config.
     // This avoids re-running the full simulation when nothing has changed.
-    // Only applies to steady-state mode; transient runs always execute fresh.
-    if (mode === "steady") {
-      try {
-        const cfgRaw = config as unknown as Record<string, unknown>;
-        const phases = cfgRaw.phases as Record<string, unknown> | undefined;
-        const gas = phases?.gas as Record<string, unknown> | undefined;
-        const mechStr = (gas?.mechanism as string | undefined) ?? null;
+    // Transient runs pass their time/step overrides so the server-side
+    // fingerprint matches what an actual run would have saved.
+    try {
+      const cfgRaw = config as unknown as Record<string, unknown>;
+      const phases = cfgRaw.phases as Record<string, unknown> | undefined;
+      const gas = phases?.gas as Record<string, unknown> | undefined;
+      const mechStr = (gas?.mechanism as string | undefined) ?? null;
 
-        const cacheResp = await checkSimulationCache(cfgRaw, mechStr);
-        if (cacheResp.cached) {
-          setResults(cacheResp.result);
-          const created = cacheResp.meta.created_at;
-          const ageMin = Math.round((Date.now() / 1000 - created) / 60);
-          const ageStr = ageMin < 2 ? "just now" : `${ageMin} min ago`;
-          toast.success(`Loaded cached results from ${ageStr}. Re-run skipped.`);
-          return;
-        }
-      } catch {
-        // Cache check failed (no config path, network error, etc.) — proceed normally.
+      const cacheResp = await checkSimulationCache(
+        cfgRaw,
+        mechStr,
+        mode === "transient" ? parseFloat(simTime) : undefined,
+        mode === "transient" ? parseFloat(timeStep) : undefined,
+      );
+      if (cacheResp.cached) {
+        setResults(cacheResp.result);
+        const created = cacheResp.meta.created_at;
+        const ageMin = Math.round((Date.now() / 1000 - created) / 60);
+        const ageStr = ageMin < 2 ? "just now" : `${ageMin} min ago`;
+        toast.success(`Loaded cached results from ${ageStr}. Re-run skipped.`);
+        return;
       }
+    } catch {
+      // Cache check failed (no config path, network error, etc.) — proceed normally.
     }
 
     beginSimulationRun();

--- a/frontend/src/components/results/ConvergenceTab.tsx
+++ b/frontend/src/components/results/ConvergenceTab.tsx
@@ -256,10 +256,106 @@ export function ConvergenceTab({ data }: Props) {
     );
   }
 
+  // --- Composite / staged stage solvers: model timeline ---
+  // A stage solver that switches between internal models reports the ordered
+  // model names and the switch times; show when each model was active and
+  // mark the switches on the temperature trend.
+  if (series?.model_sequence && series.model_sequence.length > 0) {
+    const times = series.t ?? data.times;
+    const sw = series.switch_times_s ?? [];
+    const tEnd = times.length > 0 ? times[times.length - 1] : undefined;
+    const rows = series.model_sequence.map((model, i) => ({
+      model,
+      from: i === 0 ? 0 : sw[i - 1],
+      to: i < sw.length ? sw[i] : tEnd,
+    }));
+    const switchShapes = sw.map((t) => ({
+      type: "line" as const,
+      x0: t,
+      x1: t,
+      yref: "paper" as const,
+      y0: 0,
+      y1: 1,
+      line: { dash: "dot" as const, width: 1 },
+    }));
+    return (
+      <div className="space-y-4">
+        <p className="text-sm text-muted-foreground">
+          Staged solve: the stage solver switched between internal models at
+          the times below (dotted lines on the trend).
+        </p>
+        <table className="w-full max-w-md text-sm">
+          <thead>
+            <tr className="text-left text-muted-foreground">
+              <th className="pr-6 font-medium">#</th>
+              <th className="pr-6 font-medium">Model</th>
+              <th className="pr-6 font-medium">From</th>
+              <th className="font-medium">To</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((r, i) => (
+              <tr key={`${r.model}-${i}`}>
+                <td className="pr-6">{i + 1}</td>
+                <td className="pr-6 font-mono">{r.model}</td>
+                <td className="pr-6">{fmtSeconds(r.from)}</td>
+                <td>{fmtSeconds(r.to)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        <Plot
+          data={[
+            {
+              // Log time axis: drop t = 0 so the ns-to-ms span stays legible.
+              x: times.map((t) => (t > 0 ? t : null)),
+              y: series.T ?? [],
+              type: "scatter",
+              mode: "lines",
+              name: selectedReactorId ?? "T",
+              line: { width: 2 },
+            },
+          ]}
+          layout={{
+            ...layoutDefaults,
+            title: {
+              text: "Temperature trend with model switches",
+              font: { size: 14 },
+            },
+            shapes: switchShapes,
+            xaxis: {
+              title: { text: "Time (s)", font: { size: 12 } },
+              type: "log",
+              gridcolor,
+            },
+            yaxis: {
+              title: { text: "Temperature (K)", font: { size: 12 } },
+              gridcolor,
+            },
+          }}
+          config={{ responsive: true, displayModeBar: false }}
+          useResizeHandler
+          className="w-full"
+        />
+      </div>
+    );
+  }
+
   // --- All other reactor types ---
   return (
     <p className="text-sm text-muted-foreground">
       No convergence data available for this reactor type.
     </p>
   );
+}
+
+/** Human-readable seconds with an engineering unit (ns / µs / ms / s). */
+function fmtSeconds(t?: number): string {
+  if (t === undefined || !Number.isFinite(t)) return "—";
+  if (t === 0) return "0 s";
+  const a = Math.abs(t);
+  if (a < 1e-6) return `${(t * 1e9).toPrecision(3)} ns`;
+  if (a < 1e-3) return `${(t * 1e6).toPrecision(3)} µs`;
+  if (a < 1) return `${(t * 1e3).toPrecision(3)} ms`;
+  return `${t.toPrecision(3)} s`;
 }

--- a/frontend/src/components/results/PlotsTab.tsx
+++ b/frontend/src/components/results/PlotsTab.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useCallback, useMemo, useState } from "react";
 import Plot from "react-plotly.js";
 import { coerceNumericSeries, pressureYAxis } from "@/lib/plotAxis";
 import { useSelectionStore } from "@/stores/selectionStore";
@@ -16,6 +16,27 @@ function traceModeForSamples(sampleCount: number): "lines" | "lines+markers" {
 export function PlotsTab({ data }: Props) {
   const selectedElement = useSelectionStore((s) => s.selectedElement);
   const theme = useThemeStore((s) => s.theme);
+
+  // Shared x-range: zoom/pan on any plot synchronizes all of them
+  // (double-click autoscale resets the whole set).
+  const [xRange, setXRange] = useState<[number, number] | null>(null);
+  const syncXRelayout = useCallback((event: unknown) => {
+    const e = event as Record<string, unknown>;
+    if (e["xaxis.autorange"]) {
+      setXRange(null);
+    } else if (
+      e["xaxis.range[0]"] !== undefined &&
+      e["xaxis.range[1]"] !== undefined
+    ) {
+      setXRange([Number(e["xaxis.range[0]"]), Number(e["xaxis.range[1]"])]);
+    } else if (Array.isArray(e["xaxis.range"])) {
+      const r = e["xaxis.range"] as [unknown, unknown];
+      setXRange([Number(r[0]), Number(r[1])]);
+    }
+  }, []);
+  const xRangeProps = xRange
+    ? { range: [xRange[0], xRange[1]], autorange: false as const }
+    : {};
 
   // Determine which reactor to plot (selected only)
   const selectedReactorId = useMemo(() => {
@@ -132,10 +153,11 @@ export function PlotsTab({ data }: Props) {
             layout={{
               ...layoutDefaults,
               title: { text: `Temperature vs ${coordLabel}`, font: { size: 14 } },
-              xaxis: { title: { text: xLabel, font: { size: 12 } }, gridcolor },
+              xaxis: { title: { text: xLabel, font: { size: 12 } }, gridcolor, ...xRangeProps },
               yaxis: { title: { text: "Temperature (°C)", font: { size: 12 } }, gridcolor },
             }}
             config={{ responsive: true, displayModeBar: false }}
+            onRelayout={syncXRelayout}
             useResizeHandler
             className="w-full"
           />
@@ -157,10 +179,11 @@ export function PlotsTab({ data }: Props) {
             layout={{
               ...layoutDefaults,
               title: { text: `Pressure vs ${coordLabel}`, font: { size: 14 } },
-              xaxis: { title: { text: xLabel, font: { size: 12 } }, gridcolor },
+              xaxis: { title: { text: xLabel, font: { size: 12 } }, gridcolor, ...xRangeProps },
               yaxis: pressureYAxis(gridcolor),
             }}
             config={{ responsive: true, displayModeBar: false }}
+            onRelayout={syncXRelayout}
             useResizeHandler
             className="w-full"
           />
@@ -177,7 +200,7 @@ export function PlotsTab({ data }: Props) {
                   text: `Mole fraction vs ${coordLabel} (main species)`,
                   font: { size: 14 },
                 },
-                xaxis: { title: { text: xLabel, font: { size: 12 } }, gridcolor },
+                xaxis: { title: { text: xLabel, font: { size: 12 } }, gridcolor, ...xRangeProps },
                 yaxis: {
                   title: { text: "Mole fraction", font: { size: 12 } },
                   gridcolor,
@@ -185,6 +208,7 @@ export function PlotsTab({ data }: Props) {
                 },
               }}
               config={{ responsive: true, displayModeBar: false }}
+              onRelayout={syncXRelayout}
               useResizeHandler
               className="w-full"
             />
@@ -202,7 +226,7 @@ export function PlotsTab({ data }: Props) {
                   text: `Mass fraction vs ${coordLabel} (main species)`,
                   font: { size: 14 },
                 },
-                xaxis: { title: { text: xLabel, font: { size: 12 } }, gridcolor },
+                xaxis: { title: { text: xLabel, font: { size: 12 } }, gridcolor, ...xRangeProps },
                 yaxis: {
                   title: { text: "Mass fraction", font: { size: 12 } },
                   gridcolor,
@@ -210,6 +234,7 @@ export function PlotsTab({ data }: Props) {
                 },
               }}
               config={{ responsive: true, displayModeBar: false }}
+              onRelayout={syncXRelayout}
               useResizeHandler
               className="w-full"
             />
@@ -285,6 +310,7 @@ export function PlotsTab({ data }: Props) {
               showlegend: false,
             }}
             config={{ responsive: true, displayModeBar: false }}
+            onRelayout={syncXRelayout}
             useResizeHandler
             className="w-full"
           />
@@ -307,6 +333,7 @@ export function PlotsTab({ data }: Props) {
               showlegend: false,
             }}
             config={{ responsive: true, displayModeBar: false }}
+            onRelayout={syncXRelayout}
             useResizeHandler
             className="w-full"
           />
@@ -361,6 +388,7 @@ export function PlotsTab({ data }: Props) {
             xaxis: {
               title: { text: "Time (s)", font: { size: 12 } },
               gridcolor,
+              ...xRangeProps,
             },
             yaxis: {
               title: { text: "Temperature (°C)", font: { size: 12 } },
@@ -368,6 +396,7 @@ export function PlotsTab({ data }: Props) {
             },
           }}
           config={{ responsive: true, displayModeBar: false }}
+          onRelayout={syncXRelayout}
           useResizeHandler
           className="w-full"
         />
@@ -392,10 +421,12 @@ export function PlotsTab({ data }: Props) {
             xaxis: {
               title: { text: "Time (s)", font: { size: 12 } },
               gridcolor,
+              ...xRangeProps,
             },
             yaxis: pressureYAxis(gridcolor),
           }}
           config={{ responsive: true, displayModeBar: false }}
+          onRelayout={syncXRelayout}
           useResizeHandler
           className="w-full"
         />
@@ -415,6 +446,7 @@ export function PlotsTab({ data }: Props) {
               xaxis: {
                 title: { text: "Time (s)", font: { size: 12 } },
                 gridcolor,
+                ...xRangeProps,
               },
               yaxis: {
                 title: { text: "Mole fraction", font: { size: 12 } },
@@ -423,6 +455,7 @@ export function PlotsTab({ data }: Props) {
               },
             }}
             config={{ responsive: true, displayModeBar: false }}
+            onRelayout={syncXRelayout}
             useResizeHandler
             className="w-full"
           />
@@ -443,6 +476,7 @@ export function PlotsTab({ data }: Props) {
               xaxis: {
                 title: { text: "Time (s)", font: { size: 12 } },
                 gridcolor,
+                ...xRangeProps,
               },
               yaxis: {
                 title: { text: "Mass fraction", font: { size: 12 } },
@@ -451,6 +485,7 @@ export function PlotsTab({ data }: Props) {
               },
             }}
             config={{ responsive: true, displayModeBar: false }}
+            onRelayout={syncXRelayout}
             useResizeHandler
             className="w-full"
           />

--- a/frontend/src/components/results/ResultsTabs.tsx
+++ b/frontend/src/components/results/ResultsTabs.tsx
@@ -59,6 +59,36 @@ export function ResultsTabs() {
       .catch(() => setPlugins([]));
   }, [results, progress]);
 
+  // After a run completes with nothing selected and no explicit tab choice,
+  // open a plugin pane flagged `preferred` instead of the generic default —
+  // auto-selecting the first node the pane supports so it has content.
+  const setSelectedElement = useSelectionStore((s) => s.setSelectedElement);
+  const autoOpenedForRef = useRef(0);
+  useEffect(() => {
+    if (!results || activeTab !== null || selectedElement) return;
+    if (autoOpenedForRef.current === resultsVersionRef.current) return;
+    const pref = plugins.find((p) => p.preferred);
+    if (!pref) return;
+    const kinds = pref.supported_node_types ?? null;
+    const node = config.nodes.find(
+      (n) => !kinds || kinds.includes(String(n.type)),
+    );
+    if (!node && pref.requires_selection) return;
+    autoOpenedForRef.current = resultsVersionRef.current;
+    if (node) {
+      setSelectedElement({ type: "node", data: { id: node.id, type: node.type } });
+    }
+    setActiveTab(pref.label);
+  }, [
+    results,
+    plugins,
+    activeTab,
+    selectedElement,
+    config.nodes,
+    setActiveTab,
+    setSelectedElement,
+  ]);
+
   // If the error clears while viewing the Error tab, move back to a safe tab.
   useEffect(() => {
     if (!error && activeTab === ERROR_TAB_LABEL) setActiveTab("Plots");

--- a/frontend/src/hooks/useKindSchema.ts
+++ b/frontend/src/hooks/useKindSchema.ts
@@ -1,0 +1,38 @@
+import { useEffect, useState } from "react";
+import { fetchKindFieldMeta, type FieldMeta } from "@/api/kindSchema";
+
+const cache = new Map<string, Record<string, FieldMeta> | null>();
+
+/**
+ * Field metadata (descriptions, enum options, conditional visibility) for a
+ * node/connection kind, from the schema its plugin registered. Null while
+ * loading or when the kind has no schema. Cached per kind for the session.
+ *
+ * The return value derives from the module cache; the state is only a
+ * version bump that re-renders the caller once a fetch resolves.
+ */
+export function useKindSchema(
+  kind: string,
+): Record<string, FieldMeta> | null {
+  const [, bump] = useState(0);
+
+  useEffect(() => {
+    if (!kind || cache.has(kind)) return;
+    let cancelled = false;
+    fetchKindFieldMeta(kind)
+      .then((fields) => {
+        cache.set(kind, fields);
+        if (!cancelled) bump((n) => n + 1);
+      })
+      .catch(() => {
+        // Schema lookup is best-effort; the panel degrades to plain fields.
+        cache.set(kind, null);
+        if (!cancelled) bump((n) => n + 1);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [kind]);
+
+  return kind ? (cache.get(kind) ?? null) : null;
+}

--- a/frontend/src/types/plugin.ts
+++ b/frontend/src/types/plugin.ts
@@ -7,6 +7,8 @@ export interface PluginMeta {
   supported_element_types: string[];
   /** Reactor kinds the plugin applies to (null/absent = any). */
   supported_node_types?: string[] | null;
+  /** Open this pane by default after a run (auto-selecting a node). */
+  preferred?: boolean;
 }
 
 /** A single content descriptor returned by a plugin. */

--- a/frontend/src/types/simulation.ts
+++ b/frontend/src/types/simulation.ts
@@ -24,6 +24,14 @@ export interface ReactorSeries {
    * time [s] on the x-axis in the Plots tab.
    */
   is_residence?: boolean;
+  /**
+   * Composite / staged stage solvers may report which internal model was
+   * active when: the ordered model names, plus the switch times [s] between
+   * consecutive models (length = model_sequence.length - 1). Shown as the
+   * model timeline in the Convergence tab.
+   */
+  model_sequence?: string[];
+  switch_times_s?: number[];
 }
 
 /** Connection (e.g. MFC) report from backend: mass and volumetric flow rates. */

--- a/tests/test_custom_stage_series.py
+++ b/tests/test_custom_stage_series.py
@@ -1,0 +1,63 @@
+"""A CustomStageNetwork's recorded ``.states`` is surfaced as the GUI series.
+
+A plugin stage network that integrates its whole stage internally (its own
+macro-grid, a single ``advance`` call) records the real trajectory in
+``.states``. The per-step trajectory recorder cannot see such a solve, so
+``_series_from_stage_states`` flattens the SolutionArray (plus the network's
+scalars) into the ``reactors_series`` shape the plots and panes consume.
+"""
+
+import cantera as ct
+import numpy as np
+
+from boulder.cantera_converter import _series_from_stage_states
+
+
+def _states_with_extra() -> ct.SolutionArray:
+    gas = ct.Solution("h2o2.yaml")
+    arr = ct.SolutionArray(gas, extra=["t", "T_e"])
+    for i in range(5):
+        gas.TPX = 1000.0 + 100.0 * i, ct.one_atm, "H2:2, O2:1"
+        arr.append(  # type: ignore[call-arg]
+            gas.state, t=1.0e-9 * i, T_e=2000.0 + 50.0 * i
+        )
+    return arr
+
+
+def test_flattens_states_and_extras_and_scalars():
+    """t/T/P plus extra columns and scalars all reach the flat series dict."""
+    series = _series_from_stage_states(
+        _states_with_extra(), scalars={"model_sequence": ["a", "b"], "n": 2}
+    )
+    assert series is not None
+    assert len(series["t"]) == 5
+    # Core state variables are always present (``to_pandas`` omits P).
+    assert len(series["T"]) == 5 and len(series["P"]) == 5
+    # Extra SolutionArray columns are carried through.
+    assert series["T_e"][0] == 2000.0 and len(series["T_e"]) == 5
+    # Species mole fractions are reshaped to a {species: [...]} mapping.
+    assert "H2" in series["X"] and len(series["X"]["H2"]) == 5
+    # Scalars are merged verbatim (panes key off e.g. ``model_sequence``).
+    assert series["model_sequence"] == ["a", "b"]
+    assert series["n"] == 2
+
+
+def test_single_point_trajectory_is_rejected():
+    """A degenerate (< 2 point) trajectory yields None (keeps the snapshot)."""
+    gas = ct.Solution("h2o2.yaml")
+    arr = ct.SolutionArray(gas, extra=["t"])
+    arr.append(gas.state, t=0.0)
+    assert _series_from_stage_states(arr) is None
+
+
+def test_none_states_is_none():
+    """No recorded states -> None (caller falls back to the snapshot)."""
+    assert _series_from_stage_states(None) is None
+
+
+def test_scalars_do_not_override_state_columns():
+    """A scalar named like a state column must not clobber the trajectory."""
+    series = _series_from_stage_states(_states_with_extra(), scalars={"T": 9999.0})
+    assert series is not None
+    assert isinstance(series["T"], list) and len(series["T"]) == 5
+    assert not np.isclose(series["T"][0], 9999.0)

--- a/tests/test_gui_actions_api.py
+++ b/tests/test_gui_actions_api.py
@@ -127,6 +127,7 @@ class TestGuiActionCacheContext:
     def test_build_context_matches_check_cache(self, tmp_path):
         """_build_context and check-cache agree on has_cached_result for body.config."""
         from boulder.api.routes.gui_actions import _build_context
+        from boulder.api.routes.simulations import normalize_config_for_fingerprint
         from boulder.result_cache import (
             compute_fingerprint,
             resolve_mechanism_for_fingerprint,
@@ -134,13 +135,16 @@ class TestGuiActionCacheContext:
 
         yaml_path = tmp_path / "model.yaml"
         yaml_path.write_text("nodes: []\n", encoding="utf-8")
-        mechanism = resolve_mechanism_for_fingerprint(SIMPLE_CONFIG)
-        fingerprint = compute_fingerprint(SIMPLE_CONFIG, mechanism=mechanism)
+        # Write the entry the way a real run does: the worker fingerprints
+        # the normalized (default-group-synthesized) config, not the raw one.
+        snapshot = normalize_config_for_fingerprint(SIMPLE_CONFIG)
+        mechanism = resolve_mechanism_for_fingerprint(snapshot)
+        fingerprint = compute_fingerprint(snapshot, mechanism=mechanism)
         save_result(
             cache_root=tmp_path / ".boulder-cache",
             fingerprint=fingerprint,
             gui_payload=SIMPLE_PAYLOAD,
-            config_snapshot=SIMPLE_CONFIG,
+            config_snapshot=snapshot,
         )
 
         app = create_app()

--- a/tests/test_result_cache.py
+++ b/tests/test_result_cache.py
@@ -12,6 +12,7 @@ Asserts:
 
 from __future__ import annotations
 
+import copy
 import json
 import logging
 import time
@@ -529,13 +530,20 @@ class TestCachedEndpoint:
         We set app.state inside the TestClient context manager (after lifespan
         startup) so that the lifespan reset does not overwrite our value.
         """
+        from boulder.config import synthesize_default_group
+
         fingerprint = "j" * 64
         artifacts_dir = tmp_path / "artifacts"
         artifacts_dir.mkdir()
+        # Real cache entries snapshot the config the worker received — i.e.
+        # AFTER default-group synthesis — and /check-cache normalizes the
+        # submitted config the same way before fingerprinting.
+        snapshot = copy.deepcopy(SIMPLE_CONFIG)
+        synthesize_default_group(snapshot)
         cache_data = {
             "fingerprint": fingerprint,
             "gui_payload": SIMPLE_PAYLOAD,
-            "config_snapshot": SIMPLE_CONFIG,
+            "config_snapshot": snapshot,
             "meta": {"cache_version": CACHE_VERSION, "created_at": time.time()},
             "artifacts_dir": artifacts_dir,
         }
@@ -605,6 +613,61 @@ class TestCachedEndpoint:
         assert resp.status_code == 200
         assert resp.json()["cached"] is True
         assert any("Cache HIT" in m for m in messages), messages
+
+    def test_check_cache_matches_transient_overrides(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Transient re-runs hit: the check injects time/step like a run would.
+
+        A worker that ran with explicit ``simulation_time``/``time_step``
+        saved a snapshot whose ``settings.solver.grid`` carries them; a
+        /check-cache call with the same overrides must produce the same
+        fingerprint (and a different ``simulation_time`` must not).
+        """
+        from boulder.api.routes.simulations import _resolve_run_grid
+        from boulder.config import synthesize_default_group
+
+        snapshot = copy.deepcopy(SIMPLE_CONFIG)
+        synthesize_default_group(snapshot)
+        _resolve_run_grid(snapshot, 5.0, 0.5)
+
+        fingerprint = "k" * 64
+        artifacts_dir = tmp_path / "artifacts2"
+        artifacts_dir.mkdir()
+        app = create_app()
+        with TestClient(app) as client:
+            app.state.preloaded_result = {
+                "fingerprint": fingerprint,
+                "gui_payload": SIMPLE_PAYLOAD,
+                "config_snapshot": snapshot,
+                "meta": {"cache_version": CACHE_VERSION, "created_at": time.time()},
+                "artifacts_dir": artifacts_dir,
+            }
+            cfg = tmp_path / "case2.yaml"
+            cfg.write_text("x: 1", encoding="utf-8")
+            app.state.preloaded_config_path = str(cfg)
+
+            hit = client.post(
+                "/api/simulations/check-cache",
+                json={
+                    "config": SIMPLE_CONFIG,
+                    "simulation_time": 5.0,
+                    "time_step": 0.5,
+                },
+            )
+            assert hit.status_code == 200
+            assert hit.json()["cached"] is True
+
+            miss = client.post(
+                "/api/simulations/check-cache",
+                json={
+                    "config": SIMPLE_CONFIG,
+                    "simulation_time": 7.0,
+                    "time_step": 0.5,
+                },
+            )
+            assert miss.status_code == 200
+            assert miss.json()["cached"] is False
 
     def test_check_cache_logs_miss(self, client_with_cache: TestClient, tmp_path: Path):
         """POST /check-cache announces a MISS when the config differs."""

--- a/tests/test_sim2stone_mechanisms.py
+++ b/tests/test_sim2stone_mechanisms.py
@@ -18,8 +18,10 @@ def test_sim2stone_preserves_per_node_mechanisms() -> None:
     gas_air.TPX = 300.0, ct.one_atm, "N2:0.78,O2:0.21,AR:0.01"
     gas_gri.TPX = 300.0, ct.one_atm, "CH4:1"
 
-    r1 = ct.IdealGasReactor(gas_air, name="R1")
-    r2 = ct.IdealGasReactor(gas_gri, name="R2")
+    # clone=False: Cantera 4 clones the contents by default, and a cloned
+    # Solution loses its `source` (the serializer's mechanism inference).
+    r1 = ct.IdealGasReactor(gas_air, name="R1", clone=False)
+    r2 = ct.IdealGasReactor(gas_gri, name="R2", clone=False)
 
     # Hint serializer if supported
     try:

--- a/tests/test_sim_to_yaml.py
+++ b/tests/test_sim_to_yaml.py
@@ -40,10 +40,10 @@ def _build_test_network():
 
     # Flow devices
     mfc1 = ct.MassFlowController(
-        res_a, mixer, mdot=res_a.thermo.density * 2.5 / 0.21, name="Air Inlet"
+        res_a, mixer, mdot=res_a.phase.density * 2.5 / 0.21, name="Air Inlet"
     )
     mfc2 = ct.MassFlowController(
-        res_b, mixer, mdot=res_b.thermo.density * 1.0, name="Fuel Inlet"
+        res_b, mixer, mdot=res_b.phase.density * 1.0, name="Fuel Inlet"
     )
     valve = ct.Valve(mixer, downstream, K=10.0, name="Valve")
 


### PR DESCRIPTION
Everything a *plugin-provided stage network* needs to be a first-class citizen in the GUI, plus general results-view polish.

## Plugin stage networks in the results views

- **Streaming series** — states recorded by a `CustomStageNetwork` (a plugin's own stage integrator) are surfaced into the per-reactor streaming series, with the network's JSON-serialisable `scalars` merged in verbatim. Plugin reactors now populate the standard Plots/Convergence views and restored (cache/scenario) payloads alike.
- **Convergence tab: model timeline** — a stage solver that switches between internal models can report `model_sequence` + `switch_times_s`; the tab renders a timeline table (model, from, to) and a log-time temperature trend with the switch instants marked.

## Schema-driven property panel

- Plugins can register Pydantic schemas for **connection kinds** (`register_connection_schema`) alongside the existing reactor-kind registry; `GET /api/ui/kind-schema/{kind}` serves the JSON schema for any node or edge kind.
- The properties panel uses it to show **field descriptions as tooltips** (with allowed values), render **enum-constrained fields as dropdowns**, and honor **conditional visibility** (`json_schema_extra={"visible_when": {field: value}}`) — a parameter that only applies to one sub-model is shown only while that sub-model is selected, evaluated live while editing.

## Preferred results pane

- An output-pane plugin can declare itself `preferred`: when a run completes with nothing selected and no explicit tab choice, the GUI auto-selects the first node the pane supports and opens that pane instead of the generic default.

## Result cache

- **Transient re-runs are served from cache too**: the cache-check endpoint now applies the same config normalization + run-grid resolution as a real run (`_resolve_run_grid`), and the frontend passes the transient `simulation_time`/`time_step` overrides, so identical transient re-runs hit instead of always re-solving.

## Plots tab

- **Synchronized x-axes** across the time/position charts: zoom or pan on any chart applies to all of them; double-click autoscale resets the set.

## Misc

- Cantera 4: finished the `reactor.phase` migration (Sankey, script emitter, sim2stone).

Tests: new coverage for the custom-stage series surface and the transient cache-hit path; suite green (pre-existing env-only failures unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)