### PR TITLE
feat: nudge users toward keyboard shortcuts after repeated mouse clicks

### DIFF
--- a/frontend/src/components/layout/paneControls.test.tsx
+++ b/frontend/src/components/layout/paneControls.test.tsx
@@ -1,0 +1,55 @@
+/**
+ * Asserts PaneToggle: nudges toward Ctrl+B after repeatedly clicking the
+ * left-sidebar toggle by mouse, and never nudges the right-sidebar toggle
+ * (it has no keyboard shortcut).
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { PaneToggle } from "./paneControls";
+
+const mockToastInfo = vi.fn();
+vi.mock("sonner", () => ({
+  toast: { info: (...args: unknown[]) => mockToastInfo(...args) },
+}));
+
+const mockToggleLeft = vi.fn();
+const mockToggleRight = vi.fn();
+vi.mock("@/stores/layoutStore", () => ({
+  useLayoutStore: () => ({
+    leftCollapsed: false,
+    rightCollapsed: false,
+    toggleLeft: mockToggleLeft,
+    toggleRight: mockToggleRight,
+  }),
+}));
+
+describe("PaneToggle", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("nudges toward Ctrl+B after repeatedly clicking the left toggle by mouse", () => {
+    render(<PaneToggle side="left" />);
+    const button = screen.getByLabelText("Collapse left sidebar");
+    fireEvent.click(button);
+    fireEvent.click(button);
+    expect(mockToastInfo).not.toHaveBeenCalled();
+
+    fireEvent.click(button);
+    expect(mockToastInfo).toHaveBeenCalledOnce();
+    expect(mockToastInfo).toHaveBeenCalledWith(expect.stringContaining("Ctrl+B"));
+  });
+
+  it("never nudges the right toggle, since it has no keyboard shortcut", () => {
+    render(<PaneToggle side="right" />);
+    const button = screen.getByLabelText("Collapse right sidebar");
+    fireEvent.click(button);
+    fireEvent.click(button);
+    fireEvent.click(button);
+    fireEvent.click(button);
+
+    expect(mockToastInfo).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/layout/paneControls.tsx
+++ b/frontend/src/components/layout/paneControls.tsx
@@ -1,5 +1,6 @@
 import { PanelLeft, PanelRight } from "lucide-react";
 import { useLayoutStore } from "@/stores/layoutStore";
+import { useShortcutNudge } from "@/hooks/useShortcutNudge";
 
 /** Notify canvas-based components (Cytoscape, Plotly) that the layout changed. */
 function nudgeResize() {
@@ -10,6 +11,7 @@ function nudgeResize() {
 export function PaneToggle({ side }: { side: "left" | "right" }) {
   const { leftCollapsed, rightCollapsed, toggleLeft, toggleRight } =
     useLayoutStore();
+  const notifyShortcutUsage = useShortcutNudge();
   const collapsed = side === "left" ? leftCollapsed : rightCollapsed;
   const Icon = side === "left" ? PanelLeft : PanelRight;
   const label = `${collapsed ? "Expand" : "Collapse"} ${side} sidebar`;
@@ -18,6 +20,8 @@ export function PaneToggle({ side }: { side: "left" | "right" }) {
       type="button"
       onClick={() => {
         side === "left" ? toggleLeft() : toggleRight();
+        // Only "left" has a keyboard shortcut (Ctrl+B) — see AppShell.
+        if (side === "left") notifyShortcutUsage("toggle-left-sidebar", "Ctrl+B");
         // Let the flex layout settle, then re-fit canvases.
         requestAnimationFrame(nudgeResize);
       }}

--- a/frontend/src/components/panels/RunControl.test.tsx
+++ b/frontend/src/components/panels/RunControl.test.tsx
@@ -13,8 +13,9 @@ vi.mock("@/api/sweep", () => ({
   startSweep: vi.fn(),
 }));
 
+const mockToastInfo = vi.fn();
 vi.mock("sonner", () => ({
-  toast: { error: vi.fn(), success: vi.fn() },
+  toast: { error: vi.fn(), success: vi.fn(), info: (...args: unknown[]) => mockToastInfo(...args) },
 }));
 
 vi.mock("@/stores/scenarioStore", () => ({
@@ -75,5 +76,43 @@ describe("RunControl", () => {
 
     fireEvent.click(screen.getByRole("button", { name: /run simulation/i }));
     expect(onRunSimulation).toHaveBeenCalledWith(false);
+  });
+
+  it("nudges toward Ctrl+Enter after repeatedly clicking Run Simulation by mouse", () => {
+    render(
+      <RunControl
+        onRunSimulation={onRunSimulation}
+        isRunning={false}
+        runDisabled={false}
+      />,
+    );
+
+    const button = screen.getByRole("button", { name: /run simulation/i });
+    fireEvent.click(button);
+    fireEvent.click(button);
+    expect(mockToastInfo).not.toHaveBeenCalled();
+
+    fireEvent.click(button);
+    expect(mockToastInfo).toHaveBeenCalledOnce();
+    expect(mockToastInfo).toHaveBeenCalledWith(expect.stringContaining("Ctrl+Enter"));
+  });
+
+  it("does not nudge while in Force Run mode, since Ctrl+Enter doesn't do the same thing", () => {
+    render(
+      <RunControl
+        onRunSimulation={onRunSimulation}
+        isRunning={false}
+        runDisabled={false}
+      />,
+    );
+
+    fireEvent.click(screen.getByLabelText("Choose run action"));
+    fireEvent.click(screen.getByRole("menuitemradio", { name: /force run/i }));
+    const button = screen.getByRole("button", { name: "Force Run" });
+    fireEvent.click(button);
+    fireEvent.click(button);
+    fireEvent.click(button);
+
+    expect(mockToastInfo).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/components/panels/RunControl.tsx
+++ b/frontend/src/components/panels/RunControl.tsx
@@ -4,6 +4,7 @@ import { toast } from "sonner";
 import { Button } from "@/components/ui/Button";
 import { getSweepInfo, getSweepStatus, startSweep, type SweepInfo } from "@/api/sweep";
 import { useScenarioStore } from "@/stores/scenarioStore";
+import { useShortcutNudge } from "@/hooks/useShortcutNudge";
 import { AddScenarioModal } from "@/components/modals/AddScenarioModal";
 import { ScenarioYamlEditorModal } from "@/components/modals/ScenarioYamlEditorModal";
 
@@ -37,6 +38,7 @@ export function RunControl({ onRunSimulation, isRunning, runDisabled }: RunContr
   const refreshScenarios = useScenarioStore((s) => s.refresh);
   const [addScenarioOpen, setAddScenarioOpen] = useState(false);
   const [editingScenarioId, setEditingScenarioId] = useState<string | null>(null);
+  const notifyShortcutUsage = useShortcutNudge();
 
   const loadSweepInfo = useCallback(() => {
     getSweepInfo()
@@ -147,7 +149,13 @@ export function RunControl({ onRunSimulation, isRunning, runDisabled }: RunContr
 
   const onPrimary = () => {
     if (effectiveMode === "sweep") handleRunSweep();
-    else onRunSimulation(effectiveMode === "force_sim");
+    else {
+      // Ctrl+Enter (see useKeyboardShortcuts) always runs the plain "sim"
+      // action regardless of the split button's mode — only nudge when a
+      // click here does the exact same thing the shortcut would.
+      if (effectiveMode === "sim") notifyShortcutUsage("run-simulation", "Ctrl+Enter");
+      onRunSimulation(effectiveMode === "force_sim");
+    }
   };
 
   return (

--- a/frontend/src/hooks/useShortcutNudge.test.ts
+++ b/frontend/src/hooks/useShortcutNudge.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Asserts useShortcutNudge: stays silent for the first couple of clicks,
+ * nudges once a threshold is reached within the window, resets afterward
+ * (so it takes a fresh run of clicks to nudge again), tracks each actionId
+ * independently, and forgets clicks that fall outside the window.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useShortcutNudge, NUDGE_THRESHOLD, NUDGE_WINDOW_MS } from "./useShortcutNudge";
+
+const mockToastInfo = vi.fn();
+vi.mock("sonner", () => ({
+  toast: { info: (...args: unknown[]) => mockToastInfo(...args) },
+}));
+
+describe("useShortcutNudge", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("does not nudge before the threshold is reached", () => {
+    const { result } = renderHook(() => useShortcutNudge());
+    for (let i = 0; i < NUDGE_THRESHOLD - 1; i++) {
+      result.current("run-simulation", "Ctrl+Enter");
+    }
+    expect(mockToastInfo).not.toHaveBeenCalled();
+  });
+
+  it("nudges with the shortcut label once the threshold is reached within the window", () => {
+    const { result } = renderHook(() => useShortcutNudge());
+    for (let i = 0; i < NUDGE_THRESHOLD; i++) {
+      result.current("run-simulation", "Ctrl+Enter");
+    }
+    expect(mockToastInfo).toHaveBeenCalledOnce();
+    expect(mockToastInfo).toHaveBeenCalledWith(expect.stringContaining("Ctrl+Enter"));
+  });
+
+  it("resets after nudging, requiring a fresh run of clicks before nudging again", () => {
+    const { result } = renderHook(() => useShortcutNudge());
+    for (let i = 0; i < NUDGE_THRESHOLD; i++) {
+      result.current("run-simulation", "Ctrl+Enter");
+    }
+    expect(mockToastInfo).toHaveBeenCalledOnce();
+
+    result.current("run-simulation", "Ctrl+Enter");
+    result.current("run-simulation", "Ctrl+Enter");
+    expect(mockToastInfo).toHaveBeenCalledOnce();
+
+    result.current("run-simulation", "Ctrl+Enter");
+    expect(mockToastInfo).toHaveBeenCalledTimes(2);
+  });
+
+  it("tracks each actionId independently", () => {
+    const { result } = renderHook(() => useShortcutNudge());
+    for (let i = 0; i < NUDGE_THRESHOLD - 1; i++) {
+      result.current("run-simulation", "Ctrl+Enter");
+    }
+    result.current("toggle-left-sidebar", "Ctrl+B");
+    expect(mockToastInfo).not.toHaveBeenCalled();
+
+    result.current("run-simulation", "Ctrl+Enter");
+    expect(mockToastInfo).toHaveBeenCalledOnce();
+    expect(mockToastInfo).toHaveBeenCalledWith(expect.stringContaining("Ctrl+Enter"));
+  });
+
+  it("forgets clicks once they fall outside the nudge window", () => {
+    const { result } = renderHook(() => useShortcutNudge());
+    result.current("run-simulation", "Ctrl+Enter");
+    result.current("run-simulation", "Ctrl+Enter");
+
+    vi.setSystemTime(NUDGE_WINDOW_MS + 1);
+    result.current("run-simulation", "Ctrl+Enter");
+
+    expect(mockToastInfo).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/hooks/useShortcutNudge.ts
+++ b/frontend/src/hooks/useShortcutNudge.ts
@@ -1,0 +1,33 @@
+import { useCallback, useRef } from "react";
+import { toast } from "sonner";
+
+/** A click is only counted toward a nudge if it lands within this window. */
+export const NUDGE_WINDOW_MS = 60_000;
+/** Clicks needed within the window before nudging (never on the first click or two). */
+export const NUDGE_THRESHOLD = 3;
+
+/**
+ * Returns `notify(actionId, shortcutLabel)` — call it from a button's
+ * onClick (never from the shortcut's own keydown handler, since using the
+ * shortcut is the desired behavior, not something to correct). After
+ * `NUDGE_THRESHOLD` clicks on the same `actionId` within `NUDGE_WINDOW_MS`,
+ * shows a toast naming the keyboard shortcut instead, then resets so the
+ * next nudge needs a fresh run of clicks rather than firing on every click.
+ */
+export function useShortcutNudge() {
+  const clicksByAction = useRef(new Map<string, number[]>());
+
+  return useCallback((actionId: string, shortcutLabel: string) => {
+    const now = Date.now();
+    const recent = (clicksByAction.current.get(actionId) ?? []).filter(
+      (t) => now - t < NUDGE_WINDOW_MS,
+    );
+    recent.push(now);
+    if (recent.length >= NUDGE_THRESHOLD) {
+      toast.info(`Tip: press ${shortcutLabel} instead of clicking`);
+      clicksByAction.current.set(actionId, []);
+    } else {
+      clicksByAction.current.set(actionId, recent);
+    }
+  }, []);
+}


### PR DESCRIPTION
## Summary

Side project per feedback: if a button with an associated keyboard shortcut is clicked repeatedly by mouse in quick succession, show a pop-up telling the user the shortcut they could use instead — rather than staying silent forever.

- New `useShortcutNudge()` hook (`frontend/src/hooks/useShortcutNudge.ts`): call `notify(actionId, shortcutLabel)` from a button's `onClick`. After 3 clicks on the same `actionId` within a 60s window, shows a toast — `Tip: press <shortcut> instead of clicking` — then resets, so it takes a fresh run of clicks to nudge again rather than firing on every subsequent click.
- Only wired into a button's mouse `onClick`, never into the shortcut's own `keydown` handler — using the shortcut is the desired behavior, not something to correct.

**Wired into the two buttons that currently have a keyboard shortcut:**
- `RunControl`'s primary button, only while the split button is in plain "sim" mode. `Ctrl+Enter` (see `useKeyboardShortcuts`) always runs a plain simulation regardless of which mode the split button is currently showing — nudging while in Force Run/Sweep mode would point at a shortcut that doesn't do the same thing a click would.
- `PaneToggle`'s left-sidebar toggle (`Ctrl+B`). The right-sidebar toggle has no keyboard shortcut, so it's left alone (verified in tests).

## Test plan

- [x] `npm run test:unit` — 94 passed (7 new: `useShortcutNudge.test.ts` covers the threshold/window/reset/per-actionId behavior with fake timers; `paneControls.test.tsx` and additions to `RunControl.test.tsx` cover the two wiring sites)
- [x] `npm run type-check` — clean
- [x] `npm run lint` — no new issues (pre-existing baseline unchanged)
- [x] `npm run build` — clean
- [x] Manual verification: ran `boulder --dev` on an isolated port, confirmed live in the browser that clicking "Run Simulation" 3 times shows the "Tip: press Ctrl+Enter instead of clicking" toast, clicking the left-sidebar toggle 3 times shows "Tip: press Ctrl+B instead of clicking", and Force Run mode does not nudge.

Extensive AI use — code & PR fully written by Claude Sonnet 5.
