### PR TITLE
fix: capture mass fractions alongside mole fractions in transient trajectories

### DIFF
--- a/boulder/cantera_converter.py
+++ b/boulder/cantera_converter.py
@@ -287,6 +287,16 @@ def _series_from_stage_states(
     except Exception:  # noqa: BLE001 — species optional; core variables suffice
         pass
     try:
+        names = list(states.species_names)
+        y_mat = np.atleast_2d(np.asarray(states.Y, dtype=float))
+        if y_mat.shape[0] == len(t_col):
+            series["Y"] = {
+                sp: [float(y_mat[i, j]) for i in range(y_mat.shape[0])]
+                for j, sp in enumerate(names)
+            }
+    except Exception:  # noqa: BLE001 — species optional; core variables suffice
+        pass
+    try:
         frame = states.to_pandas()
     except Exception:  # noqa: BLE001 — extras optional
         frame = None
@@ -544,6 +554,7 @@ class _TrajectoryRecorder:
                     "T": [],
                     "P": [],
                     "X": [],
+                    "Y": [],
                     "names": list(phase.species_names),
                 },
             )
@@ -551,6 +562,7 @@ class _TrajectoryRecorder:
             d["T"].append(float(phase.T))
             d["P"].append(float(phase.P))
             d["X"].append(phase.X.copy())
+            d["Y"].append(phase.Y.copy())
 
     def series(self) -> Dict[str, Dict[str, Any]]:
         """Return ``{reactor_id: series}`` for reactors with a real trajectory."""
@@ -562,11 +574,16 @@ class _TrajectoryRecorder:
                 continue
             names = d["names"]
             xmat = np.asarray(d["X"], dtype=float)
+            ymat = np.asarray(d["Y"], dtype=float)
             out[rid] = {
                 "T": [float(v) for v in d["T"]],
                 "P": [float(v) for v in d["P"]],
                 "X": {
                     sp: [float(xmat[i, j]) for i in range(xmat.shape[0])]
+                    for j, sp in enumerate(names)
+                },
+                "Y": {
+                    sp: [float(ymat[i, j]) for i in range(ymat.shape[0])]
                     for j, sp in enumerate(names)
                 },
                 "t": [float(v) for v in d["t"]],

--- a/boulder/cantera_converter.py
+++ b/boulder/cantera_converter.py
@@ -259,11 +259,18 @@ def _series_from_stage_states(
     network's JSON-serialisable ``scalars`` are carried through verbatim so
     downstream panes can consume them.
     """
+    # Errors expected from a SolutionArray/phase that doesn't support a given
+    # accessor (missing attribute, wrong shape/dtype, or a Cantera-native
+    # rejection e.g. for a phase type without the requested property) -- never
+    # a bare `except Exception`, so a genuine bug elsewhere still surfaces.
+    _states_errors = (AttributeError, ValueError, TypeError, ct.CanteraError)
+
     if states is None:
         return None
     try:
         t_col = [float(v) for v in states.t]
-    except Exception:  # noqa: BLE001 — any non-conforming states object: skip
+    except _states_errors as exc:
+        logger.debug("Stage states have no usable time column: %s", exc)
         return None
     if len(t_col) < 2:
         return None
@@ -276,29 +283,37 @@ def _series_from_stage_states(
         "T": [float(v) for v in states.T],
         "P": [float(v) for v in states.P],
     }
+    # Species composition is optional: a phase with no species, or one whose
+    # composition Cantera can't expose here (e.g. some incompressible/pure-fluid
+    # phases), must not stop the core T/P/t series from being returned.
     try:
         names = list(states.species_names)
-        x_mat = np.atleast_2d(np.asarray(states.X, dtype=float))
-        if x_mat.shape[0] == len(t_col):
-            series["X"] = {
-                sp: [float(x_mat[i, j]) for i in range(x_mat.shape[0])]
-                for j, sp in enumerate(names)
-            }
-    except Exception:  # noqa: BLE001 — species optional; core variables suffice
-        pass
-    try:
-        names = list(states.species_names)
-        y_mat = np.atleast_2d(np.asarray(states.Y, dtype=float))
-        if y_mat.shape[0] == len(t_col):
-            series["Y"] = {
-                sp: [float(y_mat[i, j]) for i in range(y_mat.shape[0])]
-                for j, sp in enumerate(names)
-            }
-    except Exception:  # noqa: BLE001 — species optional; core variables suffice
-        pass
+    except _states_errors as exc:
+        logger.debug("Stage states expose no species composition: %s", exc)
+        names = []
+    if names:
+        try:
+            x_mat = np.atleast_2d(np.asarray(states.X, dtype=float))
+            if x_mat.shape[0] == len(t_col):
+                series["X"] = {
+                    sp: [float(x_mat[i, j]) for i in range(x_mat.shape[0])]
+                    for j, sp in enumerate(names)
+                }
+        except _states_errors as exc:
+            logger.debug("Could not read mole fractions from stage states: %s", exc)
+        try:
+            y_mat = np.atleast_2d(np.asarray(states.Y, dtype=float))
+            if y_mat.shape[0] == len(t_col):
+                series["Y"] = {
+                    sp: [float(y_mat[i, j]) for i in range(y_mat.shape[0])]
+                    for j, sp in enumerate(names)
+                }
+        except _states_errors as exc:
+            logger.debug("Could not read mass fractions from stage states: %s", exc)
     try:
         frame = states.to_pandas()
-    except Exception:  # noqa: BLE001 — extras optional
+    except _states_errors as exc:
+        logger.debug("Could not read extra columns from stage states: %s", exc)
         frame = None
     if frame is not None:
         for col in frame.columns:

--- a/tests/test_custom_stage_series.py
+++ b/tests/test_custom_stage_series.py
@@ -37,6 +37,9 @@ def test_flattens_states_and_extras_and_scalars():
     assert series["T_e"][0] == 2000.0 and len(series["T_e"]) == 5
     # Species mole fractions are reshaped to a {species: [...]} mapping.
     assert "H2" in series["X"] and len(series["X"]["H2"]) == 5
+    # Mass fractions likewise (regression: only X used to be captured, so the
+    # frontend's "Mass fraction" plot silently had nothing to render).
+    assert "H2" in series["Y"] and len(series["Y"]["H2"]) == 5
     # Scalars are merged verbatim (panes key off e.g. ``model_sequence``).
     assert series["model_sequence"] == ["a", "b"]
     assert series["n"] == 2

--- a/tests/test_transient_capture.py
+++ b/tests/test_transient_capture.py
@@ -56,6 +56,13 @@ def test_transient_run_yields_multipoint_trajectory():
     assert max(s["T"]) - min(s["T"]) > 100.0
     assert max(s["T"]) > 2000.0  # reacted
 
+    # Mass fractions must be captured alongside mole fractions (regression:
+    # the recorder used to only track X, so the frontend's "Mass fraction"
+    # plot silently had nothing to render for any residence-time trajectory).
+    assert "Y" in s
+    assert len(s["Y"]["CH4"]) == len(s["T"])
+    assert max(s["Y"]["CH4"]) > min(s["Y"]["CH4"])  # fuel is consumed
+
 
 def test_steady_run_stays_single_point():
     config = _config({"kind": "advance_to_steady_state"})


### PR DESCRIPTION
## Summary
- Both per-step trajectory sources (`_TrajectoryRecorder`, used for residence-time / closed-CSTR `advance_grid` captures, and `_series_from_stage_states`, used for `CustomStageNetwork` plugin stages) only ever recorded `phase.X` (mole fractions), never `phase.Y` (mass fractions).
- The frontend's "Mass fraction" plot is gated on `massFractionTraces.length > 0`, so for any transient reactor using either path it silently rendered nothing — no chart at all, easy to miss since the Mole fraction chart right above it looks complete on its own.
- Concretely: `periodic_cstr.yaml`'s H2/O2/H2O mass-fraction plot (the exact one upstream's `periodic_cstr.py` plots) was entirely absent from Boulder's Plots tab.

## Test plan
- [x] `pytest tests/` — 637 passed, 5 pre-existing xfails
- [x] `ruff check` / `ruff format --check` / `mypy` clean
- [x] Extended regression tests in `test_transient_capture.py` / `test_custom_stage_series.py` to assert `Y` is populated
- [x] Verified live in the GUI (periodic_cstr.yaml): the Mass fraction chart now renders and matches upstream's oscillation (H2O ~0 → 0.98, O2 0.014 → 0.888, H2 0.0017 → 0.112)

*Extensive AI use — code & PR fully written by Claude Sonnet 5*