### PR TITLE
feat: per-node plot_options species visibility + PropertiesPanel object display fix

### DIFF
--- a/boulder/config.py
+++ b/boulder/config.py
@@ -168,6 +168,7 @@ _NODE_STANDARD_FIELDS: frozenset = frozenset(
         "mechanism",
         "description",
         "label",
+        "plot_options",  # optional per-node species-visibility hints (hide/show_species)
     }
 )
 
@@ -939,6 +940,8 @@ def _process_stage_items(
                     node[fld] = item[fld]
             if "mechanism" in item:
                 node["mechanism"] = item["mechanism"]
+            if "plot_options" in item:
+                node["plot_options"] = item["plot_options"]
             nodes.append(node)
 
         else:
@@ -1292,7 +1295,14 @@ def normalize_config(config: Dict[str, Any], plugins: Any = None) -> Dict[str, A
     if "nodes" in normalized:
         for node in normalized["nodes"]:
             if "type" not in node:
-                standard_fields = {"id", "metadata", "mechanism", "group", "logical"}
+                standard_fields = {
+                    "id",
+                    "metadata",
+                    "mechanism",
+                    "group",
+                    "logical",
+                    "plot_options",
+                }
                 type_keys = [k for k in node.keys() if k not in standard_fields]
 
                 if type_keys:
@@ -1309,6 +1319,13 @@ def normalize_config(config: Dict[str, Any], plugins: Any = None) -> Dict[str, A
                 props = node.setdefault("properties", {})
                 if "mechanism" not in props:
                     props["mechanism"] = node["mechanism"]
+            # Same for `plot_options:` -- optional per-node species-visibility
+            # hints for the frontend's Mole/Mass fraction charts
+            # (hide_species/show_species).
+            if "plot_options" in node:
+                props = node.setdefault("properties", {})
+                if "plot_options" not in props:
+                    props["plot_options"] = node["plot_options"]
 
     # Normalize connections — ensure every connection has type/properties keys.
     if "connections" in normalized:

--- a/frontend/src/components/panels/PropertiesPanel.test.tsx
+++ b/frontend/src/components/panels/PropertiesPanel.test.tsx
@@ -19,6 +19,8 @@ vi.mock("sonner", () => ({
 
 const mockRemoveNode = vi.fn();
 const mockRemoveConnection = vi.fn();
+const mockUpdateNode = vi.fn();
+const mockUpdateConnection = vi.fn();
 const mockClearSelection = vi.fn();
 let mockSelectedElement: {
   type: "node" | "edge";
@@ -59,8 +61,8 @@ vi.mock("@/stores/configStore", () => ({
   useConfigStore: (selector: (s: unknown) => unknown) => {
     const store = {
       config: mockConfig,
-      updateNode: vi.fn(),
-      updateConnection: vi.fn(),
+      updateNode: mockUpdateNode,
+      updateConnection: mockUpdateConnection,
       removeNode: mockRemoveNode,
       removeConnection: mockRemoveConnection,
     };
@@ -251,5 +253,83 @@ describe("PropertiesPanel edit-on-double-click", () => {
     expect(screen.getByRole("button", { name: "Edit" })).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Save" })).not.toBeInTheDocument();
     expect(screen.getByText("1000.00 °C")).toBeInTheDocument();
+  });
+});
+
+describe("PropertiesPanel object-valued properties", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockInitialConditionsEditNonce = 0;
+    mockSelectedElement = {
+      type: "node",
+      data: { id: "reactor_1", type: "ConstPressureReactor" },
+    };
+    mockConfig = {
+      nodes: [
+        {
+          id: "reactor_1",
+          type: "ConstPressureReactor",
+          properties: {
+            volume: 1.0,
+            // Declared before `initial` so the ordering test below actually
+            // exercises the "move to the end" re-insertion, not just a
+            // dict that already happened to have it last.
+            plot_options: { hide_species: ["N2", "O2"], show_species: ["e", "OH"] },
+            initial: { temperature: 1273.15, pressure: 101325.0 },
+          },
+        },
+      ],
+      connections: [],
+    };
+  });
+
+  it("renders an object-valued property as JSON text, not [object Object]", () => {
+    render(<PropertiesPanel />);
+
+    expect(
+      screen.getByText('{"hide_species":["N2","O2"],"show_species":["e","OH"]}'),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("[object Object]")).not.toBeInTheDocument();
+  });
+
+  it("shows JSON text (not [object Object]) in the edit-mode input", () => {
+    render(<PropertiesPanel />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+
+    expect(
+      screen.getByDisplayValue('{"hide_species":["N2","O2"],"show_species":["e","OH"]}'),
+    ).toBeInTheDocument();
+  });
+
+  it("round-trips the object back through Save without corrupting it to a string", () => {
+    render(<PropertiesPanel />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(mockUpdateNode).toHaveBeenCalledWith(
+      "reactor_1",
+      expect.objectContaining({
+        properties: expect.objectContaining({
+          plot_options: { hide_species: ["N2", "O2"], show_species: ["e", "OH"] },
+        }),
+      }),
+    );
+  });
+
+  it("renders plot_options last, after unfolded initial-condition fields", () => {
+    render(<PropertiesPanel />);
+
+    const labels = screen
+      .getAllByText(/^(volume|plot_options|temperature|pressure)/i)
+      .map((el) => el.textContent);
+    const plotIndex = labels.findIndex((t) => /^plot_options/i.test(t ?? ""));
+    const temperatureIndex = labels.findIndex((t) => /^temperature/i.test(t ?? ""));
+    const pressureIndex = labels.findIndex((t) => /^pressure/i.test(t ?? ""));
+
+    expect(plotIndex).toBeGreaterThan(-1);
+    expect(plotIndex).toBeGreaterThan(temperatureIndex);
+    expect(plotIndex).toBeGreaterThan(pressureIndex);
   });
 });

--- a/frontend/src/components/panels/PropertiesPanel.tsx
+++ b/frontend/src/components/panels/PropertiesPanel.tsx
@@ -19,6 +19,11 @@ function getSoleGroup(config: NormalizedConfig): string | undefined {
   return groups.size === 1 ? [...groups][0] : undefined;
 }
 
+// Display-order keys that should always render last, regardless of where
+// they land in the underlying properties dict (e.g. `plot_options` is
+// metadata about *how* to chart the node, not a physical initial condition).
+const _TRAILING_DISPLAY_KEYS = ["plot_options"];
+
 function unfoldInitialConditions(
   properties: Record<string, unknown>,
 ): Record<string, unknown> {
@@ -32,6 +37,15 @@ function unfoldInitialConditions(
       }
     }
   }
+  // Re-insert trailing keys last -- deleting and re-adding moves a key to the
+  // end of a plain object's insertion-order iteration.
+  for (const key of _TRAILING_DISPLAY_KEYS) {
+    if (key in flat) {
+      const value = flat[key];
+      delete flat[key];
+      flat[key] = value;
+    }
+  }
   return flat;
 }
 
@@ -42,6 +56,11 @@ function buildEditValuesFromProperties(
   for (const [key, value] of Object.entries(displayProperties)) {
     if (key === "temperature" && typeof value === "number") {
       vals[key] = String(kelvinToCelsius(value).toFixed(2));
+    } else if (typeof value === "object" && value !== null) {
+      // Object-valued properties (e.g. a node's `plot: {hide_species, show_species}`
+      // hints) must be JSON-stringified same as the display-mode span below --
+      // plain `String(value)` on an object yields the useless "[object Object]".
+      vals[key] = JSON.stringify(value);
     } else {
       vals[key] = String(value ?? "");
     }
@@ -196,8 +215,18 @@ export function PropertiesPanel() {
   const handleSave = () => {
     const updated: Record<string, unknown> = {};
     for (const [key, val] of Object.entries(editValues)) {
+      const original = properties[key];
       if (key === "temperature") {
         updated[key] = celsiusToKelvin(parseFloat(val) || 0);
+      } else if (typeof original === "object" && original !== null) {
+        // Object-valued properties round-trip through JSON text in the edit
+        // box (see buildEditValuesFromProperties) -- parse back to an object
+        // rather than saving the raw JSON string over the original value.
+        try {
+          updated[key] = JSON.parse(val);
+        } catch {
+          updated[key] = original;
+        }
       } else {
         const num = parseFloat(val);
         updated[key] = isNaN(num) ? val : num;

--- a/frontend/src/components/results/PlotsTab.test.tsx
+++ b/frontend/src/components/results/PlotsTab.test.tsx
@@ -8,6 +8,7 @@
 import { render } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useConfigStore } from "@/stores/configStore";
 import { useSelectionStore } from "@/stores/selectionStore";
 import type { SimulationProgress } from "@/types/simulation";
 import { PlotsTab } from "./PlotsTab";
@@ -16,6 +17,8 @@ interface PlotTrace {
   mode?: string;
   x?: number[];
   y?: number[];
+  name?: string;
+  visible?: true | "legendonly";
 }
 
 interface PlotProps {
@@ -82,6 +85,7 @@ describe("PlotsTab", () => {
     useSelectionStore.setState({
       selectedElement: { type: "node", data: { id: "steady_reactor" } },
     });
+    useConfigStore.getState().resetConfig();
   });
 
   it("shows markers for single-sample steady-state traces", () => {
@@ -119,5 +123,63 @@ describe("PlotsTab", () => {
       tickformat: ",.0f",
       exponentformat: "none",
     });
+  });
+
+  it("applies per-node plot_options.hide_species/show_species to mole fraction traces", () => {
+    useConfigStore.setState({
+      config: {
+        nodes: [
+          {
+            id: "steady_reactor",
+            type: "IdealGasReactor",
+            properties: {
+              plot_options: {
+                hide_species: ["N2"],
+                show_species: ["trace_radical"],
+              },
+            },
+          },
+        ],
+        connections: [],
+      },
+    });
+
+    const dataWithTrace: SimulationProgress = {
+      is_running: false,
+      is_complete: true,
+      times: [0, 1],
+      reactors_series: {
+        steady_reactor: {
+          T: [1011.31, 1011.31],
+          P: [101325, 101325],
+          X: {
+            O2: [0.2, 0.2],
+            N2: [0.7, 0.7],
+            // Below MAIN_SPECIES_MIN_FRACTION (1e-4) -- only appears because
+            // it's named in show_species.
+            trace_radical: [1e-6, 1e-6],
+          },
+          Y: { O2: [0.23, 0.23], N2: [0.77, 0.77] },
+        },
+      },
+    };
+
+    render(<PlotsTab data={dataWithTrace} />);
+
+    const moleFractionPlot = plotCalls.find((plot) =>
+      plot.data.some((trace) => trace.name === "N2" || trace.name === "trace_radical"),
+    );
+    expect(moleFractionPlot).toBeDefined();
+
+    const n2Trace = moleFractionPlot?.data.find((t) => t.name === "N2");
+    const o2Trace = moleFractionPlot?.data.find((t) => t.name === "O2");
+    const traceRadical = moleFractionPlot?.data.find(
+      (t) => t.name === "trace_radical",
+    );
+
+    expect(n2Trace?.visible).toBe("legendonly");
+    expect(o2Trace?.visible).toBe(true);
+    expect(traceRadical).toBeDefined();
+    expect(traceRadical?.visible).toBe(true);
   });
 });

--- a/frontend/src/components/results/PlotsTab.tsx
+++ b/frontend/src/components/results/PlotsTab.tsx
@@ -1,9 +1,22 @@
 import { useCallback, useMemo, useState } from "react";
 import Plot from "react-plotly.js";
 import { coerceNumericSeries, pressureYAxis } from "@/lib/plotAxis";
+import { useConfigStore } from "@/stores/configStore";
 import { useSelectionStore } from "@/stores/selectionStore";
 import { useThemeStore } from "@/stores/themeStore";
 import type { SimulationProgress } from "@/types/simulation";
+
+interface NodePlotConfig {
+  hideSpecies: Set<string>;
+  showSpecies: string[];
+}
+
+function traceVisibility(
+  species: string,
+  hideSpecies: Set<string>,
+): true | "legendonly" {
+  return hideSpecies.has(species) ? "legendonly" : true;
+}
 
 interface Props {
   data: SimulationProgress;
@@ -16,6 +29,7 @@ function traceModeForSamples(sampleCount: number): "lines" | "lines+markers" {
 export function PlotsTab({ data }: Props) {
   const selectedElement = useSelectionStore((s) => s.selectedElement);
   const theme = useThemeStore((s) => s.theme);
+  const configNodes = useConfigStore((s) => s.config.nodes);
 
   // Shared x-range: zoom/pan on any plot synchronizes all of them
   // (double-click autoscale resets the whole set).
@@ -64,12 +78,32 @@ export function PlotsTab({ data }: Props) {
     ? data.reactors_series[selectedReactorId]
     : undefined;
 
+  // Per-node `plot_options: {hide_species, show_species}` (STONE node
+  // property) lets an example author hide dominant/uninteresting species
+  // (e.g. N2, O2) and force minor-but-relevant ones (e.g. reaction
+  // intermediates that never crack the top-12-by-magnitude heuristic below)
+  // into the chart by default -- the user can still click a hidden trace's
+  // legend entry to reveal it.
+  const plotConfig: NodePlotConfig = useMemo(() => {
+    const node = selectedReactorId
+      ? configNodes.find((n) => n.id === selectedReactorId)
+      : undefined;
+    const raw = (node?.properties?.plot_options ?? {}) as {
+      hide_species?: string[];
+      show_species?: string[];
+    };
+    return {
+      hideSpecies: new Set(raw.hide_species ?? []),
+      showSpecies: raw.show_species ?? [],
+    };
+  }, [configNodes, selectedReactorId]);
+
   const MAIN_SPECIES_MIN_FRACTION = 1e-4;
   const MAIN_SPECIES_MAX_COUNT = 12;
 
   const mainSpeciesMole = useMemo(() => {
     const X = reactorSeries?.X ?? {};
-    return Object.entries(X)
+    const ranked = Object.entries(X)
       .map(([name, arr]) => ({
         name,
         max: Math.max(...(arr ?? []), 0),
@@ -78,11 +112,15 @@ export function PlotsTab({ data }: Props) {
       .sort((a, b) => b.max - a.max)
       .slice(0, MAIN_SPECIES_MAX_COUNT)
       .map((s) => s.name);
-  }, [reactorSeries?.X]);
+    const forced = plotConfig.showSpecies.filter(
+      (name) => name in X && !ranked.includes(name),
+    );
+    return [...ranked, ...forced];
+  }, [reactorSeries?.X, plotConfig.showSpecies]);
 
   const mainSpeciesMass = useMemo(() => {
     const Y = reactorSeries?.Y ?? {};
-    return Object.entries(Y)
+    const ranked = Object.entries(Y)
       .map(([name, arr]) => ({
         name,
         max: Math.max(...(arr ?? []), 0),
@@ -91,7 +129,11 @@ export function PlotsTab({ data }: Props) {
       .sort((a, b) => b.max - a.max)
       .slice(0, MAIN_SPECIES_MAX_COUNT)
       .map((s) => s.name);
-  }, [reactorSeries?.Y]);
+    const forced = plotConfig.showSpecies.filter(
+      (name) => name in Y && !ranked.includes(name),
+    );
+    return [...ranked, ...forced];
+  }, [reactorSeries?.Y, plotConfig.showSpecies]);
 
   if (!data.times.length && !reactorSeries?.is_spatial && !reactorSeries?.is_residence) {
     return <p className="text-sm text-muted-foreground">No data yet.</p>;
@@ -124,6 +166,7 @@ export function PlotsTab({ data }: Props) {
       mode: profileTraceMode,
       name: species,
       line: { width: 2 },
+      visible: traceVisibility(species, plotConfig.hideSpecies),
     }));
 
     const massFractionTraces = mainSpeciesMass.map((species) => ({
@@ -133,6 +176,7 @@ export function PlotsTab({ data }: Props) {
       mode: profileTraceMode,
       name: species,
       line: { width: 2 },
+      visible: traceVisibility(species, plotConfig.hideSpecies),
     }));
 
     return (
@@ -353,6 +397,7 @@ export function PlotsTab({ data }: Props) {
     mode: timeTraceMode,
     name: species,
     line: { width: 2 },
+    visible: traceVisibility(species, plotConfig.hideSpecies),
   }));
 
   const massFractionTraces = mainSpeciesMass.map((species) => ({
@@ -362,6 +407,7 @@ export function PlotsTab({ data }: Props) {
     mode: timeTraceMode,
     name: species,
     line: { width: 2 },
+    visible: traceVisibility(species, plotConfig.hideSpecies),
   }));
 
   return (

--- a/tests/test_node_plot_config.py
+++ b/tests/test_node_plot_config.py
@@ -1,0 +1,53 @@
+"""A node-level ``plot_options:`` property (species show/hide hints) survives normalization.
+
+Lets an example author hide dominant/uninteresting species (e.g. N2, O2) and
+force minor-but-relevant ones (reaction intermediates that never crack the
+frontend's top-12-by-magnitude heuristic) into the Mole/Mass fraction charts
+by default. The frontend still lets the user re-click a hidden trace's legend
+entry to reveal it -- this only sets the *initial* visibility.
+"""
+
+from __future__ import annotations
+
+from boulder.config import load_yaml_string_with_comments, normalize_config
+
+_YAML = """
+phases:
+  gas:
+    mechanism: gri30.yaml
+network:
+- id: reactor
+  IdealGasReactor:
+    volume: 1e-3
+    initial:
+      temperature: 900.0
+      pressure: 101325.0
+      composition: CH4:1,O2:2,N2:7.52
+  plot_options:
+    hide_species: [N2, O2]
+    show_species: [CH3, OH]
+"""
+
+
+def test_node_plot_property_survives_normalization() -> None:
+    """A node's ``plot_options:`` block ends up in properties.plot_options after normalization."""
+    normalized = normalize_config(load_yaml_string_with_comments(_YAML))
+    (node,) = [n for n in normalized["nodes"] if n["id"] == "reactor"]
+
+    plot_cfg = node["properties"].get("plot_options")
+    assert plot_cfg is not None
+    assert plot_cfg["hide_species"] == ["N2", "O2"]
+    assert plot_cfg["show_species"] == ["CH3", "OH"]
+
+    # The reactor kind's own properties must be unaffected by the extra key.
+    assert node["properties"]["volume"] == 1e-3
+
+
+def test_node_without_plot_property_has_no_plot_key() -> None:
+    """A node with no ``plot_options:`` block simply has no key -- no default noise."""
+    yaml_str = _YAML.replace(
+        "  plot_options:\n    hide_species: [N2, O2]\n    show_species: [CH3, OH]\n", ""
+    )
+    normalized = normalize_config(load_yaml_string_with_comments(yaml_str))
+    (node,) = [n for n in normalized["nodes"] if n["id"] == "reactor"]
+    assert "plot_options" not in node["properties"]


### PR DESCRIPTION
## Summary
- Adds a `plot_options: {hide_species, show_species}` STONE node property so example authors can set default Plotly legend visibility per species (still click-to-toggle in the UI), and force minor-but-relevant species into the chart that would otherwise never clear the top-12-by-magnitude heuristic.
- Fixes `PropertiesPanel` rendering object-valued properties (e.g. `plot_options`) as `[object Object]` in both view and edit mode — now shows/edits readable JSON, and round-trips edits back through `JSON.parse` instead of corrupting the object into a raw string.
- Ensures `plot_options` always displays last in the properties list regardless of the underlying dict's key order.

## Test plan
- [x] `pytest tests/test_node_plot_config.py tests/test_bindings_runtime.py` — 4 passed
- [x] Full backend suite: `pytest` — 686 passed, 1 skipped, 5 xfailed
- [x] `vitest run src/components/panels/PropertiesPanel.test.tsx src/components/results/PlotsTab.test.tsx` — 16 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)