### PR TITLE
docs: require AI-disclosure in PRs; add CLAUDE.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,6 +154,16 @@ Recipe for verifying a YAML against a running Boulder API without using the brow
 - **Do not commit** unless the user or maintainer explicitly asks (team rule for agents).
 - GitHub Releases: workflow [.github/workflows/release.yml](.github/workflows/release.yml) builds wheel and sdist with full git history (`setuptools_scm`).
 
+## Pull requests
+
+- **Disclose AI involvement.** Every PR written or substantially assisted by an AI coding
+  agent must say so in the PR description, naming the model, e.g.:
+
+  > *Extensive AI use — code & PR fully written by Claude Sonnet 5*
+
+  Use whatever phrasing fits the actual level of involvement (e.g. "AI-assisted" vs. "fully
+  written by") but always name the model.
+
 ## License
 
 This project is licensed under the MIT License; see the [LICENSE](LICENSE) file in the repository root.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+# CLAUDE.md
+
+Read [AGENTS.md](AGENTS.md) first — it is the canonical contributor and agent guide for this
+repository (project layout, environment setup, verification commands, coding conventions, PR
+requirements). Follow it for all work in this repo.


### PR DESCRIPTION
## Summary
- AGENTS.md now requires every AI-assisted PR to disclose the model used in its description.
- Added CLAUDE.md pointing Claude Code at AGENTS.md as the canonical guide for this repo.

*Extensive AI use — code & PR fully written by Claude Sonnet 5*