### PR TITLE
Double-click node to edit initial conditions

### DIFF
--- a/.cursor/skills/boulder-gui/SKILL.md
+++ b/.cursor/skills/boulder-gui/SKILL.md
@@ -77,7 +77,7 @@ GUI check:
 
 - The graph is a **Cytoscape `<canvas>`** — node ids are **not** exposed to `browser_search`.
 - **Single click** on a node → selects it (Properties + Thermo).
-- **Double click** on a node within ~300 ms → also switches to **Thermo** tab.
+- **Double click** on a node within ~300 ms → selects it and opens **Initial conditions** in edit mode (Properties panel).
 - **Single click** on a **MassFlowController** edge → selects it and opens **Thermo** (shows source reactor T/P/X and mdot).
 
 **Reliable click pattern (cursor-ide-browser):**

--- a/frontend/src/components/graph/ReactorGraph.tsx
+++ b/frontend/src/components/graph/ReactorGraph.tsx
@@ -1302,13 +1302,14 @@ export function ReactorGraph() {
       const nodeId = String(data.id);
       const now = Date.now();
       const last = lastTappedRef.current;
+      let editInitialConditions = false;
       if (last?.nodeId === nodeId && now - last.time < DBLTAP_MS) {
         if (tapTimeoutRef.current) {
           clearTimeout(tapTimeoutRef.current);
           tapTimeoutRef.current = null;
         }
         lastTappedRef.current = null;
-        setActiveTab("Thermo");
+        editInitialConditions = true;
       } else {
         lastTappedRef.current = { nodeId, time: now };
         if (tapTimeoutRef.current) clearTimeout(tapTimeoutRef.current);
@@ -1317,7 +1318,10 @@ export function ReactorGraph() {
           tapTimeoutRef.current = null;
         }, DBLTAP_MS);
       }
-      setSelectedElement({ type: "node", data });
+      setSelectedElement(
+        { type: "node", data },
+        editInitialConditions ? { editInitialConditions: true } : undefined,
+      );
     });
 
     cy.on("tap", "edge", (e: EventObject) => {

--- a/frontend/src/components/panels/PropertiesPanel.test.tsx
+++ b/frontend/src/components/panels/PropertiesPanel.test.tsx
@@ -24,6 +24,7 @@ let mockSelectedElement: {
   type: "node" | "edge";
   data: Record<string, unknown>;
 } | null = null;
+let mockInitialConditionsEditNonce = 0;
 let mockConfig: Record<string, unknown> = {
   nodes: [
     {
@@ -47,6 +48,7 @@ vi.mock("@/stores/selectionStore", () => ({
   useSelectionStore: (selector: (s: unknown) => unknown) => {
     const store = {
       selectedElement: mockSelectedElement,
+      initialConditionsEditNonce: mockInitialConditionsEditNonce,
       clearSelection: mockClearSelection,
     };
     return selector(store);
@@ -69,6 +71,7 @@ vi.mock("@/stores/configStore", () => ({
 describe("PropertiesPanel delete confirmation", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockInitialConditionsEditNonce = 0;
     mockSelectedElement = {
       type: "node",
       data: { id: "reactor_1", type: "IdealGasReactor" },
@@ -172,5 +175,48 @@ describe("PropertiesPanel delete confirmation", () => {
     expect(screen.getByText("101,325.00")).toBeInTheDocument();
     expect(screen.getByText("H2:2,O2:1,N2:4")).toBeInTheDocument();
     expect(screen.queryByText("initial")).not.toBeInTheDocument();
+  });
+});
+
+describe("PropertiesPanel edit-on-double-click", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockInitialConditionsEditNonce = 0;
+    mockSelectedElement = {
+      type: "node",
+      data: { id: "reactor_1", type: "IdealGasReactor" },
+    };
+    mockConfig = {
+      nodes: [
+        {
+          id: "reactor_1",
+          type: "IdealGasReactor",
+          properties: { temperature: 1273.15, pressure: 101325 },
+        },
+      ],
+      connections: [],
+    };
+  });
+
+  it("enters edit mode when selection requests editInitialConditions", () => {
+    mockInitialConditionsEditNonce = 1;
+    mockSelectedElement = {
+      type: "node",
+      data: { id: "reactor_1", type: "IdealGasReactor" },
+    };
+
+    render(<PropertiesPanel />);
+
+    expect(screen.getByRole("button", { name: "Save" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Edit" })).not.toBeInTheDocument();
+    expect(screen.getByDisplayValue("1000.00")).toBeInTheDocument();
+  });
+
+  it("shows view mode for a normal single-click selection", () => {
+    render(<PropertiesPanel />);
+
+    expect(screen.getByRole("button", { name: "Edit" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Save" })).not.toBeInTheDocument();
+    expect(screen.getByText("1000.00 °C")).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/panels/PropertiesPanel.tsx
+++ b/frontend/src/components/panels/PropertiesPanel.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useSelectionStore } from "@/stores/selectionStore";
 import { useConfigStore } from "@/stores/configStore";
 import { kelvinToCelsius, celsiusToKelvin, formatNumber, labelWithUnit } from "@/lib/units";
@@ -23,8 +23,23 @@ function unfoldInitialConditions(
   return flat;
 }
 
+function buildEditValuesFromProperties(
+  displayProperties: Record<string, unknown>,
+): Record<string, string> {
+  const vals: Record<string, string> = {};
+  for (const [key, value] of Object.entries(displayProperties)) {
+    if (key === "temperature" && typeof value === "number") {
+      vals[key] = String(kelvinToCelsius(value).toFixed(2));
+    } else {
+      vals[key] = String(value ?? "");
+    }
+  }
+  return vals;
+}
+
 export function PropertiesPanel() {
   const selectedElement = useSelectionStore((s) => s.selectedElement);
+  const initialConditionsEditNonce = useSelectionStore((s) => s.initialConditionsEditNonce);
   const config = useConfigStore((s) => s.config);
   const updateNode = useConfigStore((s) => s.updateNode);
   const updateConnection = useConfigStore((s) => s.updateConnection);
@@ -34,6 +49,57 @@ export function PropertiesPanel() {
   const [isEditing, setIsEditing] = useState(false);
   const [editValues, setEditValues] = useState<Record<string, string>>({});
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const handledEditNonceRef = useRef(0);
+  const prevSelectedElementRef = useRef<typeof selectedElement>(null);
+
+  // Double-click on a graph node bumps initialConditionsEditNonce.
+  useEffect(() => {
+    const element = selectedElement;
+    if (!element) {
+      setIsEditing(false);
+      prevSelectedElementRef.current = null;
+      return;
+    }
+
+    const elementChanged = prevSelectedElementRef.current !== element;
+    prevSelectedElementRef.current = element;
+
+    if (initialConditionsEditNonce > handledEditNonceRef.current) {
+      handledEditNonceRef.current = initialConditionsEditNonce;
+
+      if (element.data.isGroup) {
+        setIsEditing(false);
+        return;
+      }
+
+      const isNode = element.type === "node";
+      const id = String(element.data.id);
+      const entity = isNode
+        ? config.nodes.find((n) => n.id === id)
+        : config.connections.find((c) => c.id === id);
+      if (!entity) {
+        setIsEditing(false);
+        return;
+      }
+
+      const properties = entity.properties as Record<string, unknown>;
+      const isStreamPoint = isNode && Boolean(properties.stream_point);
+      const isTerminalSink = isNode && Boolean(properties.terminal_sink);
+      if (isStreamPoint || isTerminalSink) {
+        setIsEditing(false);
+        return;
+      }
+
+      const displayProperties = unfoldInitialConditions(properties);
+      setEditValues(buildEditValuesFromProperties(displayProperties));
+      setIsEditing(true);
+      return;
+    }
+
+    if (elementChanged) {
+      setIsEditing(false);
+    }
+  }, [selectedElement, initialConditionsEditNonce, config]);
 
   // Field metadata from the kind's registered schema (descriptions, enum
   // options, conditional visibility). Fetched before any early return so
@@ -125,15 +191,7 @@ export function PropertiesPanel() {
 
   // Start editing
   const handleEdit = () => {
-    const vals: Record<string, string> = {};
-    for (const [key, value] of Object.entries(displayProperties)) {
-      if (key === "temperature" && typeof value === "number") {
-        vals[key] = String(kelvinToCelsius(value).toFixed(2));
-      } else {
-        vals[key] = String(value ?? "");
-      }
-    }
-    setEditValues(vals);
+    setEditValues(buildEditValuesFromProperties(displayProperties));
     setIsEditing(true);
   };
 

--- a/frontend/src/stores/selectionStore.ts
+++ b/frontend/src/stores/selectionStore.ts
@@ -5,14 +5,30 @@ export interface SelectedElement {
   data: Record<string, unknown>;
 }
 
+export interface SetSelectedElementOptions {
+  editInitialConditions?: boolean;
+}
+
 interface SelectionState {
   selectedElement: SelectedElement | null;
-  setSelectedElement: (element: SelectedElement | null) => void;
+  /** Incremented when a graph double-click requests initial-conditions edit. */
+  initialConditionsEditNonce: number;
+  setSelectedElement: (
+    element: SelectedElement | null,
+    options?: SetSelectedElementOptions,
+  ) => void;
   clearSelection: () => void;
 }
 
 export const useSelectionStore = create<SelectionState>((set) => ({
   selectedElement: null,
-  setSelectedElement: (element) => set({ selectedElement: element }),
+  initialConditionsEditNonce: 0,
+  setSelectedElement: (element, options) =>
+    set((state) => ({
+      selectedElement: element,
+      initialConditionsEditNonce: options?.editInitialConditions
+        ? state.initialConditionsEditNonce + 1
+        : state.initialConditionsEditNonce,
+    })),
   clearSelection: () => set({ selectedElement: null }),
 }));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **Single-click** on a graph node continues to select it and show its properties in view mode.
- **Double-click** (within ~300 ms) now opens the Properties panel in **Initial conditions** edit mode, replacing the previous behavior of switching to the Thermo tab.

## Implementation

- `selectionStore` gains an `initialConditionsEditNonce` counter bumped when a double-tap requests edit mode.
- `ReactorGraph` passes `{ editInitialConditions: true }` on double-tap instead of calling `setActiveTab("Thermo")`.
- `PropertiesPanel` reacts to the nonce and auto-enters edit mode; single-click selection still resets to view mode.

## Testing

- Added unit tests in `PropertiesPanel.test.tsx` for edit-on-double-click and view-on-single-click.
- `npm run test:unit -- src/components/panels/PropertiesPanel.test.tsx` — pass
- `npm run build` — pass

## AI disclosure

Extensive AI use — code & PR fully written by Claude Opus 4.6.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0550f547-4a98-41c4-bc95-114872184877"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0550f547-4a98-41c4-bc95-114872184877"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

