### PR TITLE
feat: multi-species y-axis picker for sweep results plot

### DIFF
--- a/frontend/src/components/panels/SweepResultsPlot.test.tsx
+++ b/frontend/src/components/panels/SweepResultsPlot.test.tsx
@@ -1,0 +1,157 @@
+/**
+ * Vitest unit tests for SweepResultsPlot.
+ *
+ * Asserts:
+ * - Default render bundles the mole-fraction family as separate traces (legacy behavior).
+ * - The "Add series" dropdown lists individual species plus a "quick add" family shortcut,
+ *   and only offers series that aren't already active.
+ * - Picking an individual species from the dropdown adds it as its own active chip/trace.
+ * - Clicking a chip's remove ("x") button drops that series without touching the others.
+ * - A user can build an arbitrary combination (e.g. nC7H16 + CO + O2) one at a time,
+ *   matching Cantera's continuous_reactor.py-style plot.
+ * - Removing every active series still renders the picker (doesn't unmount the panel).
+ */
+
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ScenarioMeta } from "@/api/scenarios";
+import { SweepResultsPlot } from "./SweepResultsPlot";
+
+interface PlotTrace {
+  name?: string;
+  x?: number[];
+  y?: (number | null)[];
+}
+
+interface PlotProps {
+  data: PlotTrace[];
+  layout?: {
+    yaxis?: { title?: { text?: string } };
+  };
+}
+
+const plotCalls = vi.hoisted(() => [] as PlotProps[]);
+
+vi.mock("react-plotly.js", () => ({
+  default: (props: PlotProps) => {
+    plotCalls.push(props);
+    return <div data-testid="plot" />;
+  },
+}));
+
+vi.mock("@/stores/themeStore", () => ({
+  useThemeStore: (selector: (state: { theme: "light" }) => unknown) =>
+    selector({ theme: "light" }),
+}));
+
+function makeScenario(t0_K: number, X: Record<string, number>): ScenarioMeta {
+  const scenario: ScenarioMeta = { id: `s-${t0_K}`, t0_K, label: `${t0_K} K` };
+  for (const [species, value] of Object.entries(X)) {
+    scenario[`final_X_${species}`] = value;
+  }
+  return scenario;
+}
+
+const scenarios: ScenarioMeta[] = [
+  makeScenario(800, { nC7H16: 0.02, CO: 0.01, O2: 0.15 }),
+  makeScenario(900, { nC7H16: 0.01, CO: 0.03, O2: 0.1 }),
+  makeScenario(1000, { nC7H16: 0.0, CO: 0.02, O2: 0.05 }),
+];
+
+function addSeries(value: string) {
+  fireEvent.change(screen.getByTestId("y-axis-add-select"), { target: { value } });
+}
+
+describe("SweepResultsPlot", () => {
+  beforeEach(() => {
+    plotCalls.length = 0;
+  });
+
+  it("defaults to the mole-fraction family as separate traces", () => {
+    render(<SweepResultsPlot scenarios={scenarios} />);
+
+    const names = plotCalls.at(-1)?.data.map((t) => t.name);
+    expect(names).toEqual(expect.arrayContaining(["nC7H16", "CO", "O2"]));
+    expect(
+      screen.getByTestId("active-series-chip-final_X_nC7H16"),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("active-series-chip-final_X_CO")).toBeInTheDocument();
+    expect(screen.getByTestId("active-series-chip-final_X_O2")).toBeInTheDocument();
+  });
+
+  it("offers a quick-add family option and individual species not yet active", () => {
+    render(<SweepResultsPlot scenarios={scenarios} />);
+
+    const select = screen.getByTestId("y-axis-add-select") as HTMLSelectElement;
+    const optionValues = Array.from(select.options).map((o) => o.value);
+    // The family (mole fractions) is already fully active by default, so it
+    // should not be offered again, and none of its species should be listed
+    // as addable individually either.
+    expect(optionValues).not.toContain("f:mole_fractions");
+    expect(optionValues).not.toContain("k:final_X_CO");
+  });
+
+  it("removing a chip re-offers that species in the add dropdown", () => {
+    render(<SweepResultsPlot scenarios={scenarios} />);
+
+    fireEvent.click(screen.getByTestId("remove-series-final_X_CO"));
+
+    expect(screen.queryByTestId("active-series-chip-final_X_CO")).not.toBeInTheDocument();
+    expect(screen.getByTestId("active-series-chip-final_X_nC7H16")).toBeInTheDocument();
+    expect(screen.getByTestId("active-series-chip-final_X_O2")).toBeInTheDocument();
+
+    const select = screen.getByTestId("y-axis-add-select") as HTMLSelectElement;
+    const optionValues = Array.from(select.options).map((o) => o.value);
+    expect(optionValues).toContain("k:final_X_CO");
+
+    const names = plotCalls.at(-1)?.data.map((t) => t.name);
+    expect(names).toEqual(expect.arrayContaining(["nC7H16", "O2"]));
+    expect(names).toHaveLength(2);
+  });
+
+  it("lets a user build a custom combination of individual species one at a time", () => {
+    render(<SweepResultsPlot scenarios={scenarios} />);
+
+    // Start from scratch: drop the default family bundle.
+    fireEvent.click(screen.getByTestId("remove-series-final_X_nC7H16"));
+    fireEvent.click(screen.getByTestId("remove-series-final_X_CO"));
+    fireEvent.click(screen.getByTestId("remove-series-final_X_O2"));
+    expect(screen.queryByTestId(/^active-series-chip-/)).not.toBeInTheDocument();
+
+    // Add back exactly nC7H16, CO, and O2 individually, matching
+    // Cantera's continuous_reactor.py combination.
+    addSeries("k:final_X_nC7H16");
+    addSeries("k:final_X_CO");
+    addSeries("k:final_X_O2");
+
+    expect(screen.getByTestId("active-series-chip-final_X_nC7H16")).toBeInTheDocument();
+    expect(screen.getByTestId("active-series-chip-final_X_CO")).toBeInTheDocument();
+    expect(screen.getByTestId("active-series-chip-final_X_O2")).toBeInTheDocument();
+
+    const names = plotCalls.at(-1)?.data.map((t) => t.name);
+    expect(names).toEqual(["nC7H16", "CO", "O2"]);
+  });
+
+  it("adding the quick-add family option bundles every species in one click", () => {
+    render(<SweepResultsPlot scenarios={scenarios} />);
+    fireEvent.click(screen.getByTestId("remove-series-final_X_nC7H16"));
+    fireEvent.click(screen.getByTestId("remove-series-final_X_CO"));
+    fireEvent.click(screen.getByTestId("remove-series-final_X_O2"));
+
+    addSeries("f:mole_fractions");
+
+    const names = plotCalls.at(-1)?.data.map((t) => t.name);
+    expect(names).toEqual(expect.arrayContaining(["nC7H16", "CO", "O2"]));
+  });
+
+  it("still renders the picker after removing every active series", () => {
+    render(<SweepResultsPlot scenarios={scenarios} />);
+    fireEvent.click(screen.getByTestId("remove-series-final_X_nC7H16"));
+    fireEvent.click(screen.getByTestId("remove-series-final_X_CO"));
+    fireEvent.click(screen.getByTestId("remove-series-final_X_O2"));
+
+    expect(screen.getByTestId("y-axis-add-select")).toBeInTheDocument();
+    expect(plotCalls.at(-1)?.data).toEqual([]);
+  });
+});

--- a/frontend/src/components/panels/SweepResultsPlot.tsx
+++ b/frontend/src/components/panels/SweepResultsPlot.tsx
@@ -3,6 +3,8 @@ import Plot from "react-plotly.js";
 import { useThemeStore } from "@/stores/themeStore";
 import type { ScenarioMeta } from "@/api/scenarios";
 
+// TODO: overlay experimental/reference data points on this chart (planned future enhancement).
+
 interface Props {
   scenarios: ScenarioMeta[];
 }
@@ -12,6 +14,19 @@ interface YGroup {
   label: string;
   /** Attr keys plotted together as separate traces under this Y choice. */
   keys: { key: string; traceName: string }[];
+}
+
+/** A single addable Y-axis series, e.g. one species' mole fraction. */
+interface SeriesOption {
+  key: string;
+  label: string;
+}
+
+/** A "quick add" shortcut that adds every key of a multi-species group at once. */
+interface SeriesFamily {
+  id: string;
+  label: string;
+  keys: string[];
 }
 
 /** Bookkeeping attrs every scenario carries that are never plot axis candidates. */
@@ -73,6 +88,35 @@ function buildYGroups(keys: string[], xKey: string): YGroup[] {
   return groups;
 }
 
+/** Flatten Y groups into individually-selectable series plus "add whole family"
+ * shortcuts for any group (e.g. Mole Fractions) that bundles more than one
+ * species, so a user can either build up a custom combination of species one
+ * at a time or add a whole family in one click. */
+function buildSeriesOptions(groups: YGroup[]): {
+  options: SeriesOption[];
+  families: SeriesFamily[];
+  labelByKey: Map<string, string>;
+  groupLabelByKey: Map<string, string>;
+} {
+  const options: SeriesOption[] = [];
+  const families: SeriesFamily[] = [];
+  const labelByKey = new Map<string, string>();
+  const groupLabelByKey = new Map<string, string>();
+
+  for (const group of groups) {
+    if (group.keys.length > 1) {
+      families.push({ id: group.id, label: `${group.label} (all)`, keys: group.keys.map((k) => k.key) });
+    }
+    for (const { key, traceName } of group.keys) {
+      options.push({ key, label: traceName });
+      labelByKey.set(key, traceName);
+      groupLabelByKey.set(key, group.label);
+    }
+  }
+
+  return { options, families, labelByKey, groupLabelByKey };
+}
+
 /**
  * Sweep-results chart: pick an X axis (the swept parameter, e.g. temperature)
  * and a Y axis (a KPI or KPI family, e.g. mole fractions) and plot every
@@ -90,31 +134,71 @@ export function SweepResultsPlot({ scenarios }: Props) {
 
   const keys = useMemo(() => numericKeys(scenarios), [scenarios]);
   const [xKey, setXKey] = useState<string | null>(null);
-  const [yGroupId, setYGroupId] = useState<string | null>(null);
+  /** Individually-selected Y-axis series keys. `null` means the user hasn't
+   * touched the picker yet, so a sensible default (the first family, or the
+   * first available series) is used instead. */
+  const [activeKeys, setActiveKeys] = useState<string[] | null>(null);
 
   const effectiveXKey = xKey && keys.includes(xKey) ? xKey : (keys.includes("t0_K") ? "t0_K" : keys[0]);
   const yGroups = useMemo(
     () => (effectiveXKey ? buildYGroups(keys, effectiveXKey) : []),
     [keys, effectiveXKey],
   );
-  const effectiveYGroup =
-    yGroups.find((g) => g.id === yGroupId) ?? yGroups[0] ?? null;
+  const { options, families, labelByKey, groupLabelByKey } = useMemo(
+    () => buildSeriesOptions(yGroups),
+    [yGroups],
+  );
+
+  const validKeys = useMemo(() => new Set(options.map((o) => o.key)), [options]);
+  const effectiveActiveKeys = useMemo(() => {
+    if (activeKeys !== null) return activeKeys.filter((k) => validKeys.has(k));
+    if (families.length > 0) return families[0].keys;
+    if (options.length > 0) return [options[0].key];
+    return [];
+  }, [activeKeys, validKeys, families, options]);
+
+  const addKey = (key: string) => {
+    if (effectiveActiveKeys.includes(key)) return;
+    setActiveKeys([...effectiveActiveKeys, key]);
+  };
+  const addFamily = (familyId: string) => {
+    const family = families.find((f) => f.id === familyId);
+    if (!family) return;
+    const merged = [...effectiveActiveKeys];
+    for (const key of family.keys) {
+      if (!merged.includes(key)) merged.push(key);
+    }
+    setActiveKeys(merged);
+  };
+  const removeKey = (key: string) => {
+    setActiveKeys(effectiveActiveKeys.filter((k) => k !== key));
+  };
+
+  const availableFamilies = families.filter(
+    (f) => !f.keys.every((k) => effectiveActiveKeys.includes(k)),
+  );
+  const availableOptions = options.filter((o) => !effectiveActiveKeys.includes(o.key));
+
+  const yAxisTitle = (() => {
+    const labels = new Set(effectiveActiveKeys.map((k) => groupLabelByKey.get(k) ?? k));
+    return labels.size === 1 ? [...labels][0] : "Value";
+  })();
 
   const { xValues, series } = useMemo(() => {
-    if (!effectiveXKey || !effectiveYGroup) return { xValues: [], series: [] };
+    if (!effectiveXKey) return { xValues: [], series: [] };
     const withX = scenarios.filter((s) => typeof s[effectiveXKey] === "number");
     const sorted = [...withX].sort(
       (a, b) => (a[effectiveXKey] as number) - (b[effectiveXKey] as number),
     );
     const x = sorted.map((s) => s[effectiveXKey] as number);
-    const traces = effectiveYGroup.keys.map(({ key, traceName }) => ({
-      name: traceName,
+    const traces = effectiveActiveKeys.map((key) => ({
+      name: labelByKey.get(key) ?? key,
       y: sorted.map((s) => (s[key] as number | undefined) ?? null),
     }));
     return { xValues: x, series: traces };
-  }, [scenarios, effectiveXKey, effectiveYGroup]);
+  }, [scenarios, effectiveXKey, effectiveActiveKeys, labelByKey]);
 
-  if (keys.length < 2 || !effectiveXKey || !effectiveYGroup || xValues.length === 0) {
+  if (keys.length < 2 || !effectiveXKey || options.length === 0 || xValues.length === 0) {
     return null;
   }
 
@@ -139,20 +223,68 @@ export function SweepResultsPlot({ scenarios }: Props) {
             ))}
           </select>
         </label>
-        <label className="flex items-center gap-1.5 text-[10px] text-muted-foreground">
-          Y axis
-          <select
-            className={`${selectClass} flex-1`}
-            value={effectiveYGroup.id}
-            onChange={(e) => setYGroupId(e.target.value)}
-          >
-            {yGroups.map((g) => (
-              <option key={g.id} value={g.id}>
-                {g.label}
-              </option>
-            ))}
-          </select>
-        </label>
+        <div className="flex flex-col gap-1 text-[10px] text-muted-foreground">
+          <div className="flex items-center gap-1.5">
+            <span className="shrink-0">Y axis</span>
+            <select
+              className={`${selectClass} flex-1`}
+              value=""
+              disabled={availableFamilies.length === 0 && availableOptions.length === 0}
+              data-testid="y-axis-add-select"
+              onChange={(e) => {
+                const value = e.target.value;
+                if (!value) return;
+                if (value.startsWith("f:")) addFamily(value.slice(2));
+                else if (value.startsWith("k:")) addKey(value.slice(2));
+              }}
+            >
+              <option value="">+ Add series…</option>
+              {availableFamilies.length > 0 && (
+                <optgroup label="Quick add">
+                  {availableFamilies.map((f) => (
+                    <option key={f.id} value={`f:${f.id}`}>
+                      {f.label}
+                    </option>
+                  ))}
+                </optgroup>
+              )}
+              {availableOptions.length > 0 && (
+                <optgroup label="Individual series">
+                  {availableOptions.map((o) => (
+                    <option key={o.key} value={`k:${o.key}`}>
+                      {o.label}
+                    </option>
+                  ))}
+                </optgroup>
+              )}
+            </select>
+          </div>
+          {effectiveActiveKeys.length > 0 && (
+            <div className="flex flex-wrap gap-1">
+              {effectiveActiveKeys.map((key) => {
+                const label = labelByKey.get(key) ?? key;
+                return (
+                  <span
+                    key={key}
+                    data-testid={`active-series-chip-${key}`}
+                    className="inline-flex items-center gap-1 rounded-full border border-border bg-muted px-2 py-0.5 text-[10px] text-foreground"
+                  >
+                    {label}
+                    <button
+                      type="button"
+                      onClick={() => removeKey(key)}
+                      aria-label={`Remove ${label}`}
+                      data-testid={`remove-series-${key}`}
+                      className="leading-none text-muted-foreground hover:text-foreground"
+                    >
+                      ×
+                    </button>
+                  </span>
+                );
+              })}
+            </div>
+          )}
+        </div>
       </div>
       <Plot
         data={series.map((s) => ({
@@ -175,7 +307,7 @@ export function SweepResultsPlot({ scenarios }: Props) {
             gridcolor: theme === "dark" ? "#333" : "#e0e0e0",
           },
           yaxis: {
-            title: { text: effectiveYGroup.label },
+            title: { text: yAxisTitle },
             gridcolor: theme === "dark" ? "#333" : "#e0e0e0",
           },
         }}


### PR DESCRIPTION
## Summary
- Replaces the single-`yGroupId` select in `SweepResultsPlot` with a chip-based add/remove picker, so multiple species/series can be overlaid on the sweep plot simultaneously (e.g. comparing CH4/CO/O2 conversion together) instead of switching one at a time.

## Test plan
- [x] `vitest run src/components/panels/SweepResultsPlot.test.tsx` — 6 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)