### PR TITLE
fix: plasma reduced_electric_field bindings actually drive the solve

### DIFF
--- a/boulder/cantera_converter.py
+++ b/boulder/cantera_converter.py
@@ -1364,6 +1364,7 @@ class DualCanteraConverter:
         inlet_states: Dict[str, "ct.Solution"],
         stage_id: str = "",
         stage: Optional[Any] = None,
+        pre_solve_hook: Optional[Callable[["DualCanteraConverter"], None]] = None,
     ) -> Tuple["ct.ReactorNet", Dict[str, "ct.ReactorBase"]]:
         """Build (and solve) a :class:`~cantera.ReactorNet` for one stage.
 
@@ -1387,6 +1388,13 @@ class DualCanteraConverter:
         stage :
             :class:`~boulder.staged_solver.Stage` dataclass; used to set the
             solve directive (``advance_to_steady_state`` vs ``advance``).
+        pre_solve_hook :
+            Optional callback invoked with ``self`` after ``self.reactors``/
+            ``self.connections`` are populated for this stage but *before*
+            the solve dispatch runs. This is the only correct place to wire
+            causal-layer bindings (e.g. ``apply_bindings_block``) — calling
+            them after this method returns means the solve already ran to
+            completion with no schedule callbacks registered.
 
         Returns
         -------
@@ -1617,6 +1625,17 @@ class DualCanteraConverter:
                     exc,
                 )
 
+        # Give the caller a chance to wire causal-layer bindings (Phase B:
+        # signals -> reduced_electric_field/mass_flow_rate/tau_s) now that
+        # self.reactors/self.connections are populated but nothing has been
+        # solved yet. A binding applied *after* this method returns (as when
+        # this was the caller's own responsibility) is applied after the
+        # solve already ran to completion -- e.g. a micro_step plasma pulse
+        # would drive the reaction with reduced_electric_field frozen at
+        # its initial value the entire time, never actually pulsing.
+        if pre_solve_hook is not None:
+            pre_solve_hook(self)
+
         # Dispatch to the right integrator
         kind = str(solver.get("kind", "advance_to_steady_state"))
         if kind == "advance_to_steady_state":
@@ -1698,12 +1717,20 @@ class DualCanteraConverter:
             t = float(solver.get("start", 0.0))
             while t < t_total:
                 t_end = min(t + chunk_dt, t_total)
-                # Fire any schedule callbacks before each chunk
+                # Fire any schedule callbacks before each chunk, then
+                # reinitialize *immediately* -- CVODES caches the RHS's
+                # external parameters (e.g. a plasma's electron energy
+                # distribution) internally and won't notice a callback's
+                # mutation until reinitialize() runs. Reinitializing only
+                # after the advance loop below (the previous order) meant
+                # every chunk's advance() calls integrated with the *stale*
+                # field from before this callback, silently freezing out an
+                # entire pulse's worth of dynamics.
                 self._fire_schedule_callbacks(network, t, t_end, stage_id)
-                while network.time < t_end:
-                    network.advance(network.time + max_dt)
                 if reinit:
                     network.reinitialize()
+                while network.time < t_end:
+                    network.advance(network.time + max_dt)
                 if _scope_recorder is not None:
                     _scope_recorder.record(t_end)
                 t = t_end

--- a/boulder/sim2stone.py
+++ b/boulder/sim2stone.py
@@ -507,6 +507,27 @@ def sim_to_internal_config(
                 except Exception:
                     pass
 
+            # Plasma phases (methane-plasma-pavan-2023.yaml and similar) cannot
+            # honour a `reduced_electric_field` setter once cloned -- Cantera
+            # raises ThermoModelMethodError("This method is invalid for
+            # plasma") on every single write, which the schedule callback
+            # swallows, leaving the pulse frozen at its initial value for the
+            # entire solve. Boulder's own default is clone: true, so a plasma
+            # node must explicitly opt out; every vendored plasma example
+            # (e.g. nanosecond_pulse_discharge.py) already constructs its
+            # reactor with clone=False for exactly this reason.
+            #
+            # `hasattr` can't be used here: reading `reduced_electric_field`
+            # on a phase model that doesn't support it raises
+            # ThermoModelMethodError (a bare Exception subclass, not
+            # AttributeError), which `hasattr` does not swallow -- it would
+            # propagate and abort conversion for every non-plasma reactor.
+            try:
+                phase.reduced_electric_field  # noqa: B018 -- probe, not a no-op
+                props["clone"] = False
+            except ct.ThermoModelMethodError:
+                pass
+
             # Mechanism: node-level override first, then infer from thermo
             if isinstance(mech_override, str) and mech_override:
                 props["mechanism"] = mech_override

--- a/boulder/staged_solver.py
+++ b/boulder/staged_solver.py
@@ -645,6 +645,24 @@ def solve_staged(
         # Merge intra-stage connections with interface MFCs for this stage
         stage_connections = list(stage.intra_connections) + extra_conns
 
+        # Apply causal-layer bindings (Phase B): wire signals to MFCs / reactors.
+        # Must run as a pre_solve_hook -- build_sub_network solves the stage
+        # internally before returning, so applying bindings on its *result*
+        # (as this used to) means e.g. a plasma reduced_electric_field pulse
+        # would drive the whole solve frozen at its initial value, never
+        # actually pulsing.
+        _signals_block = config.get("signals")
+        _bindings_block = config.get("bindings")
+
+        def _apply_stage_bindings(built_converter: DualCanteraConverter) -> None:
+            if not (_signals_block and _bindings_block):
+                return
+            from boulder.bindings import apply_bindings_block
+            from boulder.signals import build_signal_registry
+
+            _signal_registry = build_signal_registry(_signals_block)
+            apply_bindings_block(built_converter, _bindings_block, _signal_registry)
+
         # Build sub-network and solve
         network, stage_reactors = converter.build_sub_network(
             stage_nodes=stage_nodes + extra_nodes,
@@ -653,18 +671,9 @@ def solve_staged(
             inlet_states=inlet_states,
             stage_id=stage.id,
             stage=stage,
+            pre_solve_hook=_apply_stage_bindings,
         )
         trajectory.networks[stage.id] = network
-
-        # Apply causal-layer bindings (Phase B): wire signals to MFCs / reactors.
-        _signals_block = config.get("signals")
-        _bindings_block = config.get("bindings")
-        if _signals_block and _bindings_block:
-            from boulder.bindings import apply_bindings_block
-            from boulder.signals import build_signal_registry
-
-            _signal_registry = build_signal_registry(_signals_block)
-            apply_bindings_block(converter, _bindings_block, _signal_registry)
 
         # Collect SolutionArray in flow order through the stage
         flow_order = _flow_order_within_stage(stage)

--- a/boulder/validation.py
+++ b/boulder/validation.py
@@ -290,6 +290,15 @@ class NormalizedConfigModel(BaseModel):
     #: Staged-solving group definitions.
     #: ``{group_id: {stage_order, mechanism, solve, advance_time}}``
     groups: Optional[Dict[str, Any]] = None
+    #: Phase-B causal layer: named signal sources (``boulder.signals``) and
+    #: their bindings to connection/node targets (``boulder.bindings``).
+    #: Flexible shape (validated by those modules, not here) -- without these
+    #: two fields, every config that round-trips through validate_config()
+    #: (every API-served/preloaded config) silently loses its signals:/
+    #: bindings: blocks, and every MFC/tau_s/reduced_electric_field binding
+    #: stops working with no error at all.
+    signals: Optional[List[Dict[str, Any]]] = None
+    bindings: Optional[List[Dict[str, Any]]] = None
 
     def __init__(self, **data):
         super().__init__(**data)

--- a/tests/test_bindings_runtime.py
+++ b/tests/test_bindings_runtime.py
@@ -5,12 +5,17 @@ Asserts:
   during a Boulder solve (the MFC accepts the signal and the solve completes).
 - A signals+bindings YAML config with an advance_grid solve normalizes and
   builds a working Cantera network.
+- A ``nodes.<id>.reduced_electric_field`` binding (plasma pulse) actually
+  drives the micro_step solve, not just gets registered after the fact.
+- ``validate_config()`` (every API-served/preloaded config goes through this)
+  preserves the top-level ``signals:``/``bindings:`` blocks instead of
+  silently dropping them.
 """
 
 import yaml
 
 from boulder.cantera_converter import DualCanteraConverter
-from boulder.config import normalize_config
+from boulder.config import normalize_config, validate_config
 
 _YAML_MFC_SIGNAL = """
 metadata:
@@ -80,3 +85,122 @@ class TestBindingsRuntime:
         network = converter.build_network(cfg)
         # If we get here without exception, the transient solve ran successfully
         assert network is not None
+
+    def test_validate_config_preserves_signals_and_bindings(self):
+        """validate_config() must not silently drop signals:/bindings:.
+
+        Regression: ``NormalizedConfigModel`` (the Pydantic schema every
+        API-served/preloaded config is round-tripped through via
+        ``validate_config()``) declared no ``signals``/``bindings`` fields at
+        all. Pydantic's default behaviour for undeclared input keys is to
+        drop them on ``.dict()`` -- so a config built directly via
+        ``normalize_config()`` (used by every test in this file, and by
+        ``boulder.cli --headless``) kept its bindings, but the *exact same*
+        config served to the GUI via ``/api/configs/preloaded`` (which calls
+        ``validate_config()``) silently lost them. Every MFC/tau_s/
+        reduced_electric_field binding then registered zero schedule
+        callbacks and the whole causal layer became a no-op -- with no error
+        anywhere, since dropping an unknown key is not a validation failure.
+        """
+        cfg = normalize_config(yaml.safe_load(_YAML_MFC_SIGNAL))
+        assert cfg.get("signals"), "sanity: normalize_config must keep signals"
+        assert cfg.get("bindings"), "sanity: normalize_config must keep bindings"
+
+        validated = validate_config(cfg)
+        assert validated.get("signals"), "validate_config() dropped the signals: block"
+        assert validated.get("bindings"), (
+            "validate_config() dropped the bindings: block"
+        )
+
+
+_YAML_PLASMA_PULSE = """
+metadata:
+  title: nanosecond pulse binding regression
+phases:
+  gas:
+    mechanism: example_data/methane-plasma-pavan-2023.yaml
+settings:
+  solver:
+    kind: micro_step
+    t_total: 9e-08
+    chunk_dt: 1e-09
+    max_dt: 1e-10
+    reinitialize_between_chunks: true
+    atol: 1.0e-15
+    rtol: 1.0e-9
+signals:
+  - id: gaussian_EN
+    Gaussian:
+      peak: 1.8999999999999998e-19
+      center: 2.4e-08
+      fwhm: 7.064460135092848e-09
+bindings:
+  - source: gaussian_EN
+    target: nodes.reactor.reduced_electric_field
+network:
+- id: reactor
+  ConstPressureReactor:
+    volume: 1.0
+    energy: "off"
+    clone: false
+    initial:
+      temperature: 300.0
+      pressure: 101325.0
+      composition: "N2:0.715,O2:0.19,CH4:0.095,e:1e-11"
+"""
+
+
+class TestReducedElectricFieldBindingDrivesMicroStep:
+    def test_pulse_binding_grows_electron_mole_fraction(self):
+        """The Gaussian E/N pulse must actually drive the micro_step solve.
+
+        Regression covering three independent bugs found together, all
+        needed for upstream's nanosecond_pulse_discharge.py to reproduce
+        through Boulder (ground truth: e mole fraction grows from a 1e-11
+        seed to ~3.17e-08):
+
+        1. ``apply_bindings_block`` used to run *after* ``build_sub_network``
+           returned, but ``build_sub_network`` solves the stage internally --
+           so the reduced_electric_field callback was registered only once
+           the solve had already finished. Fixed via ``pre_solve_hook``.
+        2. Boulder defaults every reactor to ``clone: true``; a *cloned*
+           plasma phase raises ``ThermoModelMethodError("This method is
+           invalid for plasma")`` on every ``reduced_electric_field``
+           write, silently swallowed by the callback's broad except. This
+           config sets ``clone: false`` explicitly (matching what
+           sim2stone.py now emits automatically for any node whose phase
+           exposes ``reduced_electric_field``).
+        3. ``network.reinitialize()`` ran *after* each chunk's ``advance()``
+           loop instead of immediately after the field-update callback, so
+           CVODES's cached RHS parameters never saw the new field before
+           integrating through it. Fixed by moving reinitialize() before
+           the advance loop.
+        4. Boulder's default solver tolerances (rtol=1e-6, atol=1e-8) are
+           far too loose for the electron/ion mole fractions this pulse
+           drives (~1e-11 to ~1e-8) -- CVODES treats the entire ionization
+           transient as sub-tolerance noise and never resolves it. This
+           config sets ``atol: 1e-15`` / ``rtol: 1e-9`` (the same knob
+           already used for continuous_reactor.yaml's tolerance issue).
+
+        With any one of these four unfixed, the electron mole fraction
+        stays pinned within noise of its 1e-11 seed for the entire 90 ns
+        pulse instead of growing ~3 orders of magnitude.
+        """
+        cfg = normalize_config(yaml.safe_load(_YAML_PLASMA_PULSE))
+        converter = DualCanteraConverter()
+        converter.build_network(cfg)
+
+        reactor = converter.reactors["reactor"]
+        e_index = reactor.phase.species_index("e")
+        final_e_x = float(reactor.phase.X[e_index])
+
+        # Seed was 1e-11; the real pulse drives it up by ~3 orders of
+        # magnitude (~3.17e-08 against the vendored script). A frozen field
+        # or masked tolerance leaves it within noise of the seed value.
+        assert final_e_x > 1e-10, (
+            f"electron mole fraction only reached {final_e_x:.3e}; the "
+            "reduced_electric_field pulse does not appear to have driven "
+            "the solve (binding applied too late, clone=true breaking the "
+            "setter, reinitialize() ordering, or tolerances masking the "
+            "dynamics)."
+        )


### PR DESCRIPTION
## Summary

Fixes a stack of four independent bugs that together meant a
`nodes.<id>.reduced_electric_field` binding (a plasma E/N pulse) never
actually influenced a `micro_step` solve — all discovered while debugging
why `nanosecond_pulse_discharge.py`'s mole fractions stayed flat when
reproduced through Boulder, instead of showing the several-orders-of-
magnitude ionization growth the vendored upstream script produces.

1. **Binding applied after the solve already ran.** `apply_bindings_block()` used to run *after* `build_sub_network()` returned, but `build_sub_network()` solves the stage internally — so the callback was registered only once the solve had already finished. Fixed via a new `pre_solve_hook` parameter, called after reactors/connections are built but before the solve dispatch runs.
2. **`reinitialize()` ordering.** `network.reinitialize()` ran *after* each `micro_step` chunk's `advance()` loop instead of immediately after the field-update callback, so CVODES's cached RHS parameters never saw the new field before integrating through it.
3. **`clone: true` silently breaks plasma phases.** Boulder defaults every reactor to `clone: true`. A *cloned* plasma phase raises `ThermoModelMethodError("This method is invalid for plasma")` on every `reduced_electric_field` write — silently swallowed by the schedule callback's existing broad except. `sim2stone.py` now detects any phase exposing `reduced_electric_field` and emits `clone: false` automatically (matching what every vendored plasma example already does by hand). Detection needs a `try`/`except` around the read — `hasattr()` doesn't work here since `ThermoModelMethodError` is a bare `Exception` subclass, not `AttributeError`.
4. **The deepest one: `NormalizedConfigModel` silently drops `signals`/`bindings`.** This Pydantic schema — which every API-served/preloaded config is round-tripped through via `validate_config()` — declared no `signals`/`bindings` fields at all, so Pydantic silently dropped both blocks on every validation pass. This means **any** MFC/tau_s/reduced_electric_field binding stopped working the moment a config was served through the GUI, not just this plasma example — with no error anywhere, since dropping an unknown key isn't a validation failure. Direct `normalize_config()` + `build_network()` calls (used by every existing test and by `boulder --headless`) never went through `validate_config()` and so never surfaced this.

## Test plan
- [x] `tests/test_bindings_runtime.py` (extended): a regression test builds the exact plasma-pulse config and asserts the electron mole fraction actually grows ~3 orders of magnitude (not pinned at its seed value), plus a dedicated test asserting `validate_config()` preserves `signals`/`bindings`
- [x] `ruff check` / `ruff format --check` / `mypy` clean
- [x] Full backend suite green in isolation on this branch (683 passed, 1 pre-existing flaky skip, 5 xfailed)
- [x] Live-verified end-to-end in the GUI: `e` mole fraction grows from 1e-11 seed to ~3.16e-08, `O2+` from ~0 to ~1.21e-08, matching the vendored upstream script

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>