### PR TITLE
feat: scenario authoring in the Scenario Pane

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,14 @@ Deep-dive architecture: [ARCHITECTURE.md](ARCHITECTURE.md).
 
 ## Verification (what to run before a PR)
 
-From the repo root **with conda `boulder` active**:
+**Before every commit**, run at minimum:
+
+```bash
+make qa           # pre-commit on all files
+make type-check   # mypy strict
+```
+
+From the repo root **with conda `boulder` active**, the fuller pre-PR pass:
 
 ```bash
 make unit-tests COV_REPORT=xml   # or html locally

--- a/boulder/api/main.py
+++ b/boulder/api/main.py
@@ -211,25 +211,26 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
             logger.error(f"Failed to load preloaded configuration: {e}")
 
     # Resolve the scenario-inspector store (HDF5): explicit env override wins,
-    # else the preloaded config's ``metadata.extra.scenario_store`` resolved
-    # relative to the YAML's directory. Enables the GUI Scenario Pane.
+    # else the preloaded config's ``metadata.extra.scenario_store`` (or the
+    # ``<stem>_scenarios.h5`` default) whenever there is a run-set to show —
+    # declared inline (``scenario:``/``sweep:``/``sweeps:``), a host
+    # ``run_sweep.py`` next to the config, or ``--sweep`` (BOULDER_SWEEP_MODE).
+    # Reuses the same detection the Run Sweep button uses (routes.sweep) so a
+    # config with a run-set shows its precomputed Scenario Pane on plain
+    # ``bloc config.yaml`` — no flag required.
     try:
         store_env = os.environ.get("BOULDER_SCENARIO_STORE")
         if store_env and store_env.strip():
             app.state.scenario_store_path = store_env.strip()
         elif app.state.preloaded_config and app.state.preloaded_config_path:
-            extra = (app.state.preloaded_config.get("metadata") or {}).get(
-                "extra"
-            ) or {}
-            rel = extra.get("scenario_store")
-            base = Path(app.state.preloaded_config_path).resolve().parent
-            if rel:
-                app.state.scenario_store_path = str((base / rel).resolve())
-            elif os.environ.get("BOULDER_SWEEP_MODE"):
-                # Sweep mode with no declared store → default next to the config,
-                # so pre-computed scenarios (if any) show in the pane.
-                stem = Path(app.state.preloaded_config_path).stem
-                app.state.scenario_store_path = str(base / f"{stem}_scenarios.h5")
+            from .routes.sweep import has_run_set, resolve_store_path
+
+            raw = app.state.preloaded_raw or {}
+            cfg_path = app.state.preloaded_config_path
+            if os.environ.get("BOULDER_SWEEP_MODE") or has_run_set(raw, cfg_path):
+                store = resolve_store_path(raw, cfg_path)
+                if store is not None:
+                    app.state.scenario_store_path = str(store)
         if app.state.scenario_store_path:
             logger.info("Scenario store enabled: %s", app.state.scenario_store_path)
     except Exception as store_err:  # noqa: BLE001

--- a/boulder/api/routes/scenarios.py
+++ b/boulder/api/routes/scenarios.py
@@ -114,6 +114,145 @@ async def get_scenario(scenario_id: str, request: Request) -> Dict[str, Any]:
 
 
 # --------------------------------------------------------------------------- #
+# Scenario authoring — create/edit/delete a ``scenario:`` overlay on disk.
+#
+# Unlike the read routes above (which serve precomputed HDF5 trajectories),
+# these operate on the *source* config file (``app.state.preloaded_config_path``)
+# so a newly created or edited scenario is picked up by the next Run Sweep.
+# Only that scenario's subtree is touched on disk.
+# --------------------------------------------------------------------------- #
+
+
+class CreateScenarioRequest(BaseModel):
+    scenario_id: str
+    base_scenario_id: Optional[str] = None
+
+
+class UpdateScenarioRequest(BaseModel):
+    yaml: str
+
+
+class RenameScenarioRequest(BaseModel):
+    new_id: str
+
+
+def _config_path(request: Request) -> Optional[Path]:
+    raw = getattr(request.app.state, "preloaded_config_path", None)
+    return Path(raw) if raw else None
+
+
+def _require_config_path(request: Request) -> Path:
+    cfg_path = _config_path(request)
+    if cfg_path is None:
+        raise HTTPException(
+            status_code=400,
+            detail="No configuration file loaded — scenarios can only be "
+            "authored against a config Boulder was started with (a file path, "
+            "not an uploaded/pasted config).",
+        )
+    return cfg_path
+
+
+def _reload_preloaded_state(request: Request, cfg_path: Path) -> None:
+    """Refresh the in-memory preloaded config after an on-disk scenario edit.
+
+    Mirrors the subset of the app's startup load that Run Sweep and the config
+    endpoints read (``preloaded_raw`` keeps ``scenario:``/``sweep:`` for the
+    Run Sweep button; ``preloaded_config``/``preloaded_yaml`` back the editor
+    panel). Cached simulation results are untouched — editing a scenario
+    doesn't invalidate the base config's last solve.
+    """
+    from ...runner import BoulderRunner
+
+    runner_cls = getattr(request.app.state, "runner_class", None) or BoulderRunner
+    raw = runner_cls.load(str(cfg_path))
+    request.app.state.preloaded_raw = raw
+    with open(cfg_path, "r", encoding="utf-8") as f:
+        request.app.state.preloaded_yaml = f.read()
+    normalized = runner_cls.normalize(raw)
+    request.app.state.preloaded_config = runner_cls.validate(normalized)
+
+
+@router.get("/{scenario_id}/source")
+async def get_scenario_source(scenario_id: str, request: Request) -> Dict[str, Any]:
+    """Return one scenario overlay's raw YAML text (for the scoped editor)."""
+    cfg_path = _require_config_path(request)
+    try:
+        from ...scenario_editor import ScenarioEditError, read_scenario
+
+        yaml_text = read_scenario(cfg_path, scenario_id)
+    except ScenarioEditError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    return {"scenario_id": scenario_id, "yaml": yaml_text}
+
+
+@router.post("")
+async def create_scenario(
+    body: CreateScenarioRequest, request: Request
+) -> Dict[str, Any]:
+    """Create a new scenario overlay — blank, or cloned from an existing one."""
+    cfg_path = _require_config_path(request)
+    try:
+        from ...scenario_editor import ScenarioEditError
+        from ...scenario_editor import create_scenario as _create
+
+        yaml_text = _create(cfg_path, body.scenario_id, body.base_scenario_id)
+    except ScenarioEditError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    _reload_preloaded_state(request, cfg_path)
+    return {"scenario_id": body.scenario_id, "yaml": yaml_text}
+
+
+@router.patch("/{scenario_id}")
+async def update_scenario(
+    scenario_id: str, body: UpdateScenarioRequest, request: Request
+) -> Dict[str, Any]:
+    """Save edits to a scenario overlay's YAML text."""
+    cfg_path = _require_config_path(request)
+    try:
+        from ...scenario_editor import ScenarioEditError
+        from ...scenario_editor import update_scenario as _update
+
+        yaml_text = _update(cfg_path, scenario_id, body.yaml)
+    except ScenarioEditError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    _reload_preloaded_state(request, cfg_path)
+    return {"scenario_id": scenario_id, "yaml": yaml_text}
+
+
+@router.patch("/{scenario_id}/rename")
+async def rename_scenario(
+    scenario_id: str, body: RenameScenarioRequest, request: Request
+) -> Dict[str, Any]:
+    """Rename a scenario's id (its ``scenario:`` mapping key)."""
+    cfg_path = _require_config_path(request)
+    try:
+        from ...scenario_editor import ScenarioEditError
+        from ...scenario_editor import rename_scenario as _rename
+
+        _rename(cfg_path, scenario_id, body.new_id)
+    except ScenarioEditError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    _reload_preloaded_state(request, cfg_path)
+    return {"ok": True, "scenario_id": body.new_id}
+
+
+@router.delete("/{scenario_id}")
+async def delete_scenario(scenario_id: str, request: Request) -> Dict[str, Any]:
+    """Delete a scenario overlay. The next Run Sweep prunes its stale HDF5 group."""
+    cfg_path = _require_config_path(request)
+    try:
+        from ...scenario_editor import ScenarioEditError
+        from ...scenario_editor import delete_scenario as _delete
+
+        _delete(cfg_path, scenario_id)
+    except ScenarioEditError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    _reload_preloaded_state(request, cfg_path)
+    return {"ok": True, "scenario_id": scenario_id}
+
+
+# --------------------------------------------------------------------------- #
 # Scenario-focus channel — a generic remote-control seam.
 #
 # An external process (e.g. a separate result dashboard) can ask the open GUI to

--- a/boulder/api/routes/sweep.py
+++ b/boulder/api/routes/sweep.py
@@ -67,23 +67,59 @@ def _run_set_size(raw: Dict[str, Any]) -> int:
     return total
 
 
-def _local_runner_path(request: Request) -> Optional[Path]:
-    """Return the ``run_sweep.py`` next to the preloaded config, if present."""
-    cfg_path = getattr(request.app.state, "preloaded_config_path", None)
-    if not cfg_path:
+def _local_runner_path_for(config_path: Optional[str]) -> Optional[Path]:
+    """Return the ``run_sweep.py`` next to *config_path*, if present."""
+    if not config_path:
         return None
-    local = Path(cfg_path).resolve().parent / _RUNNER_NAME
+    local = Path(config_path).resolve().parent / _RUNNER_NAME
     return local if local.is_file() else None
 
 
-def _has_run_set(request: Request) -> bool:
-    raw = getattr(request.app.state, "preloaded_raw", None) or {}
+def has_run_set(raw: Dict[str, Any], config_path: Optional[str]) -> bool:
+    """Does *raw* (the inheritance-resolved config) declare a run-set?
+
+    True when it has an inline ``scenario:``/``sweep:``/``sweeps:`` block, or a
+    ``run_sweep.py`` sits next to the config (a host-defined run-set: the runner
+    script decides the cases — e.g. adaptive/bisection sweeps a static ``sweep:``
+    block can't express). Pure function of ``(raw, config_path)`` so both the
+    request-scoped sweep routes and the app-startup lifespan can share one
+    detection rule instead of re-deciding "is this a sweep config?" twice.
+    """
     if raw.get("scenario") or _sweep_block(raw):
         return True
-    # A run_sweep.py next to the config is a host-defined run-set: the runner
-    # script decides the cases (e.g. adaptive/bisection sweeps that a static
-    # `sweep:` block cannot express).
-    return _local_runner_path(request) is not None
+    return _local_runner_path_for(config_path) is not None
+
+
+def resolve_store_path(
+    raw: Dict[str, Any], config_path: Optional[str]
+) -> Optional[Path]:
+    """Return the collection store a run-set writes to, or ``None``.
+
+    Declared via ``metadata.extra.scenario_store`` or the ``<stem>_scenarios.h5``
+    default (must match the runner's default). ``None`` when *config_path* is
+    unset — there is no config to resolve a default against.
+    """
+    if not config_path:
+        return None
+    cfg = Path(config_path).resolve()
+    rel = ((raw.get("metadata") or {}).get("extra") or {}).get("scenario_store")
+    if rel:
+        p = Path(rel)
+        return p if p.is_absolute() else cfg.parent / p
+    return cfg.parent / f"{cfg.stem}_scenarios.h5"
+
+
+def _local_runner_path(request: Request) -> Optional[Path]:
+    """Return the ``run_sweep.py`` next to the preloaded config, if present."""
+    return _local_runner_path_for(
+        getattr(request.app.state, "preloaded_config_path", None)
+    )
+
+
+def _has_run_set(request: Request) -> bool:
+    return has_run_set(
+        _raw(request), getattr(request.app.state, "preloaded_config_path", None)
+    )
 
 
 def _raw(request: Request) -> Dict[str, Any]:
@@ -91,22 +127,10 @@ def _raw(request: Request) -> Dict[str, Any]:
 
 
 def _store_path(request: Request) -> Optional[Path]:
-    """Return the collection store the run-set writes to.
-
-    Declared via ``metadata.extra.scenario_store`` or the ``<stem>_scenarios.h5``
-    default (must match the runner's default).
-    """
-    cfg_path = getattr(request.app.state, "preloaded_config_path", None)
-    if not cfg_path:
-        return None
-    cfg = Path(cfg_path).resolve()
-    rel = ((_raw(request).get("metadata") or {}).get("extra") or {}).get(
-        "scenario_store"
+    """Return the collection store the run-set writes to (request-scoped wrapper)."""
+    return resolve_store_path(
+        _raw(request), getattr(request.app.state, "preloaded_config_path", None)
     )
-    if rel:
-        p = Path(rel)
-        return p if p.is_absolute() else cfg.parent / p
-    return cfg.parent / f"{cfg.stem}_scenarios.h5"
 
 
 def _runner_command(request: Request) -> Optional[Dict[str, Any]]:

--- a/boulder/api/routes/sweep.py
+++ b/boulder/api/routes/sweep.py
@@ -76,7 +76,7 @@ def _local_runner_path_for(config_path: Optional[str]) -> Optional[Path]:
 
 
 def has_run_set(raw: Dict[str, Any], config_path: Optional[str]) -> bool:
-    """Does *raw* (the inheritance-resolved config) declare a run-set?
+    """Return whether *raw* (the inheritance-resolved config) declares a run-set.
 
     True when it has an inline ``scenario:``/``sweep:``/``sweeps:`` block, or a
     ``run_sweep.py`` sits next to the config (a host-defined run-set: the runner

--- a/boulder/scenario_editor.py
+++ b/boulder/scenario_editor.py
@@ -1,0 +1,140 @@
+"""Scenario authoring: create/update/delete a named ``scenario:`` overlay on disk.
+
+Complements :mod:`boulder.api.routes.scenarios` (which only *reads* precomputed
+trajectories from the HDF5 scenario store) with the input side of the Scenario
+Pane: creating a new scenario adds a new named overlay, editing it changes
+only that overlay's subtree, and ``Run Sweep`` is what turns overlays into
+trajectories.
+
+Every function here mutates only the targeted ``scenario.<id>`` subtree of the
+YAML on disk via ``ruamel.yaml`` — nodes, connections, settings, and comments
+elsewhere in the file are left untouched.
+"""
+
+from __future__ import annotations
+
+import copy
+import re
+from pathlib import Path
+from typing import Any, List, Optional
+
+from ruamel.yaml.comments import CommentedMap
+
+from .config import (
+    get_yaml_with_comments,
+    load_config_file_with_comments,
+    load_yaml_string_with_comments,
+    yaml_to_string_with_comments,
+)
+
+_ID_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+
+
+class ScenarioEditError(ValueError):
+    """Invalid scenario id / body / operation — routes map this to HTTP 4xx."""
+
+
+def _validate_id(scenario_id: str) -> None:
+    if not scenario_id or not _ID_RE.match(scenario_id):
+        raise ScenarioEditError(
+            f"Invalid scenario id {scenario_id!r}: use letters, digits, "
+            "'_' or '-' only"
+        )
+
+
+def _load(cfg_path: Path) -> CommentedMap:
+    data = load_config_file_with_comments(str(cfg_path))
+    if not isinstance(data, dict):
+        raise ScenarioEditError(f"{cfg_path} does not contain a YAML mapping")
+    return data
+
+
+def _save(cfg_path: Path, data: CommentedMap) -> None:
+    yaml_obj = get_yaml_with_comments()
+    with open(cfg_path, "w", encoding="utf-8") as f:
+        yaml_obj.dump(data, f)
+
+
+def _overlay_yaml_text(overlay: Any) -> str:
+    return yaml_to_string_with_comments(overlay if overlay is not None else CommentedMap())
+
+
+def list_scenario_ids(cfg_path: Path) -> List[str]:
+    """Return the ``scenario:`` mapping's keys, in file order."""
+    data = _load(cfg_path)
+    scenario_map = data.get("scenario") or {}
+    return list(scenario_map.keys())
+
+
+def create_scenario(
+    cfg_path: Path, scenario_id: str, base_scenario_id: Optional[str] = None
+) -> str:
+    """Add a new (blank or cloned) scenario overlay. Returns its YAML text."""
+    _validate_id(scenario_id)
+    data = _load(cfg_path)
+    scenario_map = data.get("scenario")
+    if scenario_map is None:
+        scenario_map = CommentedMap()
+        data["scenario"] = scenario_map
+    if scenario_id in scenario_map:
+        raise ScenarioEditError(f"Scenario {scenario_id!r} already exists")
+
+    if base_scenario_id is not None:
+        if base_scenario_id not in scenario_map:
+            raise ScenarioEditError(f"Unknown base scenario {base_scenario_id!r}")
+        overlay = copy.deepcopy(scenario_map[base_scenario_id])
+    else:
+        overlay = CommentedMap()
+
+    scenario_map[scenario_id] = overlay
+    _save(cfg_path, data)
+    return _overlay_yaml_text(overlay)
+
+
+def read_scenario(cfg_path: Path, scenario_id: str) -> str:
+    """Return one scenario overlay's YAML text (for the scoped editor)."""
+    data = _load(cfg_path)
+    scenario_map = data.get("scenario") or {}
+    if scenario_id not in scenario_map:
+        raise ScenarioEditError(f"Unknown scenario {scenario_id!r}")
+    return _overlay_yaml_text(scenario_map[scenario_id])
+
+
+def update_scenario(cfg_path: Path, scenario_id: str, yaml_text: str) -> str:
+    """Replace one scenario overlay's subtree from edited YAML text."""
+    data = _load(cfg_path)
+    scenario_map = data.get("scenario")
+    if not scenario_map or scenario_id not in scenario_map:
+        raise ScenarioEditError(f"Unknown scenario {scenario_id!r}")
+    try:
+        parsed = load_yaml_string_with_comments(yaml_text)
+    except Exception as exc:  # noqa: BLE001 — surfaced as a 422 to the editor
+        raise ScenarioEditError(f"Invalid YAML: {exc}") from exc
+    if parsed is not None and not isinstance(parsed, dict):
+        raise ScenarioEditError("A scenario overlay must be a YAML mapping")
+    scenario_map[scenario_id] = parsed if parsed is not None else CommentedMap()
+    _save(cfg_path, data)
+    return _overlay_yaml_text(scenario_map[scenario_id])
+
+
+def rename_scenario(cfg_path: Path, scenario_id: str, new_id: str) -> None:
+    """Rename a scenario's key. Note: moves it to the end of the mapping."""
+    _validate_id(new_id)
+    data = _load(cfg_path)
+    scenario_map = data.get("scenario")
+    if not scenario_map or scenario_id not in scenario_map:
+        raise ScenarioEditError(f"Unknown scenario {scenario_id!r}")
+    if new_id in scenario_map:
+        raise ScenarioEditError(f"Scenario {new_id!r} already exists")
+    scenario_map[new_id] = scenario_map.pop(scenario_id)
+    _save(cfg_path, data)
+
+
+def delete_scenario(cfg_path: Path, scenario_id: str) -> None:
+    """Remove a scenario overlay. The next sweep prunes its stale HDF5 group."""
+    data = _load(cfg_path)
+    scenario_map = data.get("scenario")
+    if not scenario_map or scenario_id not in scenario_map:
+        raise ScenarioEditError(f"Unknown scenario {scenario_id!r}")
+    del scenario_map[scenario_id]
+    _save(cfg_path, data)

--- a/boulder/scenario_editor.py
+++ b/boulder/scenario_editor.py
@@ -37,14 +37,13 @@ class ScenarioEditError(ValueError):
 def _validate_id(scenario_id: str) -> None:
     if not scenario_id or not _ID_RE.match(scenario_id):
         raise ScenarioEditError(
-            f"Invalid scenario id {scenario_id!r}: use letters, digits, "
-            "'_' or '-' only"
+            f"Invalid scenario id {scenario_id!r}: use letters, digits, '_' or '-' only"
         )
 
 
 def _load(cfg_path: Path) -> CommentedMap:
     data = load_config_file_with_comments(str(cfg_path))
-    if not isinstance(data, dict):
+    if not isinstance(data, CommentedMap):
         raise ScenarioEditError(f"{cfg_path} does not contain a YAML mapping")
     return data
 
@@ -56,7 +55,9 @@ def _save(cfg_path: Path, data: CommentedMap) -> None:
 
 
 def _overlay_yaml_text(overlay: Any) -> str:
-    return yaml_to_string_with_comments(overlay if overlay is not None else CommentedMap())
+    return yaml_to_string_with_comments(
+        overlay if overlay is not None else CommentedMap()
+    )
 
 
 def list_scenario_ids(cfg_path: Path) -> List[str]:

--- a/frontend/src/api/scenarios.ts
+++ b/frontend/src/api/scenarios.ts
@@ -50,3 +50,56 @@ export function focusScenario(id: string) {
 
 /** SSE URL the GUI subscribes to for scenario-focus events. */
 export const SCENARIO_FOCUS_STREAM_URL = "/api/scenarios/focus/stream";
+
+// ---------------------------------------------------------------------------
+// Scenario authoring — create/edit/delete a `scenario:` overlay on disk.
+// Unlike the read helpers above (precomputed HDF5 trajectories), these edit
+// the source config file so the next Run Sweep picks up the change.
+// ---------------------------------------------------------------------------
+
+export interface ScenarioSourceResponse {
+  scenario_id: string;
+  yaml: string;
+}
+
+/** Fetch one scenario overlay's raw YAML text (for the scoped editor). */
+export function fetchScenarioSource(id: string) {
+  return apiFetch<ScenarioSourceResponse>(
+    `/scenarios/${encodeURIComponent(id)}/source`,
+  );
+}
+
+/** Create a new scenario overlay — blank, or cloned from an existing one. */
+export function createScenario(scenarioId: string, baseScenarioId?: string) {
+  return apiFetch<ScenarioSourceResponse>("/scenarios", {
+    method: "POST",
+    body: JSON.stringify({
+      scenario_id: scenarioId,
+      base_scenario_id: baseScenarioId ?? null,
+    }),
+  });
+}
+
+/** Save edits to a scenario overlay's YAML text. */
+export function updateScenario(id: string, yaml: string) {
+  return apiFetch<ScenarioSourceResponse>(
+    `/scenarios/${encodeURIComponent(id)}`,
+    { method: "PATCH", body: JSON.stringify({ yaml }) },
+  );
+}
+
+/** Rename a scenario's id (its `scenario:` mapping key). */
+export function renameScenario(id: string, newId: string) {
+  return apiFetch<{ ok: boolean; scenario_id: string }>(
+    `/scenarios/${encodeURIComponent(id)}/rename`,
+    { method: "PATCH", body: JSON.stringify({ new_id: newId }) },
+  );
+}
+
+/** Delete a scenario overlay. The next Run Sweep prunes its stale HDF5 group. */
+export function deleteScenario(id: string) {
+  return apiFetch<{ ok: boolean; scenario_id: string }>(
+    `/scenarios/${encodeURIComponent(id)}`,
+    { method: "DELETE" },
+  );
+}

--- a/frontend/src/components/modals/AddScenarioModal.tsx
+++ b/frontend/src/components/modals/AddScenarioModal.tsx
@@ -1,0 +1,115 @@
+import { useState } from "react";
+import { useScenarioStore } from "@/stores/scenarioStore";
+import { Button } from "@/components/ui/Button";
+import { toast } from "sonner";
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  /** Called after the scenario is created, so the caller can open its editor. */
+  onCreated: (scenarioId: string) => void;
+}
+
+const BLANK = "__blank__";
+
+/**
+ * "+ Add Scenario" — the entry point for authoring a scenario: pick an id
+ * and, optionally, an existing scenario to clone as a starting point. The
+ * new overlay opens in the scoped editor immediately so the user edits it
+ * right away.
+ */
+export function AddScenarioModal({ open, onClose, onCreated }: Props) {
+  const scenarios = useScenarioStore((s) => s.scenarios);
+  const createScenario = useScenarioStore((s) => s.createScenario);
+  const [id, setId] = useState("");
+  const [baseId, setBaseId] = useState(BLANK);
+  const [submitting, setSubmitting] = useState(false);
+
+  if (!open) return null;
+
+  const handleSubmit = async () => {
+    const trimmed = id.trim();
+    if (!trimmed) {
+      toast.error("Scenario id is required");
+      return;
+    }
+    if (!/^[A-Za-z0-9_-]+$/.test(trimmed)) {
+      toast.error("Scenario id must use letters, digits, '_' or '-' only");
+      return;
+    }
+    setSubmitting(true);
+    try {
+      await createScenario(trimmed, baseId === BLANK ? undefined : baseId);
+      toast.success(`Scenario "${trimmed}" created`);
+      onCreated(trimmed);
+      setId("");
+      setBaseId(BLANK);
+      onClose();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : String(err));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div
+      id="add-scenario-modal"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div className="w-full max-w-md bg-card border border-border rounded-lg shadow-lg p-6 space-y-4">
+        <h2 className="text-lg font-semibold text-foreground">Add Scenario</h2>
+
+        <label className="block text-xs text-muted-foreground">
+          Scenario id
+          <input
+            id="scenario-id"
+            value={id}
+            onChange={(e) => setId(e.target.value)}
+            placeholder="e.g. C1T"
+            className="block w-full mt-1 px-2 py-1.5 text-sm rounded-md bg-input border border-border text-foreground"
+            autoFocus
+            onKeyDown={(e) => {
+              if (e.key === "Enter") void handleSubmit();
+            }}
+          />
+        </label>
+
+        <label className="block text-xs text-muted-foreground">
+          Start from
+          <select
+            id="scenario-base"
+            value={baseId}
+            onChange={(e) => setBaseId(e.target.value)}
+            className="block w-full mt-1 px-2 py-1.5 text-sm rounded-md bg-input border border-border text-foreground"
+          >
+            <option value={BLANK}>Blank overlay</option>
+            {scenarios.map((s) => (
+              <option key={s.id} value={s.id}>
+                Clone of {s.label || s.id}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <div className="flex justify-end gap-2 pt-2">
+          <Button onClick={onClose} variant="secondary" size="sm">
+            Cancel
+          </Button>
+          <Button
+            id="add-scenario-submit"
+            onClick={() => void handleSubmit()}
+            disabled={submitting}
+            variant="primary"
+            size="sm"
+          >
+            {submitting ? "Creating…" : "Create"}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/modals/ScenarioYamlEditorModal.tsx
+++ b/frontend/src/components/modals/ScenarioYamlEditorModal.tsx
@@ -1,0 +1,148 @@
+import { useState, useEffect, lazy, Suspense } from "react";
+import { fetchScenarioSource, updateScenario } from "@/api/scenarios";
+import { Button } from "@/components/ui/Button";
+import { toast } from "sonner";
+
+const MonacoEditor = lazy(() => import("@monaco-editor/react"));
+
+interface Props {
+  scenarioId: string | null;
+  /** The scenario this one was cloned from, if any — shown as "Base: <id>". */
+  baseScenarioId?: string;
+  onClose: () => void;
+  /** Called after a successful save, so the caller can refresh the list. */
+  onSaved?: (scenarioId: string) => void;
+}
+
+/**
+ * Scoped scenario editor — like YAMLEditorModal but limited to one scenario's
+ * overlay subtree (``scenario.<id>``) instead of the whole config file.
+ * Editing here never touches the base network, so there's nothing to sync
+ * against a live structured config: the overlay text is the whole story.
+ */
+export function ScenarioYamlEditorModal({
+  scenarioId,
+  baseScenarioId,
+  onClose,
+  onSaved,
+}: Props) {
+  const [value, setValue] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!scenarioId) return;
+    setLoadError(null);
+    setLoading(true);
+    fetchScenarioSource(scenarioId)
+      .then((resp) => setValue(resp.yaml))
+      .catch((err) => {
+        setLoadError(err instanceof Error ? err.message : String(err));
+      })
+      .finally(() => setLoading(false));
+  }, [scenarioId]);
+
+  if (!scenarioId) return null;
+
+  const handleSave = async () => {
+    setSaving(true);
+    try {
+      await updateScenario(scenarioId, value);
+      toast.success(`Scenario "${scenarioId}" saved`);
+      onSaved?.(scenarioId);
+      onClose();
+    } catch (err) {
+      toast.error(
+        `Could not save scenario: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div
+      id="scenario-yaml-modal"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div className="w-full max-w-3xl h-[80vh] bg-card border border-border rounded-lg shadow-lg flex flex-col">
+        <div className="flex items-center justify-between p-4 border-b border-border">
+          <div>
+            <h2 className="text-lg font-semibold text-foreground">
+              Scenario: {scenarioId}
+            </h2>
+            {baseScenarioId && (
+              <p className="text-xs text-muted-foreground">
+                Base: {baseScenarioId}
+              </p>
+            )}
+          </div>
+          <Button
+            onClick={onClose}
+            variant="ghost"
+            size="icon"
+            className="text-lg"
+            aria-label="Close"
+          >
+            ×
+          </Button>
+        </div>
+
+        <div className="flex-1 overflow-hidden">
+          {loading ? (
+            <div className="flex items-center justify-center h-full text-muted-foreground">
+              Loading scenario…
+            </div>
+          ) : loadError ? (
+            <div className="flex items-center justify-center h-full text-destructive p-4 text-center text-sm">
+              {loadError}
+            </div>
+          ) : (
+            <Suspense
+              fallback={
+                <textarea
+                  id="scenario-yaml-editor"
+                  value={value}
+                  onChange={(e) => setValue(e.target.value)}
+                  className="w-full h-full p-4 font-mono text-sm bg-background text-foreground resize-none"
+                />
+              }
+            >
+              <MonacoEditor
+                height="100%"
+                language="yaml"
+                value={value}
+                onChange={(v) => setValue(v ?? "")}
+                theme="vs-dark"
+                options={{
+                  minimap: { enabled: false },
+                  wordWrap: "on",
+                  fontSize: 13,
+                }}
+              />
+            </Suspense>
+          )}
+        </div>
+
+        <div className="flex justify-end gap-2 p-4 border-t border-border">
+          <Button onClick={onClose} variant="secondary" size="sm">
+            Cancel
+          </Button>
+          <Button
+            id="save-scenario-yaml-btn"
+            onClick={() => void handleSave()}
+            disabled={saving || loading || !!loadError}
+            variant="primary"
+            size="sm"
+          >
+            {saving ? "Saving…" : "Save"}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/panels/RunControl.tsx
+++ b/frontend/src/components/panels/RunControl.tsx
@@ -1,9 +1,11 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { Check, ChevronDown } from "lucide-react";
+import { Check, ChevronDown, Plus } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/Button";
 import { getSweepInfo, getSweepStatus, startSweep, type SweepInfo } from "@/api/sweep";
 import { useScenarioStore } from "@/stores/scenarioStore";
+import { AddScenarioModal } from "@/components/modals/AddScenarioModal";
+import { ScenarioYamlEditorModal } from "@/components/modals/ScenarioYamlEditorModal";
 
 type RunMode = "sim" | "force_sim" | "sweep";
 
@@ -33,6 +35,8 @@ export function RunControl({ onRunSimulation, isRunning, runDisabled }: RunContr
   const appliedDefault = useRef(false);
   const appliedAutorun = useRef(false);
   const refreshScenarios = useScenarioStore((s) => s.refresh);
+  const [addScenarioOpen, setAddScenarioOpen] = useState(false);
+  const [editingScenarioId, setEditingScenarioId] = useState<string | null>(null);
 
   const loadSweepInfo = useCallback(() => {
     getSweepInfo()
@@ -208,9 +212,42 @@ export function RunControl({ onRunSimulation, isRunning, runDisabled }: RunContr
                 setMenuOpen(false);
               }}
             />
+            <div className="border-t border-border" />
+            <button
+              type="button"
+              role="menuitem"
+              onClick={() => {
+                setMenuOpen(false);
+                setAddScenarioOpen(true);
+              }}
+              className="w-full text-left px-3 py-2.5 flex gap-2 hover:bg-muted cursor-pointer"
+            >
+              <span className="w-4 shrink-0 pt-0.5 text-primary">
+                <Plus size={14} />
+              </span>
+              <span className="min-w-0">
+                <span className="block text-sm font-semibold text-foreground">
+                  Add Scenario…
+                </span>
+                <span className="block text-xs text-muted-foreground">
+                  Create a new scenario overlay and edit its YAML.
+                </span>
+              </span>
+            </button>
           </div>
         </>
       )}
+
+      <AddScenarioModal
+        open={addScenarioOpen}
+        onClose={() => setAddScenarioOpen(false)}
+        onCreated={(id) => setEditingScenarioId(id)}
+      />
+      <ScenarioYamlEditorModal
+        scenarioId={editingScenarioId}
+        onClose={() => setEditingScenarioId(null)}
+        onSaved={() => void refreshScenarios()}
+      />
     </div>
   );
 }

--- a/frontend/src/components/panels/ScenarioPane.tsx
+++ b/frontend/src/components/panels/ScenarioPane.tsx
@@ -1,5 +1,9 @@
 import { type KeyboardEvent, useEffect, useRef, useState } from "react";
+import { Pencil, Plus, Trash2 } from "lucide-react";
+import { toast } from "sonner";
 import { useScenarioStore } from "@/stores/scenarioStore";
+import { AddScenarioModal } from "@/components/modals/AddScenarioModal";
+import { ScenarioYamlEditorModal } from "@/components/modals/ScenarioYamlEditorModal";
 import { SweepResultsPlot } from "./SweepResultsPlot";
 
 /** Compact relative-time label, e.g. "just now", "2 min ago", "3 h ago". */
@@ -30,7 +34,10 @@ export function ScenarioPane() {
     error,
     refresh,
     setActive,
+    deleteScenario,
   } = useScenarioStore();
+  const [addModalOpen, setAddModalOpen] = useState(false);
+  const [editingId, setEditingId] = useState<string | null>(null);
 
   // Tick so relative-time labels stay fresh without a reload.
   const [now, setNow] = useState(() => Date.now());
@@ -58,7 +65,50 @@ export function ScenarioPane() {
     prevCreated.current = createdAt;
   }, [createdAt]);
 
-  if (!available || scenarios.length === 0) return null;
+  const handleDelete = async (id: string) => {
+    if (!window.confirm(`Delete scenario "${id}"? This cannot be undone.`)) return;
+    try {
+      await deleteScenario(id);
+      toast.success(`Scenario "${id}" deleted`);
+      void refresh();
+    } catch (err) {
+      toast.error(
+        `Could not delete scenario: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  };
+
+  if (!available || scenarios.length === 0) {
+    // No precomputed store yet (nothing has been swept), but scenario
+    // authoring doesn't need one — surface just the "+ Add Scenario" entry
+    // point so the pane isn't the only way in (Run Sweep's menu has it too).
+    return (
+      <div className="rounded-lg border border-border bg-card p-4 space-y-2">
+        <div className="flex items-center justify-between">
+          <h3 className="font-semibold text-sm text-foreground">Scenarios</h3>
+          <button
+            type="button"
+            onClick={() => setAddModalOpen(true)}
+            className="flex items-center gap-1 text-xs text-primary hover:underline"
+          >
+            <Plus size={12} /> Add Scenario
+          </button>
+        </div>
+        <p className="text-xs text-muted-foreground">
+          No computed scenarios yet — add one, then Run Sweep.
+        </p>
+        <AddScenarioModal
+          open={addModalOpen}
+          onClose={() => setAddModalOpen(false)}
+          onCreated={(id) => setEditingId(id)}
+        />
+        <ScenarioYamlEditorModal
+          scenarioId={editingId}
+          onClose={() => setEditingId(null)}
+        />
+      </div>
+    );
+  }
 
   const onKeyDown = (e: KeyboardEvent<HTMLUListElement>) => {
     if (e.key !== "ArrowDown" && e.key !== "ArrowUp") return;
@@ -89,7 +139,17 @@ export function ScenarioPane() {
       <div className="rounded-lg border border-border bg-card p-4 space-y-3">
         <div className="flex items-center justify-between">
           <h3 className="font-semibold text-sm text-foreground">Scenarios</h3>
-          <span className="text-xs text-muted-foreground">{scenarios.length}</span>
+          <div className="flex items-center gap-2">
+            <span className="text-xs text-muted-foreground">{scenarios.length}</span>
+            <button
+              type="button"
+              onClick={() => setAddModalOpen(true)}
+              title="Add Scenario"
+              className="text-muted-foreground hover:text-foreground"
+            >
+              <Plus size={14} />
+            </button>
+          </div>
         </div>
         {error && <p className="text-xs text-red-500">{error}</p>}
         <ul
@@ -102,7 +162,7 @@ export function ScenarioPane() {
             const isActive = s.id === activeId;
             const ago = timeAgo(s.computed_at ?? createdAt, now);
             return (
-              <li key={s.id}>
+              <li key={s.id} className="group flex items-center gap-1">
                 <button
                   id={`scenario-${s.id}`}
                   type="button"
@@ -117,7 +177,7 @@ export function ScenarioPane() {
                       : undefined
                   }
                   className={[
-                    "w-full text-left rounded-md px-2 py-1.5 text-xs transition-colors border",
+                    "flex-1 min-w-0 text-left rounded-md px-2 py-1.5 text-xs transition-colors border",
                     "focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400",
                     isActive
                       ? "border-blue-500 bg-blue-500/20 text-foreground"
@@ -138,12 +198,38 @@ export function ScenarioPane() {
                     </div>
                   )}
                 </button>
+                <button
+                  type="button"
+                  onClick={() => setEditingId(s.id)}
+                  title="Edit scenario YAML"
+                  className="shrink-0 p-1 rounded text-muted-foreground opacity-0 group-hover:opacity-100 hover:text-foreground hover:bg-muted"
+                >
+                  <Pencil size={12} />
+                </button>
+                <button
+                  type="button"
+                  onClick={() => void handleDelete(s.id)}
+                  title="Delete scenario"
+                  className="shrink-0 p-1 rounded text-muted-foreground opacity-0 group-hover:opacity-100 hover:text-destructive hover:bg-muted"
+                >
+                  <Trash2 size={12} />
+                </button>
               </li>
             );
           })}
         </ul>
       </div>
       <SweepResultsPlot scenarios={scenarios} />
+      <AddScenarioModal
+        open={addModalOpen}
+        onClose={() => setAddModalOpen(false)}
+        onCreated={(id) => setEditingId(id)}
+      />
+      <ScenarioYamlEditorModal
+        scenarioId={editingId}
+        onClose={() => setEditingId(null)}
+        onSaved={() => void refresh()}
+      />
     </div>
   );
 }

--- a/frontend/src/stores/scenarioStore.ts
+++ b/frontend/src/stores/scenarioStore.ts
@@ -1,7 +1,11 @@
 import { create } from "zustand";
 import {
+  createScenario as apiCreateScenario,
+  deleteScenario as apiDeleteScenario,
   fetchScenario,
   listScenarios,
+  renameScenario as apiRenameScenario,
+  updateScenario as apiUpdateScenario,
   type ScenarioMeta,
 } from "@/api/scenarios";
 import { useSimulationStore } from "./simulationStore";
@@ -20,9 +24,21 @@ interface ScenarioState {
   refresh: () => Promise<void>;
   /** Load a scenario's trajectory and push it into the simulation results. */
   setActive: (id: string) => Promise<void>;
+  /**
+   * Create a new scenario overlay (blank, or cloned from `baseId`) and mark
+   * it active for editing. Throws on failure (id collision, no config file,
+   * bad YAML) so callers can show the error inline.
+   */
+  createScenario: (id: string, baseId?: string) => Promise<void>;
+  /** Save edits to a scenario overlay's YAML text. */
+  updateScenario: (id: string, yaml: string) => Promise<void>;
+  /** Rename a scenario's id. */
+  renameScenario: (id: string, newId: string) => Promise<void>;
+  /** Delete a scenario overlay. */
+  deleteScenario: (id: string) => Promise<void>;
 }
 
-export const useScenarioStore = create<ScenarioState>((set) => ({
+export const useScenarioStore = create<ScenarioState>((set, get) => ({
   available: false,
   scenarios: [],
   activeId: null,
@@ -41,6 +57,28 @@ export const useScenarioStore = create<ScenarioState>((set) => ({
       // No store / API not ready: the pane simply stays hidden.
       set({ available: false, scenarios: [] });
     }
+  },
+
+  createScenario: async (id, baseId) => {
+    await apiCreateScenario(id, baseId);
+    set({ activeId: id });
+    // The scenario config now exists but has no precomputed trajectory yet
+    // (that needs a Run Sweep) — `available`/`scenarios` are left as-is until
+    // the caller/editor decides whether to refresh the (still HDF5-backed) list.
+  },
+
+  updateScenario: async (id, yaml) => {
+    await apiUpdateScenario(id, yaml);
+  },
+
+  renameScenario: async (id, newId) => {
+    await apiRenameScenario(id, newId);
+    if (get().activeId === id) set({ activeId: newId });
+  },
+
+  deleteScenario: async (id) => {
+    await apiDeleteScenario(id);
+    if (get().activeId === id) set({ activeId: null });
   },
 
   setActive: async (id) => {

--- a/tests/test_scenario_editing.py
+++ b/tests/test_scenario_editing.py
@@ -1,0 +1,230 @@
+"""Tests for scenario authoring: POST/PATCH/DELETE /api/scenarios*.
+
+Unlike the read routes in ``test_scenario_focus.py`` (which serve precomputed
+HDF5 trajectories), these edit the *source* config file's ``scenario:``
+mapping on disk — the input side of the Scenario Pane's create/edit workflow.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List
+
+import pytest
+
+pytest.importorskip("fastapi")
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from boulder.api.main import create_app  # noqa: E402
+
+_BASE_YAML = """\
+metadata:
+  description: "test config"  # keep this comment
+phases:
+  gas:
+    mechanism: gri30.yaml
+network:
+  - id: feed
+    Reservoir:
+      temperature: 298.15
+      pressure: 101325
+      composition: "CH4:1"
+scenario:
+  base_case:
+    metadata:
+      scenario_name: "Base Case"
+    network:
+      - id: feed
+        Reservoir:
+          temperature: 320.0
+"""
+
+
+def _write_config(tmp_path: Path) -> Path:
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(_BASE_YAML, encoding="utf-8")
+    return cfg
+
+
+def _client_with_config(cfg_path: Path):
+    app = create_app()
+    client = TestClient(app)
+    client.__enter__()
+    app.state.preloaded_config_path = str(cfg_path)
+    return client, app
+
+
+def _scenario_ids(cfg_path: Path) -> List[str]:
+    from boulder.scenario_editor import list_scenario_ids
+
+    return list_scenario_ids(cfg_path)
+
+
+def test_create_scenario_requires_config_path() -> None:
+    app = create_app()
+    with TestClient(app) as client:
+        app.state.preloaded_config_path = None
+        resp = client.post("/api/scenarios", json={"scenario_id": "new1"})
+        assert resp.status_code == 400
+
+
+def test_create_scenario_blank(tmp_path: Path) -> None:
+    cfg = _write_config(tmp_path)
+    client, app = _client_with_config(cfg)
+    try:
+        resp = client.post("/api/scenarios", json={"scenario_id": "new1"})
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["scenario_id"] == "new1"
+        assert _scenario_ids(cfg) == ["base_case", "new1"]
+        # preloaded_raw refreshed so Run Sweep sees the new scenario immediately.
+        assert "new1" in (app.state.preloaded_raw.get("scenario") or {})
+        # The pre-existing comment elsewhere in the file survives.
+        assert "keep this comment" in cfg.read_text(encoding="utf-8")
+    finally:
+        client.__exit__(None, None, None)
+
+
+def test_create_scenario_clone(tmp_path: Path) -> None:
+    cfg = _write_config(tmp_path)
+    client, app = _client_with_config(cfg)
+    try:
+        resp = client.post(
+            "/api/scenarios",
+            json={"scenario_id": "clone1", "base_scenario_id": "base_case"},
+        )
+        assert resp.status_code == 200, resp.text
+        assert "scenario_name:" in resp.json()["yaml"]
+        assert "Base Case" in resp.json()["yaml"]
+    finally:
+        client.__exit__(None, None, None)
+
+
+def test_create_scenario_duplicate_422(tmp_path: Path) -> None:
+    cfg = _write_config(tmp_path)
+    client, _app = _client_with_config(cfg)
+    try:
+        resp = client.post("/api/scenarios", json={"scenario_id": "base_case"})
+        assert resp.status_code == 422
+    finally:
+        client.__exit__(None, None, None)
+
+
+def test_create_scenario_bad_id_422(tmp_path: Path) -> None:
+    cfg = _write_config(tmp_path)
+    client, _app = _client_with_config(cfg)
+    try:
+        resp = client.post("/api/scenarios", json={"scenario_id": "bad id!"})
+        assert resp.status_code == 422
+    finally:
+        client.__exit__(None, None, None)
+
+
+def test_create_scenario_unknown_base_422(tmp_path: Path) -> None:
+    cfg = _write_config(tmp_path)
+    client, _app = _client_with_config(cfg)
+    try:
+        resp = client.post(
+            "/api/scenarios",
+            json={"scenario_id": "new1", "base_scenario_id": "nope"},
+        )
+        assert resp.status_code == 422
+    finally:
+        client.__exit__(None, None, None)
+
+
+def test_get_scenario_source(tmp_path: Path) -> None:
+    cfg = _write_config(tmp_path)
+    client, _app = _client_with_config(cfg)
+    try:
+        resp = client.get("/api/scenarios/base_case/source")
+        assert resp.status_code == 200
+        assert "scenario_name" in resp.json()["yaml"]
+    finally:
+        client.__exit__(None, None, None)
+
+
+def test_get_scenario_source_unknown_404(tmp_path: Path) -> None:
+    cfg = _write_config(tmp_path)
+    client, _app = _client_with_config(cfg)
+    try:
+        resp = client.get("/api/scenarios/nope/source")
+        assert resp.status_code == 404
+    finally:
+        client.__exit__(None, None, None)
+
+
+def test_update_scenario(tmp_path: Path) -> None:
+    cfg = _write_config(tmp_path)
+    client, app = _client_with_config(cfg)
+    try:
+        new_yaml = (
+            "metadata:\n  scenario_name: Updated\n"
+            "network:\n  - id: feed\n    Reservoir:\n      temperature: 350.0\n"
+        )
+        resp = client.patch("/api/scenarios/base_case", json={"yaml": new_yaml})
+        assert resp.status_code == 200, resp.text
+        assert "Updated" in resp.json()["yaml"]
+        assert "350.0" in cfg.read_text(encoding="utf-8")
+        assert app.state.preloaded_raw["scenario"]["base_case"]["metadata"][
+            "scenario_name"
+        ] == "Updated"
+    finally:
+        client.__exit__(None, None, None)
+
+
+def test_update_scenario_invalid_yaml_422(tmp_path: Path) -> None:
+    cfg = _write_config(tmp_path)
+    client, _app = _client_with_config(cfg)
+    try:
+        resp = client.patch(
+            "/api/scenarios/base_case", json={"yaml": "not: [valid: yaml"}
+        )
+        assert resp.status_code == 422
+    finally:
+        client.__exit__(None, None, None)
+
+
+def test_update_scenario_unknown_422(tmp_path: Path) -> None:
+    cfg = _write_config(tmp_path)
+    client, _app = _client_with_config(cfg)
+    try:
+        resp = client.patch("/api/scenarios/nope", json={"yaml": "a: 1"})
+        assert resp.status_code == 422
+    finally:
+        client.__exit__(None, None, None)
+
+
+def test_rename_scenario(tmp_path: Path) -> None:
+    cfg = _write_config(tmp_path)
+    client, _app = _client_with_config(cfg)
+    try:
+        resp = client.patch(
+            "/api/scenarios/base_case/rename", json={"new_id": "renamed"}
+        )
+        assert resp.status_code == 200, resp.text
+        assert _scenario_ids(cfg) == ["renamed"]
+    finally:
+        client.__exit__(None, None, None)
+
+
+def test_delete_scenario(tmp_path: Path) -> None:
+    cfg = _write_config(tmp_path)
+    client, app = _client_with_config(cfg)
+    try:
+        resp = client.delete("/api/scenarios/base_case")
+        assert resp.status_code == 200, resp.text
+        assert _scenario_ids(cfg) == []
+        assert not (app.state.preloaded_raw.get("scenario") or {})
+    finally:
+        client.__exit__(None, None, None)
+
+
+def test_delete_scenario_unknown_404(tmp_path: Path) -> None:
+    cfg = _write_config(tmp_path)
+    client, _app = _client_with_config(cfg)
+    try:
+        resp = client.delete("/api/scenarios/nope")
+        assert resp.status_code == 404
+    finally:
+        client.__exit__(None, None, None)

--- a/tests/test_scenario_editing.py
+++ b/tests/test_scenario_editing.py
@@ -166,9 +166,12 @@ def test_update_scenario(tmp_path: Path) -> None:
         assert resp.status_code == 200, resp.text
         assert "Updated" in resp.json()["yaml"]
         assert "350.0" in cfg.read_text(encoding="utf-8")
-        assert app.state.preloaded_raw["scenario"]["base_case"]["metadata"][
-            "scenario_name"
-        ] == "Updated"
+        assert (
+            app.state.preloaded_raw["scenario"]["base_case"]["metadata"][
+                "scenario_name"
+            ]
+            == "Updated"
+        )
     finally:
         client.__exit__(None, None, None)
 

--- a/tests/test_sweep_runset.py
+++ b/tests/test_sweep_runset.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from boulder.api.routes.sweep import _run_set_size
+from pathlib import Path
+
+from boulder.api.routes.sweep import _run_set_size, has_run_set, resolve_store_path
 
 
 def test_sweep_only_counts_cartesian():
@@ -37,3 +39,42 @@ def test_scenario_local_sweep_multiplies_only_itself():
 
 def test_empty_is_zero():
     assert _run_set_size({}) == 0
+
+
+def test_has_run_set_true_for_scenario_block():
+    assert has_run_set({"scenario": {"a": {}}}, None) is True
+
+
+def test_has_run_set_true_for_sweep_block():
+    assert has_run_set({"sweep": {"T": {"values": [1]}}}, None) is True
+    assert has_run_set({"sweeps": {"T": {"values": [1]}}}, None) is True
+
+
+def test_has_run_set_false_without_block_or_runner(tmp_path: Path):
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text("metadata: {}\n", encoding="utf-8")
+    assert has_run_set({}, str(cfg)) is False
+
+
+def test_has_run_set_true_for_local_run_sweep_script(tmp_path: Path):
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text("metadata: {}\n", encoding="utf-8")
+    (tmp_path / "run_sweep.py").write_text("", encoding="utf-8")
+    # No inline scenario:/sweep: block at all — the local runner script alone
+    # is enough (host-defined run-set, e.g. the CH4 reactor-map sandbox).
+    assert has_run_set({}, str(cfg)) is True
+
+
+def test_resolve_store_path_defaults_next_to_config(tmp_path: Path):
+    cfg = tmp_path / "my_map.yaml"
+    assert resolve_store_path({}, str(cfg)) == tmp_path / "my_map_scenarios.h5"
+
+
+def test_resolve_store_path_honours_declared_relative_path(tmp_path: Path):
+    cfg = tmp_path / "my_map.yaml"
+    raw = {"metadata": {"extra": {"scenario_store": "results/store.h5"}}}
+    assert resolve_store_path(raw, str(cfg)) == tmp_path / "results" / "store.h5"
+
+
+def test_resolve_store_path_none_without_config_path():
+    assert resolve_store_path({}, None) is None


### PR DESCRIPTION
## Summary
- Add "+ Add Scenario" (Run controls split-button menu, and the Scenario Pane header/per-row icons) to create, clone, edit, rename, and delete a `scenario:` overlay directly from the GUI, instead of hand-editing the source YAML.
- New backend routes `POST/PATCH/DELETE /api/scenarios*` (`boulder/scenario_editor.py`) mutate only the targeted scenario's subtree on disk via `ruamel.yaml`, preserving comments/formatting elsewhere in the file, then refresh the server's in-memory config so **Run Sweep** picks up the change immediately (its fingerprint cache means only the new/changed scenario actually re-solves).
- Make the Scenario Pane visible whenever a config declares a run-set (`scenario:`/`sweep:`/`sweeps:`, or a host `run_sweep.py`), not just after `BOULDER_SWEEP_MODE` or a completed sweep — `has_run_set()`/`resolve_store_path()` are factored out of the request-scoped sweep routes into pure functions the startup lifespan can share.

## Test plan
- [x] `tests/test_scenario_editing.py` (new, 14 tests): create/clone/rename/delete + error cases (duplicate id, invalid id, unknown base/scenario, invalid YAML), comment preservation.
- [x] `tests/test_sweep_runset.py`: extended with unit tests for `has_run_set`/`resolve_store_path`.
- [x] `make type-check` (mypy strict) passes.
- [x] Full existing suite passes alongside these changes (no regressions).
- [ ] Frontend not build/click-tested in this environment (no Node available) — recommend `npm run build` / manual click-through in `frontend/` before merging.

---
*Extensive AI use — code & PR fully written by Claude Sonnet 5.*