### PR TITLE
fix: recover Gaussian MFC schedules instead of a frozen snapshot

### DIFF
--- a/boulder/cantera_converter.py
+++ b/boulder/cantera_converter.py
@@ -729,7 +729,10 @@ class DualCanteraConverter:
             args = spec.get("args", [])
             if not isinstance(args, (list, tuple)):
                 args = [args]
-            return ct.Func1(func_name, *[float(a) for a in args])
+            # Cantera's Func1 constructor wants a single list argument for
+            # multi-coefficient kinds (e.g. Gaussian: [peak, center, fwhm]) --
+            # unpacking into separate positional args raises "Invalid arguments".
+            return ct.Func1(func_name, [float(a) for a in args])
         if "profile" in spec or "tabulated" in spec:
             pts_key = "points" if "points" in spec else "tabulated"
             points = spec[pts_key] if pts_key in spec else spec.get("profile")

--- a/boulder/sim2stone.py
+++ b/boulder/sim2stone.py
@@ -1064,6 +1064,23 @@ def sim_to_stone_yaml(
         for cl in ast_result.closures:
             closure_map[cl.mfc_var] = cl
 
+    # AST-detected Gaussian Func1 signals not already consumed by another
+    # binding (e.g. a plasma reduced_electric_field pulse). A live Func1
+    # object exposes no way to recover its coefficients (Cantera's
+    # Func1.write() only returns a generic label, and mfc.mass_flow_rate
+    # always reads back as the evaluated float at the network's current
+    # time, never the Func1 itself) -- so the MFC-building pass above can
+    # only snapshot mass_flow_rate at whatever instant the object is
+    # introspected, discarding the pulse shape entirely. Below, a
+    # single-MFC/single-unclaimed-Gaussian-signal network gets the AST's
+    # recovered peak/center/fwhm substituted back in as a real schedule.
+    _bound_signal_ids = {b.signal_id for b in (ast_result.bindings if ast_result else [])}
+    gaussian_signals = [
+        s
+        for s in (ast_result.signals if ast_result else [])
+        if s.kind == "Gaussian" and s.source_var not in _bound_signal_ids
+    ]
+
     for node in internal.get("nodes", []):
         node_cm = CommentedMap()
         node_cm["id"] = node["id"]
@@ -1135,6 +1152,34 @@ def sim_to_stone_yaml(
                 conn_props["closure"] = "residence_time"
                 conn_props["tau_s"] = f"{{{{{apply_closure.tau_var}}}}}"
                 conn_props.pop("mass_flow_rate", None)
+                conn_props.pop("_comment", None)
+
+        # Substitute a real Gaussian schedule for an MFC whose mass_flow_rate
+        # was snapshotted from a live Func1 (see gaussian_signals comment
+        # above). Same single-MFC/single-signal heuristic as the closure
+        # case: with exactly one candidate on each side, the match is
+        # unambiguous. (Not gated on apply_closure being None: a network
+        # can't have both a residence-time closure and an unclaimed Gaussian
+        # matching the same lone MFC in practice, but if it somehow did, the
+        # closure branch above already cleared mass_flow_rate/_comment, and
+        # this would then set a real schedule instead of leaving it unset --
+        # still strictly better than the stale snapshot.)
+        if conn_is_mfc and len(gaussian_signals) == 1:
+            mfc_connections_all = [
+                c
+                for c in internal.get("connections", [])
+                if c.get("type") == "MassFlowController"
+            ]
+            if len(mfc_connections_all) == 1:
+                sig = gaussian_signals[0]
+                conn_props["mass_flow_rate"] = {
+                    "func": "Gaussian",
+                    "args": [
+                        sig.params["peak"],
+                        sig.params["center"],
+                        sig.params["fwhm"],
+                    ],
+                }
                 conn_props.pop("_comment", None)
 
         conn_cm[conn["type"]] = conn_props if conn_props else None

--- a/boulder/sim2stone.py
+++ b/boulder/sim2stone.py
@@ -1074,7 +1074,9 @@ def sim_to_stone_yaml(
     # introspected, discarding the pulse shape entirely. Below, a
     # single-MFC/single-unclaimed-Gaussian-signal network gets the AST's
     # recovered peak/center/fwhm substituted back in as a real schedule.
-    _bound_signal_ids = {b.signal_id for b in (ast_result.bindings if ast_result else [])}
+    _bound_signal_ids = {
+        b.signal_id for b in (ast_result.bindings if ast_result else [])
+    }
     gaussian_signals = [
         s
         for s in (ast_result.signals if ast_result else [])

--- a/tests/test_phase_b_transient.py
+++ b/tests/test_phase_b_transient.py
@@ -394,6 +394,20 @@ class TestBuildFunc1FromSpec:
         f = DualCanteraConverter._build_func1_from_spec(3)
         assert f(0.0) == pytest.approx(3.0)
 
+    def test_gaussian_func_spec_builds_working_func1(self):
+        """{func: Gaussian, args: [peak, center, fwhm]} builds a real pulse.
+
+        Regression test: ct.Func1(name, *args) raises "Invalid arguments" for
+        multi-coefficient kinds like Gaussian, which require a single list
+        argument -- ct.Func1(name, [peak, center, fwhm]).
+        """
+        from boulder.cantera_converter import DualCanteraConverter
+
+        spec = {"func": "Gaussian", "args": [100.0, 2.0, 0.4]}
+        f = DualCanteraConverter._build_func1_from_spec(spec)
+        assert f(2.0) == pytest.approx(100.0, rel=1e-6)
+        assert f(0.0) < f(2.0)
+
     def test_tabulated_piecewise_linear_interpolation(self):
         """Profile piecewise_linear interpolates between points."""
         from boulder.cantera_converter import DualCanteraConverter

--- a/tests/test_sim2stone_gaussian_mfc.py
+++ b/tests/test_sim2stone_gaussian_mfc.py
@@ -1,0 +1,125 @@
+"""Regression test: a Gaussian-pulse MFC round-trips through STONE correctly.
+
+It must become a real schedule, not a frozen t=0 snapshot.
+
+Bug: mfc.mass_flow_rate always reads back as the evaluated float at the
+network's current time (Cantera never returns the underlying Func1 object),
+so sim2stone's device-introspection pass could only snapshot whatever value
+happened to be current when the object was read -- discarding the pulse
+shape entirely (e.g. upstream's fuel_injection.py Gaussian fuel pulse,
+centered at t=2s with std_dev=0.5s, snapshotted near t=0 collapses to a tiny
+tail value ~1/1000th of the intended flow).
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import textwrap
+
+import pytest
+
+from boulder.config import load_yaml_string_with_comments, normalize_config
+from boulder.sim2stone import sim_to_stone_yaml
+
+
+def _write_and_run(python_content: str) -> str:
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
+        f.write(textwrap.dedent(python_content))
+        f.flush()
+        temp_name = f.name
+
+    try:
+        exec_globals: dict = {}
+        with open(temp_name, "r") as file:
+            exec(file.read(), exec_globals)
+        sim = exec_globals["sim"]
+        return sim_to_stone_yaml(
+            sim,
+            default_mechanism="h2o2.yaml",
+            source_file=temp_name,
+            include_comments=False,
+        )
+    finally:
+        os.unlink(temp_name)
+
+
+def test_gaussian_mfc_gets_real_schedule_not_snapshot() -> None:
+    """A lone Func1-Gaussian MFC's mass_flow_rate becomes a schedule dict."""
+    yaml_str = _write_and_run(
+        """
+        import cantera as ct
+
+        gas = ct.Solution("h2o2.yaml")
+        gas.TPX = 300.0, ct.one_atm, "H2:1, N2:1"
+        inlet = ct.Reservoir(gas, name="inlet")
+
+        gas.TP = 900.0, ct.one_atm
+        r = ct.IdealGasReactor(gas, name="reactor")
+        r.volume = 1e-3
+
+        total_mass = 3.0e-3
+        std_dev = 0.5
+        center_time = 2.0
+        amplitude = total_mass / (std_dev * (2 * 3.141592653589793) ** 0.5)
+        fwhm = std_dev * 2 * (2 * 0.6931471805599453) ** 0.5
+        pulse = ct.Func1("Gaussian", [amplitude, center_time, fwhm])
+
+        ct.MassFlowController(inlet, r, mdot=pulse, name="fuel_mfc")
+        sim = ct.ReactorNet([r])
+        """
+    )
+
+    normalized = normalize_config(load_yaml_string_with_comments(yaml_str))
+    (mfc,) = [c for c in normalized["connections"] if c["id"] == "fuel_mfc"]
+    mfr = mfc["properties"]["mass_flow_rate"]
+
+    assert isinstance(mfr, dict), f"expected a schedule dict, got {mfr!r}"
+    assert mfr["func"] == "Gaussian"
+    assert mfr["args"][1] == pytest.approx(2.0)  # center_time survives intact
+    assert mfr["args"][2] == pytest.approx(1.1774100225154747, rel=1e-6)  # fwhm
+
+    # The top-level signals: block should carry the same AST-recovered signal.
+    assert "signals" in normalized
+    assert any("Gaussian" in s for s in normalized["signals"])
+
+
+def test_gaussian_signal_bound_elsewhere_is_not_reused_for_mfc() -> None:
+    """A Gaussian already claimed by another binding must not be reused.
+
+    It must not also be misapplied to an unrelated MFC in the same network.
+    """
+    yaml_str = _write_and_run(
+        """
+        import cantera as ct
+
+        EN_peak = 1e-19
+        pulse_center = 24e-9
+        pulse_fwhm = 7e-9
+        gaussian_EN = ct.Func1("Gaussian", [EN_peak, pulse_center, pulse_fwhm])
+
+        gas = ct.Solution("h2o2.yaml")
+        gas.TPX = 300.0, ct.one_atm, "H2:1, N2:1"
+        try:
+            # h2o2.yaml is an ideal-gas phase, not plasma -- this raises at
+            # runtime. The AST-based binding detector reads source text
+            # independently of execution, so the assignment still needs to
+            # be *present* here without aborting the rest of the script.
+            gas.reduced_electric_field = gaussian_EN(0.0)
+        except Exception:
+            pass
+
+        inlet = ct.Reservoir(gas, name="inlet")
+        r = ct.IdealGasReactor(gas, name="reactor")
+        r.volume = 1e-3
+        ct.MassFlowController(inlet, r, mdot=0.01, name="steady_mfc")
+        sim = ct.ReactorNet([r])
+        """
+    )
+
+    normalized = normalize_config(load_yaml_string_with_comments(yaml_str))
+    (mfc,) = [c for c in normalized["connections"] if c["id"] == "steady_mfc"]
+    mfr = mfc["properties"]["mass_flow_rate"]
+    # Plain constant mdot -- must stay a scalar, not get hijacked into the
+    # unrelated plasma Gaussian's schedule.
+    assert isinstance(mfr, (int, float))


### PR DESCRIPTION
*Extensive IA Use - Code & PR fully written by Claude Sonnet 5*

## Summary
- sim2stone improvement : sim2stone snapshotted a Func1-backed MassFlowController's mass_flow_rate at whatever instant the object was introspected (Cantera's getter always returns the evaluated float, never the Func1 itself). For a Gaussian fuel pulse centered away from t=0 (e.g. boulder_examples' fuel_injection.py), this collapsed the pulse to a near-zero tail value, silently breaking the pollutant/PAH-formation dynamics the example exists to demonstrate.
- For the common single-MFC/single-signal case, the AST's independently-recovered peak/center/fwhm now gets substituted back in as a real `{func: Gaussian, args: [...]}` schedule.
- Also fixes a related latent bug: `_build_func1_from_spec` called `ct.Func1(name, *args)` which raises for multi-coefficient kinds (Gaussian needs a single list arg, not unpacked positional args).

## Test plan
- [x] `pytest tests/` — 633 passed, 5 pre-existing xfails
- [x] `ruff check` / `mypy` clean
- [x] New regression tests: `test_sim2stone_gaussian_mfc.py` (schedule recovery + no false-positive reuse of a signal already bound elsewhere), `TestBuildFunc1FromSpec::test_gaussian_func_spec_builds_working_func1`
- [x] Verified against boulder_examples' fuel_injection.yaml: PAH precursor species (naphthalene, pyrene, etc.) went from ~1e-15 (numerical noise) to physically real 1e-3-1e-5 mole fractions peaking near the pulse center, matching upstream's qualitative behavior