### PR TITLE
feat: Wall velocity callable + FlowReactor design doc

### DIFF
--- a/boulder/cantera_converter.py
+++ b/boulder/cantera_converter.py
@@ -780,6 +780,60 @@ class DualCanteraConverter:
             "Expected 'func' or 'profile'/'tabulated'."
         )
 
+    def _build_wall_velocity(self, spec: Any, src: str, tgt: str) -> Any:
+        """Build a ``ct.Wall`` ``velocity`` Func1/callable from a STONE spec.
+
+        Supported forms
+        ---------------
+        Scalar / ``{func:, args:}`` / ``{profile:/tabulated:, points:}``:
+            Delegated to :meth:`_build_func1_from_spec`.
+        ``{closure: pressure_proportional, coeff:, start_time:}``:
+            A wall held fixed until ``start_time`` (default 0), then moving at
+            ``coeff * (P_src - P_tgt)`` -- the same proportional-control
+            behaviour as ``expansion_rate_coeff``, but with an optional delay
+            and evaluated as a live callable rather than a bare coefficient
+            (matches upstream Cantera's ``piston.py`` example, where the wall
+            is released only after ``t >= 0.1``).
+
+        Parameters
+        ----------
+        spec:
+            Raw value from the STONE ``velocity`` property.
+        src, tgt:
+            Node ids of the two reactors the wall connects, resolved against
+            ``self.reactors`` at call time (not at build time), so the
+            closure always reads the reactors' live pressures.
+
+        Returns
+        -------
+        ct.Func1
+            A Cantera Func1 object ready to assign to a Wall's ``velocity``.
+        """
+        if isinstance(spec, dict) and "closure" in spec:
+            closure_kind = str(spec["closure"])
+            if closure_kind != "pressure_proportional":
+                raise ValueError(
+                    f"Wall velocity: unsupported closure '{closure_kind}'. "
+                    "Only 'pressure_proportional' is supported."
+                )
+            coeff = float(spec.get("coeff", 0.0))
+            start_time = float(spec.get("start_time", 0.0))
+
+            def _velocity_closure(t: float, _src: str = src, _tgt: str = tgt) -> float:
+                if t < start_time:
+                    return 0.0
+                r_src = self.reactors.get(_src)
+                r_tgt = self.reactors.get(_tgt)
+                if r_src is None or r_tgt is None:
+                    return 0.0
+                try:
+                    return coeff * (r_src.phase.P - r_tgt.phase.P)
+                except (AttributeError, ct.CanteraError):
+                    return 0.0
+
+            return ct.Func1(_velocity_closure)
+        return self._build_func1_from_spec(spec)
+
     # ------------------------------------------------------------------
     # Low-level helpers shared by build_network / build_sub_network
     # ------------------------------------------------------------------
@@ -1180,6 +1234,15 @@ class DualCanteraConverter:
                 if "expansion_rate_coeff" in props
                 else None
             )
+            # velocity is Cantera's other (additive) piston-motion input: a
+            # constant, a Func1 schedule, or a proportional-control closure --
+            # unlike expansion_rate_coeff (a bare coefficient), this can express
+            # e.g. a piston held fixed until some start_time.
+            velocity_signal = (
+                self._build_wall_velocity(props["velocity"], src, tgt)
+                if "velocity" in props
+                else None
+            )
             if "heat_transfer_coeff" in props:
                 # Passive heat-conduction wall: Q = U*A*(T_left - T_right),
                 # recomputed every step from the two reactors' live temperatures
@@ -1192,6 +1255,8 @@ class DualCanteraConverter:
                 }
                 if expansion_rate_coeff is not None:
                     wall_kwargs["K"] = expansion_rate_coeff
+                if velocity_signal is not None:
+                    wall_kwargs["velocity"] = velocity_signal
                 wall = ct.Wall(
                     self.reactors[src],
                     self.reactors[tgt],
@@ -1212,12 +1277,14 @@ class DualCanteraConverter:
                 )
             else:
                 # Generic passive wall: heat_flux=0 by default, settable post-build.
-                # Still honours a standalone expansion_rate_coeff (a purely
-                # mechanical piston with no heat exchange).
+                # Still honours a standalone expansion_rate_coeff and/or velocity
+                # (a purely mechanical piston with no heat exchange).
                 area = float(props.get("area", 1.0))
                 wall_kwargs = {"A": area, "name": cid}
                 if expansion_rate_coeff is not None:
                     wall_kwargs["K"] = expansion_rate_coeff
+                if velocity_signal is not None:
+                    wall_kwargs["velocity"] = velocity_signal
                 wall = ct.Wall(
                     self.reactors[src],
                     self.reactors[tgt],

--- a/boulder/download_script_emitter.py
+++ b/boulder/download_script_emitter.py
@@ -368,11 +368,46 @@ class CanteraScriptEmitter:
                 if "expansion_rate_coeff" in props
                 else ""
             )
+            velocity_spec = props.get("velocity")
+            velocity_kwarg = ""
+            if velocity_spec is not None:
+                if isinstance(velocity_spec, dict) and "closure" in velocity_spec:
+                    closure_kind = str(velocity_spec["closure"])
+                    if closure_kind == "pressure_proportional":
+                        coeff = float(velocity_spec.get("coeff", 0.0))
+                        start_time = float(velocity_spec.get("start_time", 0.0))
+                        fn = f"_velocity_{cref}"
+                        out.append(
+                            f"def {fn}(t, _src={src!r}, _tgt={tgt!r}, "
+                            f"_coeff={coeff!r}, _start={start_time!r}):"
+                        )
+                        out.append("    if t < _start:")
+                        out.append("        return 0.0")
+                        out.append("    r_src = reactors.get(_src)")
+                        out.append("    r_tgt = reactors.get(_tgt)")
+                        out.append("    if r_src is None or r_tgt is None:")
+                        out.append("        return 0.0")
+                        out.append(
+                            "    return _coeff * (r_src.phase.P - r_tgt.phase.P)"
+                        )
+                        velocity_kwarg = f", velocity=ct.Func1({fn})"
+                    else:
+                        out.append(
+                            f'raise ValueError("Wall {cid!r}: unsupported velocity '
+                            f'closure {closure_kind!r}")'
+                        )
+                elif isinstance(velocity_spec, (int, float)):
+                    velocity_kwarg = f", velocity={float(velocity_spec)!r}"
+                else:
+                    out.append(
+                        f'raise ValueError("Wall {cid!r}: Func1 velocity schedule '
+                        f'specs not supported in native download script")'
+                    )
             if "heat_transfer_coeff" in props:
                 u_coeff = float(props["heat_transfer_coeff"])
                 out.append(
                     f"{cref} = ct.Wall({sv}, {tv}, A={area}, "
-                    f"U={u_coeff!r}{k_coeff}, name={cid!r})"
+                    f"U={u_coeff!r}{k_coeff}{velocity_kwarg}, name={cid!r})"
                 )
             elif "electric_power_kW" in props:
                 q_w = (
@@ -387,7 +422,8 @@ class CanteraScriptEmitter:
                 )
             else:
                 out.append(
-                    f"{cref} = ct.Wall({sv}, {tv}, A={area}{k_coeff}, name={cid!r})"
+                    f"{cref} = ct.Wall({sv}, {tv}, A={area}{k_coeff}"
+                    f"{velocity_kwarg}, name={cid!r})"
                 )
             out.append(f"walls[{cid!r}] = {cref}")
         elif ctype == "Valve":

--- a/boulder/sim2stone.py
+++ b/boulder/sim2stone.py
@@ -1120,6 +1120,17 @@ def sim_to_stone_yaml(
         if s.kind == "Gaussian" and s.source_var not in _bound_signal_ids
     ]
 
+    # AST-detected Wall velocity closures (e.g. upstream Cantera's piston.py:
+    # `def v(t): ... return coeff*(r1.phase.P - r2.phase.P)`). Live
+    # introspection of ``wall.velocity`` always yields the evaluated float at
+    # conversion time, never the original Func1/callable (same limitation as
+    # ``mass_flow_rate`` above), so a velocity-only Wall falls through
+    # ``sim_to_internal_config``'s heat-rate snapshot branch and needs its
+    # properties substituted here instead.
+    wall_velocity_closures = (
+        list(ast_result.wall_velocity_closures) if ast_result else []
+    )
+
     for node in internal.get("nodes", []):
         node_cm = CommentedMap()
         node_cm["id"] = node["id"]
@@ -1220,6 +1231,28 @@ def sim_to_stone_yaml(
                     ],
                 }
                 conn_props.pop("_comment", None)
+
+        # Substitute a real velocity closure for a Wall whose motion was
+        # snapshotted as a (typically zero) electric_power_kW torch — same
+        # single-candidate-on-each-side heuristic as the Gaussian/MFC and
+        # residence-time cases above.
+        if (
+            conn.get("type") == "Wall"
+            and len(wall_velocity_closures) == 1
+            and "electric_power_kW" in conn_props
+        ):
+            wall_connections = [
+                c for c in internal.get("connections", []) if c.get("type") == "Wall"
+            ]
+            if len(wall_connections) == 1:
+                wv = wall_velocity_closures[0]
+                conn_props = {
+                    "velocity": {
+                        "closure": "pressure_proportional",
+                        "coeff": wv.coeff,
+                        "start_time": wv.start_time,
+                    }
+                }
 
         conn_cm[conn["type"]] = conn_props if conn_props else None
         conn_cm["source"] = conn["source"]

--- a/boulder/sim2stone_ast.py
+++ b/boulder/sim2stone_ast.py
@@ -81,6 +81,24 @@ class DetectedClosure:
 
 
 @dataclass
+class DetectedWallVelocityClosure:
+    """Detected ``def v(t): return coeff * (r1.phase.P - r2.phase.P)`` pattern.
+
+    Also matches the delayed form ``if t < start: return 0.0 else: ...`` used
+    by upstream Cantera's ``piston.py`` example, where the wall is held fixed
+    until ``start_time``. Maps to STONE's ``{closure: pressure_proportional}``
+    wall velocity spec.
+    """
+
+    wall_var: str
+    src_reactor_var: str
+    tgt_reactor_var: str
+    coeff: float
+    start_time: float = 0.0
+    derived_via: str = "ast_match"
+
+
+@dataclass
 class DetectedContinuation:
     """Detected ``while reactor.T > N: sim.solve_steady(); tau *= k`` pattern."""
 
@@ -107,6 +125,9 @@ class ASTExtractionResult:
     signals: List[DetectedSignal] = field(default_factory=list)
     bindings: List[DetectedBinding] = field(default_factory=list)
     closures: List[DetectedClosure] = field(default_factory=list)
+    wall_velocity_closures: List[DetectedWallVelocityClosure] = field(
+        default_factory=list
+    )
     continuations: List[DetectedContinuation] = field(default_factory=list)
     solver: Optional[DetectedSolver] = None
 
@@ -518,6 +539,172 @@ def _detect_residence_time_closures(
 
 
 # ---------------------------------------------------------------------------
+# Wall velocity closure detection
+# ---------------------------------------------------------------------------
+
+
+def _match_pressure_diff_expr(
+    expr: ast.expr, scalars: Dict[str, float]
+) -> Optional[Tuple[str, str, float]]:
+    """Match ``coeff * (rA.phase.P - rB.phase.P)`` (either operand order).
+
+    Returns ``(rA_var, rB_var, coeff)`` such that the expression equals
+    ``coeff * (rA.phase.P - rB.phase.P)``, or ``None`` if no match.
+    """
+    if not (isinstance(expr, ast.BinOp) and isinstance(expr.op, ast.Mult)):
+        return None
+    sides = [expr.left, expr.right]
+    diff_node: Optional[ast.BinOp] = None
+    coeff_node: Optional[ast.expr] = None
+    for i, side in enumerate(sides):
+        if isinstance(side, ast.BinOp) and isinstance(side.op, ast.Sub):
+            diff_node = side
+            coeff_node = sides[1 - i]
+    if diff_node is None or coeff_node is None:
+        return None
+    coeff = _eval_const_extended(coeff_node, scalars)
+    if not isinstance(coeff, (int, float)):
+        return None
+
+    def _reactor_pressure_var(node: ast.expr) -> Optional[str]:
+        # Matches ``X.phase.P``
+        if (
+            isinstance(node, ast.Attribute)
+            and node.attr == "P"
+            and isinstance(node.value, ast.Attribute)
+            and node.value.attr == "phase"
+            and isinstance(node.value.value, ast.Name)
+        ):
+            return node.value.value.id
+        return None
+
+    r_a = _reactor_pressure_var(diff_node.left)
+    r_b = _reactor_pressure_var(diff_node.right)
+    if r_a is None or r_b is None:
+        return None
+    return r_a, r_b, float(coeff)
+
+
+def _detect_wall_velocity_closures(
+    tree: ast.AST,
+) -> List[DetectedWallVelocityClosure]:
+    """Detect ``def v(t): [if t < start:] return coeff*(r1.phase.P - r2.phase.P)``.
+
+    Also looks for ``ct.Wall(r1, r2, velocity=<var>)`` to link the function to
+    the Wall variable. Matches upstream Cantera's ``piston.py`` pattern, where
+    the wall is held at rest until ``start_time`` then moves proportionally to
+    the pressure difference between its two reactors.
+    """
+    scalars = _collect_scalar_assignments(tree)
+    # func_name -> (rA_var, rB_var, coeff, start_time)
+    closure_funcs: Dict[str, Tuple[str, str, float, float]] = {}
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.FunctionDef) or len(node.args.args) != 1:
+            continue
+        arg_name = node.args.args[0].arg
+        body = node.body
+
+        if (
+            len(body) == 1
+            and isinstance(body[0], ast.Return)
+            and body[0].value is not None
+        ):
+            match = _match_pressure_diff_expr(body[0].value, scalars)
+            if match is not None:
+                r_a, r_b, coeff = match
+                closure_funcs[node.name] = (r_a, r_b, coeff, 0.0)
+            continue
+
+        if not (len(body) == 1 and isinstance(body[0], ast.If)):
+            continue
+        if_stmt: ast.If = body[0]
+        test = if_stmt.test
+        if not (
+            isinstance(test, ast.Compare)
+            and len(test.ops) == 1
+            and isinstance(test.ops[0], (ast.Lt, ast.LtE))
+            and isinstance(test.left, ast.Name)
+            and test.left.id == arg_name
+        ):
+            continue
+        threshold = _eval_const_extended(test.comparators[0], scalars)
+        if not isinstance(threshold, (int, float)):
+            continue
+        if not (
+            len(if_stmt.body) == 1
+            and isinstance(if_stmt.body[0], ast.Return)
+            and len(if_stmt.orelse) == 1
+            and isinstance(if_stmt.orelse[0], ast.Return)
+        ):
+            continue
+        zero_return = if_stmt.body[0].value
+        zero_val = (
+            _eval_const_extended(zero_return, scalars)
+            if zero_return is not None
+            else None
+        )
+        if zero_val not in (0, 0.0):
+            continue
+        else_return = if_stmt.orelse[0].value
+        if else_return is None:
+            continue
+        match = _match_pressure_diff_expr(else_return, scalars)
+        if match is None:
+            continue
+        r_a, r_b, coeff = match
+        closure_funcs[node.name] = (r_a, r_b, coeff, float(threshold))
+
+    closures: List[DetectedWallVelocityClosure] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign):
+            continue
+        if len(node.targets) != 1 or not isinstance(node.targets[0], ast.Name):
+            continue
+        wall_var = node.targets[0].id
+        call = node.value
+        if not isinstance(call, ast.Call):
+            continue
+        callee = call.func
+        is_wall = (isinstance(callee, ast.Attribute) and callee.attr == "Wall") or (
+            isinstance(callee, ast.Name) and callee.id == "Wall"
+        )
+        if not is_wall:
+            continue
+        velocity_kw = next((kw for kw in call.keywords if kw.arg == "velocity"), None)
+        if velocity_kw is None or not isinstance(velocity_kw.value, ast.Name):
+            continue
+        func_name = velocity_kw.value.id
+        if func_name not in closure_funcs:
+            continue
+        r_a, r_b, coeff, start_time = closure_funcs[func_name]
+
+        # Resolve source/target reactor vars from the Wall(...) call's own
+        # positional args when available, flipping the coefficient's sign if
+        # the closure's variable order is reversed relative to the call --
+        # STONE's connection source/target must follow the call, not the
+        # closure body's arbitrary variable order.
+        src_var, tgt_var = r_a, r_b
+        pos_args = [a.id for a in call.args if isinstance(a, ast.Name)]
+        if len(pos_args) >= 2 and {pos_args[0], pos_args[1]} == {r_a, r_b}:
+            src_var, tgt_var = pos_args[0], pos_args[1]
+            if src_var != r_a:
+                coeff = -coeff
+
+        closures.append(
+            DetectedWallVelocityClosure(
+                wall_var=wall_var,
+                src_reactor_var=src_var,
+                tgt_reactor_var=tgt_var,
+                coeff=coeff,
+                start_time=start_time,
+                derived_via="ast_match",
+            )
+        )
+    return closures
+
+
+# ---------------------------------------------------------------------------
 # Continuation detection
 # ---------------------------------------------------------------------------
 
@@ -823,6 +1010,7 @@ def extract_from_source(source_file: str) -> ASTExtractionResult:
 
     result.signals = _detect_func1_signals(tree)
     result.closures = _detect_residence_time_closures(tree)
+    result.wall_velocity_closures = _detect_wall_velocity_closures(tree)
     result.continuations = _cont_list(_detect_continuation(tree))
     solver = _detect_solver_hint(tree)
     if solver is not None:

--- a/docs/plans/2026-07-14-flow-reactor-support.md
+++ b/docs/plans/2026-07-14-flow-reactor-support.md
@@ -1,0 +1,139 @@
+# FlowReactor / FlowReactorSurface Support — Design Sketch (Deferred)
+
+> **Status:** design only, not scheduled. Implementation is explicitly deferred pending
+> a separate scoping decision — do not start Task 1 without re-confirming priority.
+
+**Goal:** Support Cantera's `ct.FlowReactor` (plug-flow, distance-marched) and
+`ct.FlowReactorSurface` (coupled spatial surface-coverage evolution) so examples like
+`surf_pfr.py` / `surf_pfr_chain.py` / `1D_pfr_surfchem.py` can be modeled in Boulder
+instead of being marked `status: unsupported` in `boulder_examples/examples/manifest.yaml`.
+
+**Repo:** Boulder (`boulder/boulder/cantera_converter.py`, `boulder/boulder/sim2stone.py`,
+`boulder/boulder/config.py`, `frontend/src/components/results/PlotsTab.tsx`)
+
+______________________________________________________________________
+
+## Background
+
+### Why this doesn't fit today's model
+
+Every reactor type Boulder currently supports (`IdealGasReactor`, `ConstPressureReactor`,
+`IdealGasMoleReactor`, etc.) is a 0-D control volume advanced through **time** as part of a
+`ct.ReactorNet`. The entire STONE schema, `cantera_converter.py`'s `create_reactor_from_node`
+(~line 950), and the frontend's plotting assumptions (`PlotsTab.tsx`, always keyed on `t`)
+are built around that.
+
+`ct.FlowReactor` is fundamentally different:
+
+- It represents a plug-flow duct and is integrated along **distance**, not time
+  (`reactor.distance`, driven by `mass_flow_rate` and cross-sectional `area`).
+- `ct.FlowReactorSurface` attaches wall surface chemistry to that duct — site coverages
+  evolve as a function of the same distance march, coupled back into the gas phase.
+
+There is currently no "independent variable" concept in STONE at all (time is implicit
+everywhere), no surface-phase node kind, and no distance-based plotting support.
+
+### Current state (confirmed by investigation, 2026-07-14)
+
+- `create_reactor_from_node` has a plain `if/elif` chain over reactor type strings
+  (`IdealGasReactor`, `ConstPressureReactor`, `IdealGasConstPressureReactor`,
+  `IdealGasConstPressureMoleReactor`, `IdealGasMoleReactor`, `Reservoir`, legacy
+  `OutletSink`), plus a plugin registry (`self.plugins.reactor_builders`) checked first.
+  `FlowReactor` is entirely absent — not stubbed, not partially wired.
+- `build_connection` only knows `MassFlowController`, `Valve`, `PressureController`,
+  `Wall` — no `ReactorSurface`/`FlowReactorSurface` handling anywhere.
+- `sim2stone_ast.py` / `sim2stone_trace.py` have zero references to `FlowReactor`.
+- `boulder_examples/examples/manifest.yaml` already documents the gap accurately:
+  `1D_pfr_surfchem`, `surf_pfr`, `surf_pfr_chain` are all `status: unsupported` with
+  reasons naming `FlowReactor`/`FlowReactorSurface` directly.
+
+### Success criteria (for whenever this is picked up)
+
+1. A YAML node of `type: FlowReactor` builds a working `ct.FlowReactor` with
+   `mass_flow_rate`, `area`, initial `T`/`P`/`X`.
+2. A YAML node of `type: FlowReactorSurface` (or a `surface:` property on the
+   `FlowReactor` node) attaches surface chemistry with initial coverages and a surface
+   mechanism reference.
+3. sim2stone can convert a hand-written `ct.FlowReactor` + `ct.FlowReactorSurface`
+   Cantera script back into STONE YAML (reverse direction), following the existing
+   AST-detection pattern used for Gaussian MFC schedules.
+4. The frontend plots these nodes' output against `distance`, not `t` — a per-node
+   x-axis override, not a global change.
+5. `surf_pfr.py` runs end-to-end as a new boulder_examples catalog entry, replacing its
+   `status: unsupported` manifest entry.
+6. New tests cover both directions (YAML→Cantera and Cantera→YAML).
+
+______________________________________________________________________
+
+## Proposed shape
+
+### Task 1 — STONE schema: distance axis
+
+**Files:** `boulder/boulder/config.py`, `boulder/docs/stone.rst`
+
+Add an explicit `axis: distance` marker (parallel to today's implicit `axis: time`) at
+the node or stage level, plus a `distance_end` / grid config — mirroring how
+`advance_grid`/`micro_step` solver hints already carry timing params in
+`sim2stone_ast.py`, but for a distance grid instead of a time grid.
+
+### Task 2 — `FlowReactor` node construction
+
+**Files:** `boulder/boulder/cantera_converter.py` (`create_reactor_from_node`)
+
+New branch alongside the existing reactor-type chain: construct `ct.FlowReactor`,
+set `mass_flow_rate`, `area` (constant or profile), initial thermodynamic state.
+Follow the existing per-branch style (see the `Reservoir` branch for the simplest
+template).
+
+### Task 3 — `FlowReactorSurface` construction + attachment
+
+**Files:** `boulder/boulder/cantera_converter.py` (new builder, or extend
+`build_connection`)
+
+New node kind or connection kind that attaches a `ct.FlowReactorSurface` to a
+`FlowReactor` node: `site_density`, initial coverages, surface mechanism file.
+Needs a decision: separate node (cleaner, matches "surface phase as its own thing")
+vs. a property bag on the `FlowReactor` node (less STONE surface area, less flexible).
+Recommend separate node + new connection kind, consistent with how `Wall` is already
+a first-class connection rather than a property of the reactors it joins.
+
+### Task 4 — sim2stone reverse-direction support
+
+**Files:** `boulder/boulder/sim2stone.py`, `boulder/boulder/sim2stone_ast.py`
+
+Detect `ct.FlowReactor`/`ct.FlowReactorSurface` instances during export; emit the
+`axis: distance` marker instead of assuming time; export distance-grid timing the same
+way `_detect_advance_timing` extracts time-grid params today.
+
+### Task 5 — Frontend distance-axis plotting
+
+**Files:** `frontend/src/components/results/PlotsTab.tsx`
+
+`PlotsTab.tsx` currently assumes every series is keyed on `t`. Add a per-node override
+(read from the node's `axis` property, set by Task 1) so a `FlowReactor` node's series
+plot against `distance` on the x-axis instead.
+
+### Task 6 — Tests + example
+
+**Files:** new `tests/test_sim2stone/test_flow_reactor.py`,
+`boulder_examples/adapters/surf_pfr.py`, `boulder_examples/examples/surf_pfr.yaml`,
+update `boulder_examples/examples/manifest.yaml` (`surf_pfr` entry:
+`status: unsupported` → `status: adapted`).
+
+______________________________________________________________________
+
+## Rough scope estimate
+
+Schema + converter + sim2stone + frontend x-axis + tests + example ≈ **3–7 days** of
+focused work. This is closer to "add a new reactor family" than "add one enum value" —
+treat it as its own PR/milestone, not a quick side-diff.
+
+## Agent constraints (for whoever picks this up)
+
+| Do | Don't |
+|----|-------|
+| Confirm scope/priority before starting Task 1 | Assume this doc means the work is scheduled |
+| Follow the existing per-reactor-type branch style in `create_reactor_from_node` | Invent a parallel reactor-construction pathway |
+| Reuse the AST-signal-detection pattern already used for Gaussian MFC schedules | Add live-Func1-object introspection (known to not work — see `mass_flow_rate`/`wall.velocity`) |
+| Keep `axis: distance` opt-in / per-node | Change the default x-axis for existing time-integrated reactors |
+| Run the full test suite + `surf_pfr` example before claiming done | Skip `FlowReactorSurface` silently while claiming full support |

--- a/docs/plans/2026-07-14-flow-reactor-support.md
+++ b/docs/plans/2026-07-14-flow-reactor-support.md
@@ -51,17 +51,17 @@ everywhere), no surface-phase node kind, and no distance-based plotting support.
 
 1. A YAML node of `type: FlowReactor` builds a working `ct.FlowReactor` with
    `mass_flow_rate`, `area`, initial `T`/`P`/`X`.
-2. A YAML node of `type: FlowReactorSurface` (or a `surface:` property on the
+1. A YAML node of `type: FlowReactorSurface` (or a `surface:` property on the
    `FlowReactor` node) attaches surface chemistry with initial coverages and a surface
    mechanism reference.
-3. sim2stone can convert a hand-written `ct.FlowReactor` + `ct.FlowReactorSurface`
+1. sim2stone can convert a hand-written `ct.FlowReactor` + `ct.FlowReactorSurface`
    Cantera script back into STONE YAML (reverse direction), following the existing
    AST-detection pattern used for Gaussian MFC schedules.
-4. The frontend plots these nodes' output against `distance`, not `t` — a per-node
+1. The frontend plots these nodes' output against `distance`, not `t` — a per-node
    x-axis override, not a global change.
-5. `surf_pfr.py` runs end-to-end as a new boulder_examples catalog entry, replacing its
+1. `surf_pfr.py` runs end-to-end as a new boulder_examples catalog entry, replacing its
    `status: unsupported` manifest entry.
-6. New tests cover both directions (YAML→Cantera and Cantera→YAML).
+1. New tests cover both directions (YAML→Cantera and Cantera→YAML).
 
 ______________________________________________________________________
 

--- a/tests/test_wall_velocity.py
+++ b/tests/test_wall_velocity.py
@@ -19,6 +19,7 @@ import ast
 import os
 import tempfile
 import textwrap
+from typing import cast
 
 import cantera as ct
 import pytest
@@ -169,7 +170,9 @@ def test_cantera_converter_builds_velocity_wall_from_closure_spec() -> None:
     converter.build_connection(conn)
 
     wall = converter.walls["piston"]
-    net = ct.ReactorNet([converter.reactors["left"], converter.reactors["right"]])
+    left_reactor = cast(ct.Reactor, converter.reactors["left"])
+    right_reactor = cast(ct.Reactor, converter.reactors["right"])
+    net = ct.ReactorNet([left_reactor, right_reactor])
     # Held fixed before start_time...
     net.advance(0.05)
     assert wall.velocity == pytest.approx(0.0)

--- a/tests/test_wall_velocity.py
+++ b/tests/test_wall_velocity.py
@@ -1,0 +1,260 @@
+"""Regression tests: ``ct.Wall(velocity=...)`` round-trips through STONE correctly.
+
+A pure velocity-driven piston (no ``heat_transfer_coeff``/``expansion_rate_coeff``)
+must become a real closure-driven wall, not a frozen (typically zero)
+``electric_power_kW`` snapshot.
+
+Bug/gap: ``wall.velocity`` always reads back as the evaluated float at the
+network's current time (Cantera never returns the underlying Func1/callable),
+so a velocity-only wall fell into ``sim_to_internal_config``'s heat-rate
+snapshot branch and silently discarded the piston's motion entirely (e.g.
+upstream Cantera's ``piston.py``, whose adiabatic free piston is held fixed
+until ``t=0.1s`` then moves proportionally to the pressure difference between
+its two reactors).
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+import tempfile
+import textwrap
+
+import cantera as ct
+import pytest
+
+from boulder.cantera_converter import DualCanteraConverter
+from boulder.config import load_yaml_string_with_comments, normalize_config
+from boulder.download_script_emitter import CanteraScriptEmitter
+from boulder.sim2stone import sim_to_stone_yaml
+from boulder.sim2stone_ast import _detect_wall_velocity_closures
+
+_PISTON_SOURCE = """
+    import cantera as ct
+
+    gas1 = ct.Solution('h2o2.yaml')
+    gas1.TPX = 900.0, ct.one_atm, 'H2:2, O2:1, AR:20'
+    gas2 = ct.Solution('gri30.yaml')
+    gas2.TPX = 900.0, ct.one_atm, 'CO:2, H2O:0.01, O2:5'
+
+    r1 = ct.IdealGasReactor(gas1)
+    r1.volume = 0.5
+    r2 = ct.IdealGasReactor(gas2)
+    r2.volume = 0.1
+
+    def v(t):
+        if t < 0.1:
+            return 0.0
+        else:
+            return (r1.phase.P - r2.phase.P) * 1e-4
+
+    w = ct.Wall(r1, r2, velocity=v)
+    sim = ct.ReactorNet([r1, r2])
+"""
+
+
+def _write_and_run(python_content: str) -> str:
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
+        f.write(textwrap.dedent(python_content))
+        f.flush()
+        temp_name = f.name
+
+    try:
+        exec_globals: dict = {}
+        with open(temp_name, "r") as file:
+            exec(file.read(), exec_globals)
+        sim = exec_globals["sim"]
+        return sim_to_stone_yaml(
+            sim,
+            default_mechanism="h2o2.yaml",
+            source_file=temp_name,
+            include_comments=False,
+        )
+    finally:
+        os.unlink(temp_name)
+
+
+def test_detect_delayed_pressure_proportional_velocity_closure() -> None:
+    """AST detection recovers coeff/start_time from piston.py's ``v(t)``."""
+    tree = ast.parse(textwrap.dedent(_PISTON_SOURCE))
+    closures = _detect_wall_velocity_closures(tree)
+    assert len(closures) == 1
+    cl = closures[0]
+    assert cl.src_reactor_var == "r1"
+    assert cl.tgt_reactor_var == "r2"
+    assert cl.coeff == pytest.approx(1e-4)
+    assert cl.start_time == pytest.approx(0.1)
+
+
+def test_detect_undelayed_velocity_closure() -> None:
+    """A ``def v(t): return coeff*(r1.phase.P - r2.phase.P)`` (no delay) works too."""
+    tree = ast.parse(
+        textwrap.dedent(
+            """
+            import cantera as ct
+            r1 = ct.IdealGasReactor(gas1)
+            r2 = ct.IdealGasReactor(gas2)
+
+            def v(t):
+                return 2e-5 * (r1.phase.P - r2.phase.P)
+
+            w = ct.Wall(r1, r2, velocity=v)
+            """
+        )
+    )
+    closures = _detect_wall_velocity_closures(tree)
+    assert len(closures) == 1
+    cl = closures[0]
+    assert cl.coeff == pytest.approx(2e-5)
+    assert cl.start_time == pytest.approx(0.0)
+
+
+def test_sim2stone_recovers_velocity_closure_from_source() -> None:
+    """A velocity-only Wall emits a pressure_proportional closure, not a torch."""
+    yaml_str = _write_and_run(_PISTON_SOURCE)
+    normalized = normalize_config(load_yaml_string_with_comments(yaml_str))
+
+    walls = [c for c in normalized["connections"] if c["type"] == "Wall"]
+    assert len(walls) == 1
+    props = walls[0]["properties"]
+    assert "electric_power_kW" not in props
+    velocity = props.get("velocity")
+    assert isinstance(velocity, dict), f"expected a closure dict, got {velocity!r}"
+    assert velocity["closure"] == "pressure_proportional"
+    assert velocity["coeff"] == pytest.approx(1e-4)
+    assert velocity["start_time"] == pytest.approx(0.1)
+
+
+def test_cantera_converter_builds_velocity_wall_from_closure_spec() -> None:
+    """build_connection constructs a real velocity-driven Wall from the spec."""
+    converter = DualCanteraConverter(mechanism="h2o2.yaml")
+
+    nodes = [
+        {
+            "id": "left",
+            "type": "IdealGasReactor",
+            "properties": {
+                "temperature": 900.0,
+                "pressure": 2.0 * 101325.0,
+                "composition": "H2:2,O2:1,AR:20",
+                "volume": 0.5,
+            },
+        },
+        {
+            "id": "right",
+            "type": "IdealGasReactor",
+            "properties": {
+                "temperature": 900.0,
+                "pressure": 101325.0,
+                "composition": "H2:1,O2:5",
+                "volume": 0.1,
+            },
+        },
+    ]
+    conn = {
+        "id": "piston",
+        "type": "Wall",
+        "source": "left",
+        "target": "right",
+        "properties": {
+            "velocity": {
+                "closure": "pressure_proportional",
+                "coeff": 1e-4,
+                "start_time": 0.1,
+            },
+        },
+    }
+    for node in nodes:
+        converter.build_isolated_reactor(node)
+    converter.build_connection(conn)
+
+    wall = converter.walls["piston"]
+    net = ct.ReactorNet([converter.reactors["left"], converter.reactors["right"]])
+    # Held fixed before start_time...
+    net.advance(0.05)
+    assert wall.velocity == pytest.approx(0.0)
+    # ...then proportional to the (nonzero) pressure difference afterwards.
+    net.advance(0.2)
+    expected = 1e-4 * (
+        converter.reactors["left"].phase.P - converter.reactors["right"].phase.P
+    )
+    assert wall.velocity == pytest.approx(expected)
+
+
+def test_cantera_converter_builds_scalar_velocity_wall() -> None:
+    """A plain scalar ``velocity:`` builds a constant-velocity Wall."""
+    converter = DualCanteraConverter(mechanism="h2o2.yaml")
+
+    nodes = [
+        {
+            "id": "left",
+            "type": "IdealGasReactor",
+            "properties": {
+                "temperature": 900.0,
+                "pressure": 101325.0,
+                "composition": "H2:1",
+                "volume": 0.5,
+            },
+        },
+        {
+            "id": "right",
+            "type": "IdealGasReactor",
+            "properties": {
+                "temperature": 900.0,
+                "pressure": 101325.0,
+                "composition": "O2:1",
+                "volume": 0.5,
+            },
+        },
+    ]
+    conn = {
+        "id": "wall_0",
+        "type": "Wall",
+        "source": "left",
+        "target": "right",
+        "properties": {"velocity": 0.01},
+    }
+    for node in nodes:
+        converter.build_isolated_reactor(node)
+    converter.build_connection(conn)
+
+    wall = converter.walls["wall_0"]
+    assert wall.velocity == pytest.approx(0.01)
+
+
+def test_download_script_emits_velocity_closure_for_pressure_proportional() -> None:
+    """The --download script constructs a real def+Func1 for the closure."""
+    conn = {
+        "id": "piston",
+        "type": "Wall",
+        "source": "left",
+        "target": "right",
+        "properties": {
+            "velocity": {
+                "closure": "pressure_proportional",
+                "coeff": 1e-4,
+                "start_time": 0.1,
+            },
+        },
+    }
+    emitter = CanteraScriptEmitter()
+    lines = emitter._emit_connection(conn, "_conn_piston", "_conn_piston_spec")
+    joined = "\n".join(lines)
+    assert "def _velocity__conn_piston(" in joined
+    assert "velocity=ct.Func1(_velocity__conn_piston)" in joined
+    assert "raise ValueError" not in joined
+
+
+def test_download_script_emits_scalar_velocity_kwarg() -> None:
+    """The --download script passes a plain float velocity through directly."""
+    conn = {
+        "id": "wall_0",
+        "type": "Wall",
+        "source": "left",
+        "target": "right",
+        "properties": {"velocity": 0.01},
+    }
+    emitter = CanteraScriptEmitter()
+    lines = emitter._emit_connection(conn, "_conn_wall_0", "_conn_wall_0_spec")
+    joined = "\n".join(lines)
+    assert "velocity=0.01" in joined


### PR DESCRIPTION
## Summary
- Adds `velocity:` support to Wall connections — a Cantera 3.0+ Func1/callable piston-motion input, additive with the existing `expansion_rate_coeff`. Supports a scalar, a Func1 schedule spec, and a new `{closure: pressure_proportional, coeff, start_time}` spec matching upstream Cantera's `piston.py` example (a piston held fixed until `start_time`, then moving proportional to the pressure difference between its two reactors).
- Wired on both directions: forward (YAML → Cantera, in `cantera_converter.py`) and reverse (Cantera → YAML via AST detection in `sim2stone_ast.py`/`sim2stone.py`, since live `Func1` introspection can't recover the closure — same limitation already worked around for Gaussian MFC schedules).
- `--download` native script emitter (`download_script_emitter.py`) emits the matching real Python for both the scalar and closure forms.
- Adds `docs/plans/2026-07-14-flow-reactor-support.md` — a design sketch for `FlowReactor`/`FlowReactorSurface` support (distance-marched plug-flow reactors), explicitly marked deferred pending a separate scoping decision. Boulder's whole model is currently time-integrated 0-D reactors; this is a new subsystem, not a quick addition.

## Test plan
- [x] `tests/test_wall_velocity.py` (new, 7 tests): scalar velocity, delayed/undelayed AST closure detection, forward build, sim2stone round-trip, `--download` script emission
- [x] `ruff check` / `ruff format --check` / `mypy` clean on all touched files
- [x] Full backend suite green in isolation on this branch (666 passed, 1 pre-existing flaky skip, 5 xfailed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>