### PR TITLE
Add 'Regenerate cache' action and purge cache on scenario delete

### DIFF
--- a/boulder/api/routes/scenarios.py
+++ b/boulder/api/routes/scenarios.py
@@ -39,6 +39,27 @@ def _store_path(request: Request) -> Optional[Path]:
     return Path(raw) if raw else None
 
 
+def _purge_cached_group(store: Optional[Path], scenario_id: str) -> bool:
+    """Remove *scenario_id*'s cached trajectory from the store, if present.
+
+    Best-effort: the scenario's *definition* is already deleted by the caller
+    by the time this runs, so a missing/unreadable store is not an error here
+    — there is just nothing left to purge. Returns whether a group was
+    actually removed (surfaced to the frontend so "Delete" can honestly say
+    whether it also cleared a cached result).
+    """
+    if h5py is None or store is None or not store.is_file():
+        return False
+    try:
+        with h5py.File(str(store), "a") as handle:
+            if scenario_id in handle:
+                del handle[scenario_id]
+                return True
+    except OSError:
+        return False
+    return False
+
+
 def _to_py(value: Any) -> Any:
     if isinstance(value, bytes):
         return value.decode("utf-8", "replace")
@@ -257,7 +278,14 @@ async def rename_scenario(
 
 @router.delete("/{scenario_id}")
 async def delete_scenario(scenario_id: str, request: Request) -> Dict[str, Any]:
-    """Delete a scenario overlay. The next Run Sweep prunes its stale HDF5 group."""
+    """Delete a scenario overlay and purge its cached trajectory, if any.
+
+    Both happen immediately: the definition is removed from the config's
+    ``scenario:`` mapping, and the matching HDF5 group (if the active store
+    has one) is deleted right away — not left for the next Run Sweep to
+    notice and prune. ``cache_purged`` in the response tells the caller
+    whether there was actually a cached result to clear.
+    """
     cfg_path = _require_config_path(request)
     try:
         from ...scenario_editor import ScenarioEditError
@@ -266,8 +294,9 @@ async def delete_scenario(scenario_id: str, request: Request) -> Dict[str, Any]:
         _delete(cfg_path, scenario_id)
     except ScenarioEditError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
+    cache_purged = _purge_cached_group(_store_path(request), scenario_id)
     _reload_preloaded_state(request, cfg_path)
-    return {"ok": True, "scenario_id": scenario_id}
+    return {"ok": True, "scenario_id": scenario_id, "cache_purged": cache_purged}
 
 
 # --------------------------------------------------------------------------- #

--- a/boulder/api/routes/sweep.py
+++ b/boulder/api/routes/sweep.py
@@ -23,8 +23,19 @@ from pathlib import Path
 from typing import Any, Dict, Optional
 
 from fastapi import APIRouter, HTTPException, Request
+from pydantic import BaseModel
 
 router = APIRouter()
+
+
+class SweepRunRequest(BaseModel):
+    """Body for ``POST /run``. Defaults match the plain "Run Sweep" click."""
+
+    #: "Regenerate cache" — set BOULDER_NO_CACHE=1 for the subprocess so a
+    #: cache-aware runner (e.g. bloc.scenario_sweep) discards its collection
+    #: store and re-solves every scenario instead of skipping unchanged ones.
+    no_cache: bool = False
+
 
 _SCENARIO_RE = re.compile(r"scenario\s+(\d+)\s*/\s*(\d+)", re.IGNORECASE)
 _RUNNER_NAME = "run_sweep.py"
@@ -193,8 +204,13 @@ async def sweep_info(request: Request) -> Dict[str, Any]:
 
 
 @router.post("/run")
-async def sweep_run(request: Request) -> Dict[str, Any]:
-    """Start the run-set subprocess for the preloaded config."""
+async def sweep_run(
+    request: Request, body: SweepRunRequest = SweepRunRequest()
+) -> Dict[str, Any]:
+    """Start the run-set subprocess for the preloaded config.
+
+    ``no_cache=true`` is the Scenario Pane's "Regenerate cache" action.
+    """
     cmd = _runner_command(request)
     if not _has_run_set(request) or cmd is None:
         raise HTTPException(
@@ -220,10 +236,17 @@ async def sweep_run(request: Request) -> Dict[str, Any]:
     }
     request.app.state.sweep_job = state
     # Surface on the server console by default — at least that the run started.
-    print(f"[sweep] starting {total} run(s): {' '.join(cmd['argv'])}", flush=True)
+    cache_note = " (no-cache: re-solving everything)" if body.no_cache else ""
+    print(
+        f"[sweep] starting {total} run(s){cache_note}: {' '.join(cmd['argv'])}",
+        flush=True,
+    )
 
     def _worker() -> None:
         try:
+            env = os.environ.copy()
+            if body.no_cache:
+                env["BOULDER_NO_CACHE"] = "1"
             proc = subprocess.Popen(
                 cmd["argv"],
                 cwd=cmd["cwd"],
@@ -231,7 +254,7 @@ async def sweep_run(request: Request) -> Dict[str, Any]:
                 stderr=subprocess.STDOUT,
                 text=True,
                 bufsize=1,
-                env=os.environ.copy(),
+                env=env,
             )
             tail: list[str] = []
             assert proc.stdout is not None

--- a/frontend/src/api/scenarios.ts
+++ b/frontend/src/api/scenarios.ts
@@ -103,9 +103,13 @@ export function renameScenario(id: string, newId: string) {
   );
 }
 
-/** Delete a scenario overlay. The next Run Sweep prunes its stale HDF5 group. */
+/**
+ * Delete a scenario overlay. Also purges its cached HDF5 group immediately,
+ * if the active store has one — `cache_purged` reports whether there was
+ * actually a cached result to clear.
+ */
 export function deleteScenario(id: string) {
-  return apiFetch<{ ok: boolean; scenario_id: string }>(
+  return apiFetch<{ ok: boolean; scenario_id: string; cache_purged: boolean }>(
     `/scenarios/${encodeURIComponent(id)}`,
     { method: "DELETE" },
   );

--- a/frontend/src/api/sweep.ts
+++ b/frontend/src/api/sweep.ts
@@ -24,11 +24,17 @@ export function getSweepInfo() {
   return apiFetch<SweepInfo>("/sweep");
 }
 
-/** Start the sweep as a background batch job on the server. */
-export function startSweep() {
+/**
+ * Start the sweep as a background batch job on the server.
+ *
+ * `noCache` is the "Regenerate cache" action: the server sets
+ * `BOULDER_NO_CACHE=1` for the runner subprocess, so every scenario is
+ * re-solved instead of skipping ones whose fingerprint is unchanged.
+ */
+export function startSweep(options?: { noCache?: boolean }) {
   return apiFetch<{ status: string; total: number }>("/sweep/run", {
     method: "POST",
-    body: "{}",
+    body: JSON.stringify({ no_cache: options?.noCache ?? false }),
   });
 }
 

--- a/frontend/src/components/panels/RunControl.test.tsx
+++ b/frontend/src/components/panels/RunControl.test.tsx
@@ -2,18 +2,21 @@
  * Asserts RunControl split-button modes: Run Simulation, Force Run, and Run Sweep.
  */
 
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { RunControl } from "./RunControl";
+import { useSweepRunStore } from "@/stores/sweepStore";
 
 const mockGetSweepInfo = vi
   .fn()
   .mockResolvedValue({ can_run: false, reason: "No sweep" });
+const mockStartSweep = vi.fn();
+const mockGetSweepStatus = vi.fn();
 vi.mock("@/api/sweep", () => ({
   getSweepInfo: (...args: unknown[]) => mockGetSweepInfo(...args),
-  getSweepStatus: vi.fn(),
-  startSweep: vi.fn(),
+  getSweepStatus: (...args: unknown[]) => mockGetSweepStatus(...args),
+  startSweep: (...args: unknown[]) => mockStartSweep(...args),
 }));
 
 const mockToastInfo = vi.fn();
@@ -22,10 +25,16 @@ vi.mock("sonner", () => ({
 }));
 
 let mockScenarioRevision = 0;
-vi.mock("@/stores/scenarioStore", () => ({
-  useScenarioStore: (selector: (s: unknown) => unknown) =>
-    selector({ refresh: vi.fn(), revision: mockScenarioRevision }),
-}));
+const mockRefresh = vi.fn();
+vi.mock("@/stores/scenarioStore", () => {
+  // sweepStore (a real module, exercised via useSweepRunStore below) reads
+  // this through the static `.getState()` accessor, not the selector-hook
+  // call form the rest of this test file uses -- both need to work.
+  const hook = (selector: (s: unknown) => unknown) =>
+    selector({ refresh: mockRefresh, revision: mockScenarioRevision });
+  hook.getState = () => ({ refresh: mockRefresh, revision: mockScenarioRevision });
+  return { useScenarioStore: hook };
+});
 
 describe("RunControl", () => {
   const onRunSimulation = vi.fn();
@@ -34,6 +43,11 @@ describe("RunControl", () => {
     vi.clearAllMocks();
     mockGetSweepInfo.mockResolvedValue({ can_run: false, reason: "No sweep" });
     mockScenarioRevision = 0;
+    useSweepRunStore.setState({ sweeping: false, progress: { current: 0, total: 0 } });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it("shows Force Run in the menu and switches the primary label without Ctrl+Enter", () => {
@@ -120,6 +134,35 @@ describe("RunControl", () => {
     fireEvent.click(button);
 
     expect(mockToastInfo).not.toHaveBeenCalled();
+  });
+
+  it("clicking Run Sweep starts a sweep via the shared sweep-run store", async () => {
+    mockGetSweepInfo.mockResolvedValue({
+      can_run: true,
+      n_scenarios: 2,
+      reason: "Run 2 scenarios",
+    });
+    render(
+      <RunControl onRunSimulation={onRunSimulation} isRunning={false} runDisabled={false} />,
+    );
+    await waitFor(() => expect(mockGetSweepInfo).toHaveBeenCalled());
+
+    fireEvent.click(screen.getByLabelText("Choose run action"));
+    fireEvent.click(screen.getByRole("menuitemradio", { name: /run sweep/i }));
+
+    vi.useFakeTimers();
+    try {
+      mockStartSweep.mockResolvedValue({ status: "running", total: 2 });
+      mockGetSweepStatus.mockResolvedValueOnce({ status: "done", current: 2, total: 2 });
+
+      fireEvent.click(screen.getByRole("button", { name: /run sweep/i }));
+
+      expect(mockStartSweep).toHaveBeenCalledWith({ noCache: undefined });
+      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(1000);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("re-fetches sweep info when a scenario is added/edited/renamed/deleted elsewhere", async () => {

--- a/frontend/src/components/panels/RunControl.tsx
+++ b/frontend/src/components/panels/RunControl.tsx
@@ -1,9 +1,10 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import { Check, ChevronDown, Plus } from "lucide-react";
-import { toast } from "sonner";
 import { Button } from "@/components/ui/Button";
-import { getSweepInfo, getSweepStatus, startSweep, type SweepInfo } from "@/api/sweep";
+import { getSweepInfo, type SweepInfo } from "@/api/sweep";
 import { useScenarioStore } from "@/stores/scenarioStore";
+import { useSweepRunStore } from "@/stores/sweepStore";
 import { useShortcutNudge } from "@/hooks/useShortcutNudge";
 import { AddScenarioModal } from "@/components/modals/AddScenarioModal";
 import { ScenarioYamlEditorModal } from "@/components/modals/ScenarioYamlEditorModal";
@@ -26,13 +27,15 @@ interface RunControlProps {
 export function RunControl({ onRunSimulation, isRunning, runDisabled }: RunControlProps) {
   const [runMode, setRunMode] = useState<RunMode>("sim");
   const [menuOpen, setMenuOpen] = useState(false);
+  // The menu portals to `document.body` (see below) so the sidebar's
+  // `overflow-y-auto` can't clip it -- position is computed from this
+  // anchor's rect each time the menu opens.
+  const anchorRef = useRef<HTMLDivElement>(null);
+  const [menuPos, setMenuPos] = useState<{ top: number; right: number } | null>(null);
   const [sweep, setSweep] = useState<SweepInfo | null>(null);
-  const [sweeping, setSweeping] = useState(false);
-  const [progress, setProgress] = useState<{ current: number; total: number }>({
-    current: 0,
-    total: 0,
-  });
-  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const sweeping = useSweepRunStore((s) => s.sweeping);
+  const progress = useSweepRunStore((s) => s.progress);
+  const runSweepJob = useSweepRunStore((s) => s.run);
   const appliedDefault = useRef(false);
   const appliedAutorun = useRef(false);
   const refreshScenarios = useScenarioStore((s) => s.refresh);
@@ -61,14 +64,30 @@ export function RunControl({ onRunSimulation, isRunning, runDisabled }: RunContr
     loadSweepInfo();
   }, [loadSweepInfo, scenarioRevision]);
 
-  // Separate from the effect above: only tears down the poll interval on
-  // unmount, not on every scenarioRevision bump (which would otherwise kill
-  // an in-flight sweep's progress polling the moment a scenario changes).
-  useEffect(() => {
-    return () => {
-      if (pollRef.current) clearInterval(pollRef.current);
-    };
+  // Open: compute the menu's viewport position from the anchor now (not on
+  // every render) so it tracks wherever the split button actually is,
+  // including when the sidebar has been scrolled.
+  const openMenu = useCallback(() => {
+    const rect = anchorRef.current?.getBoundingClientRect();
+    if (rect) {
+      setMenuPos({ top: rect.bottom + 4, right: window.innerWidth - rect.right });
+    }
+    setMenuOpen(true);
   }, []);
+
+  // Close (rather than reposition) on scroll/resize elsewhere on the page --
+  // simplest robust fix for the menu drifting from its anchor; reopening
+  // recomputes the position fresh via openMenu above.
+  useEffect(() => {
+    if (!menuOpen) return;
+    const close = () => setMenuOpen(false);
+    window.addEventListener("scroll", close, true);
+    window.addEventListener("resize", close);
+    return () => {
+      window.removeEventListener("scroll", close, true);
+      window.removeEventListener("resize", close);
+    };
+  }, [menuOpen]);
 
   const canSweep = Boolean(sweep?.can_run);
   // If sweep is unavailable, fall back to simulation (force_sim is kept as-is).
@@ -79,39 +98,14 @@ export function RunControl({ onRunSimulation, isRunning, runDisabled }: RunContr
         ? "force_sim"
         : "sim";
 
+  // loadSweepInfo() re-fetches automatically once the sweep finishes: it
+  // depends on scenarioRevision (above), which the shared sweep store bumps
+  // via scenarioStore.refresh() on completion -- no separate wiring needed
+  // here, and it stays in sync even when a sweep is started elsewhere (e.g.
+  // the Scenario Pane's "Regenerate cache").
   const handleRunSweep = useCallback(() => {
-    setSweeping(true);
-    setProgress({ current: 0, total: sweep?.n_scenarios ?? 0 });
-    startSweep()
-      .then(() => {
-        pollRef.current = setInterval(() => {
-          getSweepStatus()
-            .then((st) => {
-              if (st.status === "running") {
-                setProgress({ current: st.current ?? 0, total: st.total ?? 0 });
-              } else {
-                if (pollRef.current) clearInterval(pollRef.current);
-                setSweeping(false);
-                if (st.status === "done") {
-                  toast.success("Sweep complete — scenarios updated");
-                  void refreshScenarios();
-                  loadSweepInfo();
-                } else {
-                  toast.error(`Sweep failed: ${st.message ?? "unknown error"}`);
-                }
-              }
-            })
-            .catch(() => {
-              if (pollRef.current) clearInterval(pollRef.current);
-              setSweeping(false);
-            });
-        }, 1000);
-      })
-      .catch((e) => {
-        setSweeping(false);
-        toast.error(e instanceof Error ? e.message : String(e));
-      });
-  }, [sweep, refreshScenarios, loadSweepInfo]);
+    runSweepJob({ total: sweep?.n_scenarios ?? 0 });
+  }, [runSweepJob, sweep]);
 
   // `--run`: auto-start the run once, as soon as it is actually runnable.
   useEffect(() => {
@@ -169,7 +163,7 @@ export function RunControl({ onRunSimulation, isRunning, runDisabled }: RunContr
   };
 
   return (
-    <div className="relative w-full">
+    <div className="relative w-full" ref={anchorRef}>
       <div className="flex w-full">
         <Button
           id="run-primary"
@@ -182,7 +176,7 @@ export function RunControl({ onRunSimulation, isRunning, runDisabled }: RunContr
         </Button>
         <Button
           id="run-mode-caret"
-          onClick={() => setMenuOpen((o) => !o)}
+          onClick={() => (menuOpen ? setMenuOpen(false) : openMenu())}
           disabled={isRunning || sweeping}
           variant={variant}
           className="rounded-l-none border-l border-black/15 px-2"
@@ -194,12 +188,13 @@ export function RunControl({ onRunSimulation, isRunning, runDisabled }: RunContr
         </Button>
       </div>
 
-      {menuOpen && (
+      {menuOpen && menuPos && createPortal(
         <>
-          <div className="fixed inset-0 z-10" onClick={() => setMenuOpen(false)} />
+          <div className="fixed inset-0 z-40" onClick={() => setMenuOpen(false)} />
           <div
             role="menu"
-            className="absolute right-0 z-20 mt-1 w-72 rounded-md border border-border bg-card shadow-lg overflow-hidden"
+            style={{ position: "fixed", top: menuPos.top, right: menuPos.right }}
+            className="z-[41] w-72 rounded-md border border-border bg-card shadow-lg overflow-hidden"
           >
             <RunModeItem
               active={effectiveMode === "sim"}
@@ -253,7 +248,8 @@ export function RunControl({ onRunSimulation, isRunning, runDisabled }: RunContr
               </span>
             </button>
           </div>
-        </>
+        </>,
+        document.body,
       )}
 
       <AddScenarioModal

--- a/frontend/src/components/panels/ScenarioPane.test.tsx
+++ b/frontend/src/components/panels/ScenarioPane.test.tsx
@@ -1,8 +1,15 @@
 /**
- * Asserts ScenarioPane: the new rename action calls the store's
- * renameScenario, and the previously-missing onSaved wiring (both in the
- * empty "no scenarios yet" state and the populated one) triggers a refresh
- * after editing a scenario's YAML.
+ * Asserts ScenarioPane: deleting a scenario confirms first, then reports
+ * whether a cached result was purged too; "Regenerate cache" confirms, then
+ * starts a no-cache sweep via the shared sweep-run store; and the
+ * previously-missing onSaved wiring (both in the empty "no scenarios yet"
+ * state and the populated one) triggers a refresh after editing a scenario's
+ * YAML.
+ *
+ * No "Rename scenario" action here — a scenario's display name is
+ * `metadata.scenario_name`, already editable via "Edit scenario YAML"; a
+ * separate control that renames the underlying `scenario:` mapping key
+ * would be a second, confusing way to change what looks like the same thing.
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
@@ -12,7 +19,6 @@ import { ScenarioPane } from "./ScenarioPane";
 
 const mockRefresh = vi.fn();
 const mockSetActive = vi.fn();
-const mockRenameScenario = vi.fn();
 const mockDeleteScenario = vi.fn();
 let mockAvailable = true;
 let mockScenarios: Array<{ id: string; label: string; t0_K: number }> = [
@@ -29,9 +35,15 @@ vi.mock("@/stores/scenarioStore", () => ({
     error: null,
     refresh: mockRefresh,
     setActive: mockSetActive,
-    renameScenario: mockRenameScenario,
     deleteScenario: mockDeleteScenario,
   }),
+}));
+
+const mockRunSweepJob = vi.fn();
+let mockSweeping = false;
+vi.mock("@/stores/sweepStore", () => ({
+  useSweepRunStore: (selector: (s: unknown) => unknown) =>
+    selector({ sweeping: mockSweeping, run: mockRunSweepJob }),
 }));
 
 vi.mock("sonner", () => ({
@@ -60,37 +72,63 @@ describe("ScenarioPane", () => {
     capturedOnSaved = undefined;
     mockAvailable = true;
     mockScenarios = [{ id: "A", label: "Scenario A", t0_K: 300 }];
+    mockSweeping = false;
   });
 
-  it("renaming a scenario prompts for a new id and calls renameScenario", () => {
-    const promptSpy = vi.spyOn(window, "prompt").mockReturnValue("A2");
+  it("deleting a scenario confirms first, then calls deleteScenario", () => {
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
+    mockDeleteScenario.mockResolvedValue({ cachePurged: true });
     render(<ScenarioPane />);
 
-    fireEvent.click(screen.getByTitle("Rename scenario"));
+    fireEvent.click(screen.getByTitle("Delete scenario"));
 
-    expect(promptSpy).toHaveBeenCalledWith('Rename scenario "A" to:', "A");
-    expect(mockRenameScenario).toHaveBeenCalledWith("A", "A2");
-    promptSpy.mockRestore();
+    expect(confirmSpy).toHaveBeenCalledWith(
+      'Delete scenario "A"? This also removes its cached trajectory ' +
+        "immediately. This cannot be undone.",
+    );
+    expect(mockDeleteScenario).toHaveBeenCalledWith("A");
+    confirmSpy.mockRestore();
   });
 
-  it("rejects an invalid new id without calling renameScenario", () => {
-    const promptSpy = vi.spyOn(window, "prompt").mockReturnValue("bad id!");
+  it("does nothing when the delete confirmation is dismissed", () => {
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(false);
     render(<ScenarioPane />);
 
-    fireEvent.click(screen.getByTitle("Rename scenario"));
+    fireEvent.click(screen.getByTitle("Delete scenario"));
 
-    expect(mockRenameScenario).not.toHaveBeenCalled();
-    promptSpy.mockRestore();
+    expect(mockDeleteScenario).not.toHaveBeenCalled();
+    confirmSpy.mockRestore();
   });
 
-  it("does nothing when the rename prompt is cancelled or unchanged", () => {
-    const promptSpy = vi.spyOn(window, "prompt").mockReturnValue("A");
+  it("Regenerate cache confirms, then starts a no-cache sweep", () => {
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
     render(<ScenarioPane />);
 
-    fireEvent.click(screen.getByTitle("Rename scenario"));
+    fireEvent.click(screen.getByTitle(/Regenerate cache/));
 
-    expect(mockRenameScenario).not.toHaveBeenCalled();
-    promptSpy.mockRestore();
+    expect(confirmSpy).toHaveBeenCalledWith(
+      "Regenerate the cache? This re-solves every scenario in this sweep " +
+        "from scratch, ignoring cached results. This may take a while.",
+    );
+    expect(mockRunSweepJob).toHaveBeenCalledWith({ total: 1, noCache: true });
+    confirmSpy.mockRestore();
+  });
+
+  it("does nothing when the Regenerate cache confirmation is dismissed", () => {
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(false);
+    render(<ScenarioPane />);
+
+    fireEvent.click(screen.getByTitle(/Regenerate cache/));
+
+    expect(mockRunSweepJob).not.toHaveBeenCalled();
+    confirmSpy.mockRestore();
+  });
+
+  it("disables Regenerate cache while a sweep is already running", () => {
+    mockSweeping = true;
+    render(<ScenarioPane />);
+
+    expect(screen.getByTitle(/Regenerate cache/)).toBeDisabled();
   });
 
   it("wires onSaved into the scoped editor in the populated state", () => {

--- a/frontend/src/components/panels/ScenarioPane.tsx
+++ b/frontend/src/components/panels/ScenarioPane.tsx
@@ -1,7 +1,8 @@
 import { type KeyboardEvent, useEffect, useRef, useState } from "react";
-import { Pencil, Plus, SquarePen, Trash2 } from "lucide-react";
+import { Pencil, Plus, RefreshCw, Trash2 } from "lucide-react";
 import { toast } from "sonner";
 import { useScenarioStore } from "@/stores/scenarioStore";
+import { useSweepRunStore } from "@/stores/sweepStore";
 import { AddScenarioModal } from "@/components/modals/AddScenarioModal";
 import { ScenarioYamlEditorModal } from "@/components/modals/ScenarioYamlEditorModal";
 import { SweepResultsPlot } from "./SweepResultsPlot";
@@ -34,9 +35,10 @@ export function ScenarioPane() {
     error,
     refresh,
     setActive,
-    renameScenario,
     deleteScenario,
   } = useScenarioStore();
+  const sweeping = useSweepRunStore((s) => s.sweeping);
+  const runSweepJob = useSweepRunStore((s) => s.run);
   const [addModalOpen, setAddModalOpen] = useState(false);
   const [editingId, setEditingId] = useState<string | null>(null);
 
@@ -67,10 +69,24 @@ export function ScenarioPane() {
   }, [createdAt]);
 
   const handleDelete = async (id: string) => {
-    if (!window.confirm(`Delete scenario "${id}"? This cannot be undone.`)) return;
+    // Every row here already has a cached trajectory (that's why it's in
+    // `scenarios`, the store-derived list), so this message is always
+    // accurate — deleting drops both the definition and its cached result.
+    if (
+      !window.confirm(
+        `Delete scenario "${id}"? This also removes its cached trajectory ` +
+          "immediately. This cannot be undone.",
+      )
+    ) {
+      return;
+    }
     try {
-      await deleteScenario(id);
-      toast.success(`Scenario "${id}" deleted`);
+      const { cachePurged } = await deleteScenario(id);
+      toast.success(
+        cachePurged
+          ? `Scenario "${id}" and its cached result deleted`
+          : `Scenario "${id}" deleted`,
+      );
     } catch (err) {
       toast.error(
         `Could not delete scenario: ${err instanceof Error ? err.message : String(err)}`,
@@ -78,21 +94,16 @@ export function ScenarioPane() {
     }
   };
 
-  const handleRename = async (id: string) => {
-    const trimmed = window.prompt(`Rename scenario "${id}" to:`, id)?.trim();
-    if (!trimmed || trimmed === id) return;
-    if (!/^[A-Za-z0-9_-]+$/.test(trimmed)) {
-      toast.error("Scenario id must use letters, digits, '_' or '-' only");
+  const handleRegenerate = () => {
+    if (
+      !window.confirm(
+        "Regenerate the cache? This re-solves every scenario in this sweep " +
+          "from scratch, ignoring cached results. This may take a while.",
+      )
+    ) {
       return;
     }
-    try {
-      await renameScenario(id, trimmed);
-      toast.success(`Scenario renamed to "${trimmed}"`);
-    } catch (err) {
-      toast.error(
-        `Could not rename scenario: ${err instanceof Error ? err.message : String(err)}`,
-      );
-    }
+    runSweepJob({ total: scenarios.length, noCache: true });
   };
 
   if (!available || scenarios.length === 0) {
@@ -161,6 +172,15 @@ export function ScenarioPane() {
             <span className="text-xs text-muted-foreground">{scenarios.length}</span>
             <button
               type="button"
+              onClick={handleRegenerate}
+              disabled={sweeping}
+              title="Regenerate cache (re-solve every scenario, ignoring cached results)"
+              className="text-muted-foreground hover:text-foreground disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              <RefreshCw size={14} className={sweeping ? "animate-spin" : ""} />
+            </button>
+            <button
+              type="button"
               onClick={() => setAddModalOpen(true)}
               title="Add Scenario"
               className="text-muted-foreground hover:text-foreground"
@@ -215,14 +235,6 @@ export function ScenarioPane() {
                       {s.reactor_mode}
                     </div>
                   )}
-                </button>
-                <button
-                  type="button"
-                  onClick={() => void handleRename(s.id)}
-                  title="Rename scenario"
-                  className="shrink-0 p-1 rounded text-muted-foreground opacity-0 group-hover:opacity-100 hover:text-foreground hover:bg-muted"
-                >
-                  <SquarePen size={12} />
                 </button>
                 <button
                   type="button"

--- a/frontend/src/components/ui/Tooltip.tsx
+++ b/frontend/src/components/ui/Tooltip.tsx
@@ -6,6 +6,18 @@ interface TooltipProps {
   className?: string;
 }
 
+const _DISPLAY_UTILITIES = new Set([
+  "block",
+  "inline-block",
+  "inline",
+  "flex",
+  "inline-flex",
+  "grid",
+  "inline-grid",
+  "contents",
+  "hidden",
+]);
+
 /**
  * Hover/focus tooltip that works even when `children` is a disabled button.
  *
@@ -18,9 +30,19 @@ export function Tooltip({ content, children, className }: TooltipProps) {
   const [open, setOpen] = useState(false);
   const id = useId();
 
+  // Default to `inline-flex` (shrink-to-fit trigger), but defer to a display
+  // utility the caller passed (e.g. `className="block"` for a full-width
+  // button) -- Tailwind's generated stylesheet defines `.inline-flex` after
+  // `.block`, so appending "block" to the class string does NOT override a
+  // hardcoded "inline-flex" of equal specificity; only omitting it does.
+  const callerClasses = (className ?? "").split(/\s+/).filter(Boolean);
+  const display = callerClasses.some((c) => _DISPLAY_UTILITIES.has(c))
+    ? ""
+    : "inline-flex";
+
   return (
     <span
-      className={`relative inline-flex ${className ?? ""}`}
+      className={`relative ${display} ${className ?? ""}`.trim().replace(/\s+/g, " ")}
       onMouseEnter={() => setOpen(true)}
       onMouseLeave={() => setOpen(false)}
       onFocus={() => setOpen(true)}

--- a/frontend/src/stores/scenarioStore.ts
+++ b/frontend/src/stores/scenarioStore.ts
@@ -44,8 +44,8 @@ interface ScenarioState {
   updateScenario: (id: string, yaml: string) => Promise<void>;
   /** Rename a scenario's id. */
   renameScenario: (id: string, newId: string) => Promise<void>;
-  /** Delete a scenario overlay. */
-  deleteScenario: (id: string) => Promise<void>;
+  /** Delete a scenario overlay; resolves with whether a cached result was purged too. */
+  deleteScenario: (id: string) => Promise<{ cachePurged: boolean }>;
 }
 
 export const useScenarioStore = create<ScenarioState>((set, get) => ({
@@ -100,9 +100,10 @@ export const useScenarioStore = create<ScenarioState>((set, get) => ({
   },
 
   deleteScenario: async (id) => {
-    await apiDeleteScenario(id);
+    const resp = await apiDeleteScenario(id);
     if (get().activeId === id) set({ activeId: null });
     await get().refresh();
+    return { cachePurged: resp.cache_purged };
   },
 
   setActive: async (id) => {

--- a/frontend/src/stores/sweepStore.test.ts
+++ b/frontend/src/stores/sweepStore.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Asserts the shared sweep-run store: starts a job, polls to completion,
+ * refreshes scenarios and toasts on success/failure, passes `noCache`
+ * through, and refuses a second job while one is already running. Both
+ * RunControl's "Run Sweep" and the Scenario Pane's "Regenerate cache" call
+ * this single store instead of each owning their own poll loop.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockStartSweep = vi.fn();
+const mockGetSweepStatus = vi.fn();
+vi.mock("@/api/sweep", () => ({
+  startSweep: (...args: unknown[]) => mockStartSweep(...args),
+  getSweepStatus: (...args: unknown[]) => mockGetSweepStatus(...args),
+}));
+
+const mockRefresh = vi.fn();
+vi.mock("./scenarioStore", () => ({
+  useScenarioStore: { getState: () => ({ refresh: mockRefresh }) },
+}));
+
+const mockToastSuccess = vi.fn();
+const mockToastError = vi.fn();
+vi.mock("sonner", () => ({
+  toast: {
+    success: (...args: unknown[]) => mockToastSuccess(...args),
+    error: (...args: unknown[]) => mockToastError(...args),
+  },
+}));
+
+import { useSweepRunStore } from "./sweepStore";
+
+describe("sweepStore", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useSweepRunStore.setState({ sweeping: false, progress: { current: 0, total: 0 } });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("run() starts a sweep, polls progress, and refreshes scenarios on completion", async () => {
+    vi.useFakeTimers();
+    mockStartSweep.mockResolvedValue({ status: "running", total: 2 });
+    mockGetSweepStatus
+      .mockResolvedValueOnce({ status: "running", current: 1, total: 2 })
+      .mockResolvedValueOnce({ status: "done", current: 2, total: 2 });
+
+    useSweepRunStore.getState().run({ total: 2 });
+    expect(useSweepRunStore.getState().sweeping).toBe(true);
+
+    await vi.advanceTimersByTimeAsync(0); // flush startSweep().then(...)
+    await vi.advanceTimersByTimeAsync(1000); // first poll tick -> running
+    expect(useSweepRunStore.getState().progress).toEqual({ current: 1, total: 2 });
+    expect(useSweepRunStore.getState().sweeping).toBe(true);
+
+    await vi.advanceTimersByTimeAsync(1000); // second poll tick -> done
+    expect(useSweepRunStore.getState().sweeping).toBe(false);
+    expect(mockRefresh).toHaveBeenCalledOnce();
+    expect(mockToastSuccess).toHaveBeenCalledOnce();
+  });
+
+  it("run() toasts an error and stops polling when the job fails", async () => {
+    vi.useFakeTimers();
+    mockStartSweep.mockResolvedValue({ status: "running", total: 1 });
+    mockGetSweepStatus.mockResolvedValueOnce({ status: "error", message: "boom" });
+
+    useSweepRunStore.getState().run({ total: 1 });
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(useSweepRunStore.getState().sweeping).toBe(false);
+    expect(mockToastError).toHaveBeenCalledWith(expect.stringContaining("boom"));
+    expect(mockRefresh).not.toHaveBeenCalled();
+  });
+
+  it("run() passes noCache through to startSweep (the Regenerate cache action)", async () => {
+    vi.useFakeTimers();
+    mockStartSweep.mockResolvedValue({ status: "running", total: 1 });
+    mockGetSweepStatus.mockResolvedValueOnce({ status: "done", current: 1, total: 1 });
+
+    useSweepRunStore.getState().run({ total: 1, noCache: true });
+    expect(mockStartSweep).toHaveBeenCalledWith({ noCache: true });
+
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(1000);
+  });
+
+  it("run() refuses to start a second job while one is already running", () => {
+    useSweepRunStore.setState({ sweeping: true, progress: { current: 0, total: 0 } });
+
+    useSweepRunStore.getState().run();
+
+    expect(mockStartSweep).not.toHaveBeenCalled();
+    expect(mockToastError).toHaveBeenCalledWith("A sweep is already running");
+  });
+});

--- a/frontend/src/stores/sweepStore.ts
+++ b/frontend/src/stores/sweepStore.ts
@@ -1,0 +1,69 @@
+import { create } from "zustand";
+import { toast } from "sonner";
+import { getSweepStatus, startSweep } from "@/api/sweep";
+import { useScenarioStore } from "./scenarioStore";
+
+interface SweepRunState {
+  sweeping: boolean;
+  progress: { current: number; total: number };
+  /**
+   * Start a sweep job and poll it to completion, toasting the outcome and
+   * refreshing the Scenario Pane. A single shared job — RunControl's "Run
+   * Sweep" and the Scenario Pane's "Regenerate cache" both call this instead
+   * of each owning their own poll loop, so the two surfaces can never
+   * disagree about whether a sweep is currently running.
+   */
+  run: (options?: { total?: number; noCache?: boolean }) => void;
+}
+
+// Module-level (not store state) — a plain interval handle, not observed by
+// React; only one ever exists regardless of how many components call run().
+let pollHandle: ReturnType<typeof setInterval> | null = null;
+
+function stopPolling(): void {
+  if (pollHandle !== null) {
+    clearInterval(pollHandle);
+    pollHandle = null;
+  }
+}
+
+export const useSweepRunStore = create<SweepRunState>((set, get) => ({
+  sweeping: false,
+  progress: { current: 0, total: 0 },
+
+  run: (options) => {
+    if (get().sweeping) {
+      toast.error("A sweep is already running");
+      return;
+    }
+    set({ sweeping: true, progress: { current: 0, total: options?.total ?? 0 } });
+    startSweep({ noCache: options?.noCache })
+      .then(() => {
+        pollHandle = setInterval(() => {
+          getSweepStatus()
+            .then((st) => {
+              if (st.status === "running") {
+                set({ progress: { current: st.current ?? 0, total: st.total ?? 0 } });
+                return;
+              }
+              stopPolling();
+              set({ sweeping: false });
+              if (st.status === "done") {
+                toast.success("Sweep complete — scenarios updated");
+                void useScenarioStore.getState().refresh();
+              } else {
+                toast.error(`Sweep failed: ${st.message ?? "unknown error"}`);
+              }
+            })
+            .catch(() => {
+              stopPolling();
+              set({ sweeping: false });
+            });
+        }, 1000);
+      })
+      .catch((e) => {
+        set({ sweeping: false });
+        toast.error(e instanceof Error ? e.message : String(e));
+      });
+  },
+}));

--- a/tests/test_scenario_editing.py
+++ b/tests/test_scenario_editing.py
@@ -223,6 +223,47 @@ def test_delete_scenario(tmp_path: Path) -> None:
         client.__exit__(None, None, None)
 
 
+def test_delete_scenario_purges_cached_group(tmp_path: Path) -> None:
+    """Deleting a scenario immediately removes its cached HDF5 group too.
+
+    Not left for the next Run Sweep to notice and prune — the Scenario Pane's
+    "N cached" count and the store on disk stay in sync with the config the
+    moment you click Delete.
+    """
+    pytest.importorskip("h5py")
+    import h5py
+
+    cfg = _write_config(tmp_path)
+    client, app = _client_with_config(cfg)
+    try:
+        store = tmp_path / "scenarios.h5"
+        with h5py.File(str(store), "w") as handle:
+            grp = handle.create_group("base_case")
+            grp.create_dataset("payload_json", data=b"{}")
+        app.state.scenario_store_path = str(store)
+
+        resp = client.delete("/api/scenarios/base_case")
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["cache_purged"] is True
+
+        with h5py.File(str(store), "r") as handle:
+            assert "base_case" not in handle
+    finally:
+        client.__exit__(None, None, None)
+
+
+def test_delete_scenario_without_cached_group_reports_false(tmp_path: Path) -> None:
+    """`cache_purged` is False when there was nothing cached to clear."""
+    cfg = _write_config(tmp_path)
+    client, _app = _client_with_config(cfg)
+    try:
+        resp = client.delete("/api/scenarios/base_case")
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["cache_purged"] is False
+    finally:
+        client.__exit__(None, None, None)
+
+
 def test_delete_scenario_unknown_404(tmp_path: Path) -> None:
     cfg = _write_config(tmp_path)
     client, _app = _client_with_config(cfg)

--- a/tests/test_sweep_run_no_cache.py
+++ b/tests/test_sweep_run_no_cache.py
@@ -54,7 +54,7 @@ def _client_with_local_runner(tmp_path: Path):
 
 
 def _mock_popen_factory(started: threading.Event, captured: Dict[str, Any]):
-    """A Popen stand-in that exits immediately with no output."""
+    """Build a Popen stand-in that exits immediately with no output."""
     proc = MagicMock()
     proc.stdout = iter([])
     proc.wait.return_value = None

--- a/tests/test_sweep_run_no_cache.py
+++ b/tests/test_sweep_run_no_cache.py
@@ -1,0 +1,120 @@
+"""Tests for POST /api/sweep/run's `no_cache` passthrough.
+
+The "Regenerate cache" action (Scenario Pane) reuses the plain "Run Sweep"
+endpoint with ``no_cache: true``, which must set ``BOULDER_NO_CACHE=1`` in the
+subprocess env so a cache-aware runner (e.g. ``bloc.scenario_sweep``) discards
+its collection store instead of skipping unchanged scenarios.
+"""
+
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+from typing import Any, Dict
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytest.importorskip("fastapi")
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from boulder.api.main import create_app  # noqa: E402
+
+_CONFIG_YAML = """\
+metadata:
+  description: "test config"
+phases:
+  gas:
+    mechanism: gri30.yaml
+network:
+  - id: feed
+    Reservoir:
+      temperature: 298.15
+      pressure: 101325
+      composition: "CH4:1"
+scenario:
+  a:
+    metadata:
+      scenario_name: "A"
+"""
+
+
+def _client_with_local_runner(tmp_path: Path):
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(_CONFIG_YAML, encoding="utf-8")
+    (tmp_path / "run_sweep.py").write_text("", encoding="utf-8")
+
+    app = create_app()
+    client = TestClient(app)
+    client.__enter__()
+    app.state.preloaded_config_path = str(cfg)
+    app.state.preloaded_raw = {"scenario": {"a": {}}}
+    return client, app
+
+
+def _mock_popen_factory(started: threading.Event, captured: Dict[str, Any]):
+    """A Popen stand-in that exits immediately with no output."""
+    proc = MagicMock()
+    proc.stdout = iter([])
+    proc.wait.return_value = None
+    proc.returncode = 0
+
+    def _factory(*args: Any, **kwargs: Any) -> MagicMock:
+        captured["kwargs"] = kwargs
+        started.set()
+        return proc
+
+    return _factory
+
+
+def test_sweep_run_default_does_not_set_no_cache_env(tmp_path: Path) -> None:
+    client, _app = _client_with_local_runner(tmp_path)
+    started = threading.Event()
+    captured: Dict[str, Any] = {}
+    try:
+        with patch(
+            "boulder.api.routes.sweep.subprocess.Popen",
+            side_effect=_mock_popen_factory(started, captured),
+        ):
+            resp = client.post("/api/sweep/run", json={})
+            assert resp.status_code == 200, resp.text
+            assert started.wait(timeout=2), "subprocess.Popen was never called"
+        assert "BOULDER_NO_CACHE" not in captured["kwargs"]["env"]
+    finally:
+        client.__exit__(None, None, None)
+
+
+def test_sweep_run_no_body_also_does_not_set_no_cache_env(tmp_path: Path) -> None:
+    """A client that omits the body entirely gets the same default as `{}`."""
+    client, _app = _client_with_local_runner(tmp_path)
+    started = threading.Event()
+    captured: Dict[str, Any] = {}
+    try:
+        with patch(
+            "boulder.api.routes.sweep.subprocess.Popen",
+            side_effect=_mock_popen_factory(started, captured),
+        ):
+            resp = client.post("/api/sweep/run")
+            assert resp.status_code == 200, resp.text
+            assert started.wait(timeout=2), "subprocess.Popen was never called"
+        assert "BOULDER_NO_CACHE" not in captured["kwargs"]["env"]
+    finally:
+        client.__exit__(None, None, None)
+
+
+def test_sweep_run_no_cache_sets_env(tmp_path: Path) -> None:
+    client, _app = _client_with_local_runner(tmp_path)
+    started = threading.Event()
+    captured: Dict[str, Any] = {}
+    try:
+        with patch(
+            "boulder.api.routes.sweep.subprocess.Popen",
+            side_effect=_mock_popen_factory(started, captured),
+        ):
+            resp = client.post("/api/sweep/run", json={"no_cache": True})
+            assert resp.status_code == 200, resp.text
+            assert started.wait(timeout=2), "subprocess.Popen was never called"
+        assert captured["kwargs"]["env"].get("BOULDER_NO_CACHE") == "1"
+    finally:
+        client.__exit__(None, None, None)


### PR DESCRIPTION
## Summary
- Scenario Pane gets a "Regenerate cache" button (`POST /api/sweep/run` with `no_cache: true`) that sets `BOULDER_NO_CACHE=1` for the runner subprocess so every scenario is re-solved from scratch instead of skipping unchanged ones.
- Deleting a scenario now purges its cached HDF5 group immediately (`DELETE /api/scenarios/{id}` returns `cache_purged`) instead of waiting for the next Run Sweep to prune it.
- `RunControl`'s "Run Sweep" and the Scenario Pane's "Regenerate cache" now share a single `sweepStore` poll loop so both surfaces always agree on whether a sweep is running.
- `RunControl`'s dropdown menu is portaled to `document.body` so the sidebar's `overflow-y-auto` can no longer clip it.
- `Tooltip` no longer fights a caller-supplied display utility (e.g. `className="block"`) with a hardcoded `inline-flex`.
- Removed the scenario "Rename" action — redundant with editing `metadata.scenario_name` via the existing YAML editor, and having both was a confusing two-ways-to-rename-the-same-thing situation.

## Test plan
- [x] `python -m pytest tests/test_scenario_editing.py tests/test_sweep_run_no_cache.py -q` — 22 passed
- [x] `cd frontend && npm run test:unit` — 140 passed (24 files)
- [x] `cd frontend && npm run type-check` — clean
- [x] `python -m mypy . --exclude docs/cantera_examples` — clean
- [x] `pre-commit run --all-files` — clean
- [x] `cd frontend && npm run build` — succeeds

Extensive AI use — code & PR fully written by Claude Sonnet 5