### PR TITLE
fix: target reactor.phase, not gas_for_node, in the plasma schedule callback

### DIFF
--- a/boulder/cantera_converter.py
+++ b/boulder/cantera_converter.py
@@ -1023,7 +1023,12 @@ class DualCanteraConverter:
             if ref_field_spec is not None:
                 # Build a Func1 representing E/N(t) and register it as a callback.
                 ref_func = self._build_func1_from_spec(ref_field_spec)
-                phase = gas_for_node  # shared Solution for clone=False reactors
+                # reactor.phase (not gas_for_node) is whichever Solution the
+                # reactor actually integrates -- gas_for_node is only correct
+                # when clone=False; with the (now default) clone=True, the
+                # reactor gets an independent copy, and mutating gas_for_node
+                # would silently update a phase object nothing reads from.
+                phase = reactor.phase
 
                 def _ref_callback(net, t0, t1, _phase=phase, _f=ref_func):
                     t_mid = (t0 + t1) / 2.0

--- a/tests/test_phase_b_transient.py
+++ b/tests/test_phase_b_transient.py
@@ -199,6 +199,46 @@ class TestRunTransientSolver:
         assert len(fired_chunks) == 3
 
 
+class TestScheduleReducedElectricFieldTargetsLivePhase:
+    """create_reactor_from_node's inline schedule: must target reactor.phase.
+
+    Regression test: the registered callback used to close over gas_for_node
+    (the pre-construction Solution), which is only the phase the reactor
+    actually integrates when clone=False. With the default clone=True, the
+    reactor gets an independent copy and the callback would silently mutate
+    an orphaned object nothing reads from.
+    """
+
+    def test_callback_targets_reactor_phase_not_gas_for_node(self):
+        from boulder.cantera_converter import DualCanteraConverter
+
+        converter = DualCanteraConverter(mechanism="gri30.yaml")
+        gas = converter.gas
+        gas.TPX = 1200.0, 101325.0, "N2:1"
+
+        node = {
+            "id": "batch",
+            "type": "IdealGasReactor",
+            "properties": {
+                "temperature": 1200.0,
+                "pressure": 101325.0,
+                "composition": "N2:1",
+                # clone defaults to True -- reactor.phase must differ from gas.
+                "schedule": {"reduced_electric_field": 5.0},
+            },
+        }
+        reactor = converter.create_reactor_from_node(node, gas)
+
+        assert reactor.phase is not gas  # confirms clone=True actually cloned
+        assert len(converter._schedule_callbacks) == 1
+        cb = converter._schedule_callbacks[0]
+        # _phase/_f are bound as default parameter values, not closure cells.
+        param_names = cb.__code__.co_varnames[: cb.__code__.co_argcount]
+        defaults = dict(zip(param_names[-len(cb.__defaults__) :], cb.__defaults__))
+        assert defaults["_phase"] is reactor.phase
+        assert defaults["_phase"] is not gas
+
+
 # ---------------------------------------------------------------------------
 # Integration test: advance_grid on a real (inert) Cantera network
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
*Extensive IA Use - Code & PR fully written by Claude Sonnet 5*

## Summary
- `create_reactor_from_node`'s inline `schedule: {reduced_electric_field: ...}` callback closed over `gas_for_node` (the pre-construction Solution), which only equals the phase the reactor actually integrates when `clone=False`. With the now-default `clone=True`, the reactor gets an independent copy, so the callback silently mutated an orphaned Phase object -- no error, no effect.
- Investigated while digging into why `nanosecond_pulse_discharge` shows no gas heating or species evolution in Boulder's GUI vs. upstream. That specific example drives its plasma field via the top-level `bindings:` mechanism (`boulder/bindings.py`), which already correctly used `reactor.phase` -- so this fix doesn't change its behavior. It closes the same latent gap for the inline node-level `schedule:` property, which does hit this code path.
- The dominant reason that example stays far below upstream's plotted magnitudes is a genuine, currently open **Cantera** limitation, not fixable here: `PlasmaPhase` has no `cp_mole()` implemented in Cantera 3.2, so upstream's `energy="on"` raises immediately, forcing the adapter to use `energy="off"` -- losing the thermal feedback needed to reach a self-sustaining discharge. Documented in a companion boulder_examples manifest-notes update.

## Test plan
- [x] `pytest tests/` — 637 passed, 5 pre-existing xfails
- [x] `ruff check` / `ruff format --check` / `mypy` clean
- [x] New regression test confirms the registered callback now closes over `reactor.phase`, not the pre-clone `gas_for_node`, when `clone=True` (the default)