### PR TITLE
fix: pass through a moving wall's expansion_rate_coeff (piston K)

### DIFF
--- a/boulder/cantera_converter.py
+++ b/boulder/cantera_converter.py
@@ -1133,17 +1133,32 @@ class DualCanteraConverter:
             pc.pressure_coeff = coeff  # type: ignore[attr-defined]
             self.connections[cid] = pc
         elif typ == "Wall":
+            # expansion_rate_coeff (K) makes this a moving piston wall: Cantera
+            # moves it at K*(P_left - P_right) every step, transferring volume
+            # between the two reactors -- native Wall/Reactor ODE physics that
+            # only needs K passed through, not computed here. Independent of
+            # (and combinable with) heat_transfer_coeff/electric_power_kW below.
+            expansion_rate_coeff = (
+                float(props["expansion_rate_coeff"])
+                if "expansion_rate_coeff" in props
+                else None
+            )
             if "heat_transfer_coeff" in props:
                 # Passive heat-conduction wall: Q = U*A*(T_left - T_right),
                 # recomputed every step from the two reactors' live temperatures
                 # (unlike electric_power_kW below, which is a fixed Q).
                 area = float(props.get("area", 1.0))
+                wall_kwargs: Dict[str, Any] = {
+                    "A": area,
+                    "U": float(props["heat_transfer_coeff"]),
+                    "name": cid,
+                }
+                if expansion_rate_coeff is not None:
+                    wall_kwargs["K"] = expansion_rate_coeff
                 wall = ct.Wall(
                     self.reactors[src],
                     self.reactors[tgt],
-                    A=area,
-                    U=float(props["heat_transfer_coeff"]),
-                    name=cid,  # type: ignore[arg-type]
+                    **wall_kwargs,  # type: ignore[arg-type]
                 )
             elif "electric_power_kW" in props:
                 # Torch-style wall: constant power delivered via electric heating.
@@ -1160,12 +1175,16 @@ class DualCanteraConverter:
                 )
             else:
                 # Generic passive wall: heat_flux=0 by default, settable post-build.
+                # Still honours a standalone expansion_rate_coeff (a purely
+                # mechanical piston with no heat exchange).
                 area = float(props.get("area", 1.0))
+                wall_kwargs = {"A": area, "name": cid}
+                if expansion_rate_coeff is not None:
+                    wall_kwargs["K"] = expansion_rate_coeff
                 wall = ct.Wall(
                     self.reactors[src],
                     self.reactors[tgt],
-                    A=area,
-                    name=cid,  # type: ignore[arg-type]
+                    **wall_kwargs,  # type: ignore[arg-type]
                 )
                 if "heat_flux" in props:
                     wall.heat_flux = float(props["heat_flux"])

--- a/boulder/download_script_emitter.py
+++ b/boulder/download_script_emitter.py
@@ -363,11 +363,16 @@ class CanteraScriptEmitter:
             out.append(f"_mfc_topology[{cid!r}] = ({src!r}, {tgt!r})")
         elif ctype == "Wall":
             area = float(props.get("area", 1.0))
+            k_coeff = (
+                f", K={float(props['expansion_rate_coeff'])!r}"
+                if "expansion_rate_coeff" in props
+                else ""
+            )
             if "heat_transfer_coeff" in props:
                 u_coeff = float(props["heat_transfer_coeff"])
                 out.append(
                     f"{cref} = ct.Wall({sv}, {tv}, A={area}, "
-                    f"U={u_coeff!r}, name={cid!r})"
+                    f"U={u_coeff!r}{k_coeff}, name={cid!r})"
                 )
             elif "electric_power_kW" in props:
                 q_w = (
@@ -381,7 +386,9 @@ class CanteraScriptEmitter:
                     f"Q=lambda t: {q_w!r}, name={cid!r})"
                 )
             else:
-                out.append(f"{cref} = ct.Wall({sv}, {tv}, A={area}, name={cid!r})")
+                out.append(
+                    f"{cref} = ct.Wall({sv}, {tv}, A={area}{k_coeff}, name={cid!r})"
+                )
             out.append(f"walls[{cid!r}] = {cref}")
         elif ctype == "Valve":
             coeff = float(props.get("valve_coeff", 1.0))

--- a/boulder/sim2stone.py
+++ b/boulder/sim2stone.py
@@ -657,19 +657,32 @@ def sim_to_internal_config(
         except Exception:
             heat_transfer_coeff = 0.0
 
-        if heat_transfer_coeff != 0.0:
+        try:
+            expansion_rate_coeff = float(getattr(w, "expansion_rate_coeff"))
+        except Exception:
+            expansion_rate_coeff = 0.0
+
+        if heat_transfer_coeff != 0.0 or expansion_rate_coeff != 0.0:
             # Passive heat-conduction wall (Q = U*A*(T_left - T_right), evaluated
             # dynamically every step). Snapshotting heat_rate instead — the
             # branch below — would freeze the flux at whatever it happens to be
             # at conversion time (often ~0, since both sides usually start at
             # the same temperature), silently discarding the U/A coupling.
+            #
+            # expansion_rate_coeff (K) makes this a moving piston wall: Cantera
+            # moves it at K*(P_left - P_right), transferring volume between the
+            # two reactors every step -- this is native Wall/Reactor ODE
+            # physics, not something Boulder computes itself; it only needs to
+            # pass K through so Cantera's own equations do the rest.
+            wall_props: Dict[str, Any] = {"area": float(getattr(w, "area", 1.0))}
+            if heat_transfer_coeff != 0.0:
+                wall_props["heat_transfer_coeff"] = heat_transfer_coeff
+            if expansion_rate_coeff != 0.0:
+                wall_props["expansion_rate_coeff"] = expansion_rate_coeff
             wall_dict = {
                 "id": cid,
                 "type": "Wall",
-                "properties": {
-                    "heat_transfer_coeff": heat_transfer_coeff,
-                    "area": float(getattr(w, "area", 1.0)),
-                },
+                "properties": wall_props,
                 "source": l_id,
                 "target": r_id,
             }

--- a/boulder/sim2stone_ast.py
+++ b/boulder/sim2stone_ast.py
@@ -713,8 +713,12 @@ def _detect_advance_timing(tree: ast.AST) -> Dict[str, Any]:
     env: Dict[str, float] = {}
     tracked = ("t_total", "t_end", "dt_max", "dt_chunk", "n_steps", "step_size", "dt")
 
-    body = tree.body if isinstance(tree, ast.Module) else []
-    for node in body:
+    # Walk the whole tree (not just module top-level statements) so adapters
+    # that keep a stepping pattern under an `if False:` guard purely for AST
+    # extraction (to avoid actually re-running the transient at conversion
+    # time -- see e.g. adapters/reactor2.py) still resolve. Matches
+    # _collect_scalar_assignments's depth-unrestricted approach.
+    for node in ast.walk(tree):
         if not isinstance(node, ast.Assign):
             continue
         if len(node.targets) != 1 or not isinstance(node.targets[0], ast.Name):

--- a/tests/test_wall_heat_transfer_coeff.py
+++ b/tests/test_wall_heat_transfer_coeff.py
@@ -125,3 +125,93 @@ def test_download_script_emits_u_kwarg_for_heat_transfer_coeff() -> None:
     joined = "\n".join(lines)
     assert "U=0.02" in joined
     assert "Q=lambda" not in joined
+
+
+def test_sim2stone_preserves_expansion_rate_coeff() -> None:
+    """A moving piston wall (K=) emits expansion_rate_coeff alongside U/area.
+
+    Without K, Cantera's Wall/Reactor ODE system never moves the piston, so a
+    two-reactor network driven mainly by piston-compression (e.g. upstream's
+    reactor2.py) loses that dynamic almost entirely -- the reactors only
+    exchange heat, not volume.
+    """
+    gas = ct.Solution("h2o2.yaml")
+    gas.TPX = 1000.0, 20.0 * ct.one_atm, "H2:1"
+    r1 = ct.IdealGasReactor(gas, name="left")
+    gas.TPX = 500.0, 0.2 * ct.one_atm, "O2:1"
+    r2 = ct.IdealGasReactor(gas, name="right")
+    ct.Wall(r2, r1, A=1.0, K=0.5e-4, U=100.0, name="piston")
+    sim = ct.ReactorNet([r1, r2])
+
+    yaml_str = sim_to_stone_yaml(sim, default_mechanism="h2o2.yaml")
+    normalized = normalize_config(load_yaml_string_with_comments(yaml_str))
+
+    (wall,) = [c for c in normalized["connections"] if c["id"] == "piston"]
+    assert wall["properties"].get("expansion_rate_coeff") == pytest.approx(0.5e-4)
+    assert wall["properties"].get("heat_transfer_coeff") == pytest.approx(100.0)
+
+
+def test_cantera_converter_builds_moving_wall_from_expansion_rate_coeff() -> None:
+    """build_connection passes K through so Cantera moves the piston itself."""
+    converter = DualCanteraConverter(mechanism="h2o2.yaml")
+
+    nodes = [
+        {
+            "id": "left",
+            "type": "IdealGasReactor",
+            "properties": {
+                "temperature": 1000.0,
+                "pressure": 20.0 * 101325.0,
+                "composition": "H2:1",
+                "volume": 1.0,
+            },
+        },
+        {
+            "id": "right",
+            "type": "IdealGasReactor",
+            "properties": {
+                "temperature": 500.0,
+                "pressure": 0.2 * 101325.0,
+                "composition": "O2:1",
+                "volume": 1.0,
+            },
+        },
+    ]
+    conn = {
+        "id": "piston",
+        "type": "Wall",
+        "source": "right",
+        "target": "left",
+        "properties": {
+            "heat_transfer_coeff": 100.0,
+            "expansion_rate_coeff": 0.5e-4,
+            "area": 1.0,
+        },
+    }
+    for node in nodes:
+        converter.build_isolated_reactor(node)
+    converter.build_connection(conn)
+
+    wall = converter.walls["piston"]
+    assert wall.expansion_rate_coeff == pytest.approx(0.5e-4)
+    assert wall.heat_transfer_coeff == pytest.approx(100.0)
+
+
+def test_download_script_emits_k_kwarg_for_expansion_rate_coeff() -> None:
+    """The --download script constructs ct.Wall(..., K=...) for a piston."""
+    conn = {
+        "id": "piston",
+        "type": "Wall",
+        "source": "right",
+        "target": "left",
+        "properties": {
+            "heat_transfer_coeff": 100.0,
+            "expansion_rate_coeff": 0.5e-4,
+            "area": 1.0,
+        },
+    }
+    emitter = CanteraScriptEmitter()
+    lines = emitter._emit_connection(conn, "_conn_piston", "_conn_piston_spec")
+    joined = "\n".join(lines)
+    assert "K=5e-05" in joined
+    assert "U=100.0" in joined


### PR DESCRIPTION
## Summary
- `ct.Wall(A=, K=, U=)` makes a wall a moving piston (Cantera moves it at `K*(P_left - P_right)` every step, natively transferring volume between the two connected reactors). sim2stone captured `heat_transfer_coeff` but silently dropped `K` entirely, so a piston-driven network (upstream's reactor2.py) only exchanged heat, never volume.
- Also fixes a related bug that was masking this even with `K` wired through: `_detect_advance_timing` only scanned module top-level statements for `n_steps`/`step_size`, so an adapter keeping its stepping pattern under `if False:` (the established pattern here for letting the AST solver-hint detector see a loop's shape without re-running the transient) lost the grid's `stop:` time. Broadened to a full-tree walk, matching `_collect_scalar_assignments`.

## Test plan
- [x] `pytest tests/` — 636 passed, 5 pre-existing xfails
- [x] `ruff check` / `ruff format --check` / `mypy` clean
- [x] New regression tests: `test_sim2stone_preserves_expansion_rate_coeff`, `test_cantera_converter_builds_moving_wall_from_expansion_rate_coeff`, `test_download_script_emits_k_kwarg_for_expansion_rate_coeff`
- [x] Verified against a companion boulder_examples fix (new reactor2 adapter + this K fix): Argon partition pressure now traces 19.0 → 6.7 → 7.2 bar, matching a direct run of the real upstream reactor2.py almost exactly (previously ~0.14 bar total range)