### PR TITLE
fix: adapt Cantera network examples for Boulder GUI and sim2stone

### DIFF
--- a/boulder/cantera_converter.py
+++ b/boulder/cantera_converter.py
@@ -1130,7 +1130,19 @@ class DualCanteraConverter:
             pc.pressure_coeff = coeff  # type: ignore[attr-defined]
             self.connections[cid] = pc
         elif typ == "Wall":
-            if "electric_power_kW" in props:
+            if "heat_transfer_coeff" in props:
+                # Passive heat-conduction wall: Q = U*A*(T_left - T_right),
+                # recomputed every step from the two reactors' live temperatures
+                # (unlike electric_power_kW below, which is a fixed Q).
+                area = float(props.get("area", 1.0))
+                wall = ct.Wall(
+                    self.reactors[src],
+                    self.reactors[tgt],
+                    A=area,
+                    U=float(props["heat_transfer_coeff"]),
+                    name=cid,  # type: ignore[arg-type]
+                )
+            elif "electric_power_kW" in props:
                 # Torch-style wall: constant power delivered via electric heating.
                 torch_eff = float(props.get("torch_eff", 1.0))
                 gen_eff = float(props.get("gen_eff", 1.0))

--- a/boulder/download_script_emitter.py
+++ b/boulder/download_script_emitter.py
@@ -363,7 +363,13 @@ class CanteraScriptEmitter:
             out.append(f"_mfc_topology[{cid!r}] = ({src!r}, {tgt!r})")
         elif ctype == "Wall":
             area = float(props.get("area", 1.0))
-            if "electric_power_kW" in props:
+            if "heat_transfer_coeff" in props:
+                u_coeff = float(props["heat_transfer_coeff"])
+                out.append(
+                    f"{cref} = ct.Wall({sv}, {tv}, A={area}, "
+                    f"U={u_coeff!r}, name={cid!r})"
+                )
+            elif "electric_power_kW" in props:
                 q_w = (
                     float(props["electric_power_kW"])
                     * 1e3

--- a/boulder/sim2stone.py
+++ b/boulder/sim2stone.py
@@ -652,31 +652,55 @@ def sim_to_internal_config(
         else:
             cid = cid_raw
 
-        # Convert current heat rate to an equivalent electric power in kW (best effort)
         try:
-            q_watts = float(getattr(w, "heat_rate"))
+            heat_transfer_coeff = float(getattr(w, "heat_transfer_coeff"))
         except Exception:
-            q_watts = 0.0
-        # If heat flows from right to left (negative), invert orientation and use positive magnitude
-        if q_watts < 0:
-            electric_power_kW = (-q_watts) / 1e3
-            l_id, r_id = r_id, l_id
-        else:
-            electric_power_kW = q_watts / 1e3
+            heat_transfer_coeff = 0.0
 
-        # Create wall connection dictionary
-        wall_dict = {
-            "id": cid,
-            "type": "Wall",
-            "properties": {
-                "electric_power_kW": electric_power_kW,
-                # Efficiency unknown; preserve neutral defaults used by builder
-                "torch_eff": 1.0,
-                "gen_eff": 1.0,
-            },
-            "source": l_id,
-            "target": r_id,
-        }
+        if heat_transfer_coeff != 0.0:
+            # Passive heat-conduction wall (Q = U*A*(T_left - T_right), evaluated
+            # dynamically every step). Snapshotting heat_rate instead — the
+            # branch below — would freeze the flux at whatever it happens to be
+            # at conversion time (often ~0, since both sides usually start at
+            # the same temperature), silently discarding the U/A coupling.
+            wall_dict = {
+                "id": cid,
+                "type": "Wall",
+                "properties": {
+                    "heat_transfer_coeff": heat_transfer_coeff,
+                    "area": float(getattr(w, "area", 1.0)),
+                },
+                "source": l_id,
+                "target": r_id,
+            }
+        else:
+            # Convert current heat rate to an equivalent electric power in kW
+            # (best effort) — appropriate for torch-style walls whose Q is set
+            # via an explicit function rather than a U/A coefficient.
+            try:
+                q_watts = float(getattr(w, "heat_rate"))
+            except Exception:
+                q_watts = 0.0
+            # If heat flows from right to left (negative), invert orientation
+            # and use positive magnitude.
+            if q_watts < 0:
+                electric_power_kW = (-q_watts) / 1e3
+                l_id, r_id = r_id, l_id
+            else:
+                electric_power_kW = q_watts / 1e3
+
+            wall_dict = {
+                "id": cid,
+                "type": "Wall",
+                "properties": {
+                    "electric_power_kW": electric_power_kW,
+                    # Efficiency unknown; preserve neutral defaults used by builder
+                    "torch_eff": 1.0,
+                    "gen_eff": 1.0,
+                },
+                "source": l_id,
+                "target": r_id,
+            }
 
         # Add description from smart comment extraction if available
         if cid in object_comments:

--- a/tests/test_wall_heat_transfer_coeff.py
+++ b/tests/test_wall_heat_transfer_coeff.py
@@ -1,0 +1,127 @@
+"""Regression tests: ct.Wall(A=, U=) round-trips through STONE correctly.
+
+It must become a real dynamic heat-conduction wall, not a frozen
+electric_power_kW snapshot.
+
+Bug: sim2stone converted every ct.Wall by reading its *instantaneous*
+``heat_rate`` at conversion time and baking it into a constant
+``electric_power_kW``. For a passive U/A wall (e.g. upstream's
+``ct.Wall(cstr, env, A=1.0, U=0.02)`` in periodic_cstr.py), both sides
+typically start at the same temperature, so heat_rate is ~0 at that instant —
+the emitted wall silently became a permanent no-op, discarding the U/A
+coupling the whole example's oscillatory behaviour depends on
+("We need to have heat loss to see the oscillations" — periodic_cstr.py).
+"""
+
+from __future__ import annotations
+
+import cantera as ct
+import pytest
+
+from boulder.cantera_converter import DualCanteraConverter
+from boulder.config import load_yaml_string_with_comments, normalize_config
+from boulder.download_script_emitter import CanteraScriptEmitter
+from boulder.sim2stone import sim_to_stone_yaml
+
+
+def _build_two_reactor_wall_network(U: float = 0.02):
+    gas = ct.Solution("h2o2.yaml")
+    gas.TPX = 770.0, 60.0 * 133.3, "H2:2, O2:1"
+    r1 = ct.IdealGasReactor(gas, name="cstr")
+    env = ct.Reservoir(gas, name="env")
+    ct.Wall(r1, env, A=1.0, U=U, name="wall_0")
+    sim = ct.ReactorNet([r1])
+    return sim
+
+
+def test_sim2stone_preserves_heat_transfer_coeff() -> None:
+    """A U/A wall emits heat_transfer_coeff, not a frozen electric_power_kW."""
+    sim = _build_two_reactor_wall_network(U=0.02)
+    yaml_str = sim_to_stone_yaml(sim, default_mechanism="h2o2.yaml")
+    normalized = normalize_config(load_yaml_string_with_comments(yaml_str))
+
+    (wall,) = [c for c in normalized["connections"] if c["id"] == "wall_0"]
+    assert wall["properties"].get("heat_transfer_coeff") == pytest.approx(0.02)
+    assert "electric_power_kW" not in wall["properties"]
+
+
+def test_sim2stone_zero_u_falls_back_to_electric_power() -> None:
+    """Torch-style wall (no U) must still use the electric_power_kW path.
+
+    This fix must not regress that case.
+    """
+    gas = ct.Solution("gri30.yaml")
+    gas.TPX = 1500.0, ct.one_atm, "CH4:1"
+    r1 = ct.IdealGasReactor(gas, name="combustor")
+    env = ct.Reservoir(gas, name="env")
+    ct.Wall(r1, env, A=1.0, Q=lambda t: 500.0, name="torch")
+    sim = ct.ReactorNet([r1])
+
+    yaml_str = sim_to_stone_yaml(sim, default_mechanism="gri30.yaml")
+    normalized = normalize_config(load_yaml_string_with_comments(yaml_str))
+
+    (wall,) = [c for c in normalized["connections"] if c["id"] == "torch"]
+    assert "heat_transfer_coeff" not in wall["properties"]
+    assert wall["properties"].get("electric_power_kW") == pytest.approx(0.5)
+
+
+def test_cantera_converter_builds_dynamic_wall_from_heat_transfer_coeff() -> None:
+    """build_connection constructs a real U/A wall, not a fixed-Q one.
+
+    build_isolated_reactor is the documented single source of truth for
+    reactor construction outside a full staged-solver build — it registers
+    into converter.reactors[rid], which build_connection then requires.
+    """
+    converter = DualCanteraConverter(mechanism="h2o2.yaml")
+
+    nodes = [
+        {
+            "id": "cstr",
+            "type": "IdealGasReactor",
+            "properties": {
+                "temperature": 770.0,
+                "pressure": 60.0 * 133.3,
+                "composition": "H2:0.6667,O2:0.3333",
+                "volume": 1e-5,
+            },
+        },
+        {
+            "id": "env",
+            "type": "Reservoir",
+            "properties": {
+                "temperature": 770.0,
+                "pressure": 60.0 * 133.3,
+                "composition": "H2:0.6667,O2:0.3333",
+            },
+        },
+    ]
+    conn = {
+        "id": "wall_0",
+        "type": "Wall",
+        "source": "cstr",
+        "target": "env",
+        "properties": {"heat_transfer_coeff": 0.02, "area": 1.0},
+    }
+    for node in nodes:
+        converter.build_isolated_reactor(node)
+    converter.build_connection(conn)
+
+    wall = converter.walls["wall_0"]
+    assert wall.heat_transfer_coeff == pytest.approx(0.02)
+    assert wall.area == pytest.approx(1.0)
+
+
+def test_download_script_emits_u_kwarg_for_heat_transfer_coeff() -> None:
+    """The --download script constructs ct.Wall(..., U=...), not Q=lambda."""
+    conn = {
+        "id": "wall_0",
+        "type": "Wall",
+        "source": "cstr",
+        "target": "env",
+        "properties": {"heat_transfer_coeff": 0.02, "area": 1.0},
+    }
+    emitter = CanteraScriptEmitter()
+    lines = emitter._emit_connection(conn, "_conn_wall_0", "_conn_wall_0_spec")
+    joined = "\n".join(lines)
+    assert "U=0.02" in joined
+    assert "Q=lambda" not in joined


### PR DESCRIPTION
## Summary
- Adapts several Cantera reactor-network examples so they solve/display correctly in Boulder's GUI (residence-time MFC closures, sweep plot fixes, QA cleanup).
- Fixes a sim2stone/converter bug where `ct.Wall(A=, U=)` heat-conduction walls were silently converted into a frozen, zero `electric_power_kW` snapshot — discarding the dynamic U/A coupling several upstream examples (e.g. `periodic_cstr.py`) depend on for their oscillatory behavior.

## Test plan
- [x] `pytest tests/` — 630 passed, 5 pre-existing xfails
- [x] `ruff check` / `mypy` clean on all touched files
- [x] New regression tests in `tests/test_wall_heat_transfer_coeff.py` cover sim2stone export, the runtime converter build, and the `--download` script emitter for both the U/A wall path and the existing torch-style fallback
- [x] Verified end-to-end against boulder_examples' regenerated `periodic_cstr.yaml`: H2 mole fraction now oscillates (~0.017–0.667 sawtooth) instead of staying flat