### PR TITLE
Fix Scenario Pane visibility and stale YAML editor after authoring a scenario

### DIFF
--- a/frontend/src/components/layout/AppShell.test.tsx
+++ b/frontend/src/components/layout/AppShell.test.tsx
@@ -67,6 +67,23 @@ vi.mock("@/components/panels/YamlPane", () => ({
   YamlPane: () => <div data-testid="yaml-pane" />,
 }));
 
+vi.mock("@/components/panels/ScenarioPane", () => ({
+  ScenarioPane: () => <div data-testid="scenario-pane" />,
+}));
+
+let mockScenariosAvailable = false;
+let mockAuthoredScenarioIds: string[] = [];
+const mockRefreshScenarios = vi.fn();
+
+vi.mock("@/stores/scenarioStore", () => ({
+  useScenarioStore: (selector: (s: unknown) => unknown) =>
+    selector({
+      available: mockScenariosAvailable,
+      authoredIds: mockAuthoredScenarioIds,
+      refresh: mockRefreshScenarios,
+    }),
+}));
+
 let mockYamlPaneOpen = false;
 const mockOpenYamlPane = vi.fn();
 
@@ -147,6 +164,8 @@ describe("AppShell", () => {
     mockReactorModal = { open: false };
     mockConnectionModal = { open: false };
     mockYamlPaneOpen = false;
+    mockScenariosAvailable = false;
+    mockAuthoredScenarioIds = [];
   });
 
   it("renders the sidebar cards but no header filename button or solver badge", () => {
@@ -192,5 +211,22 @@ describe("AppShell", () => {
     render(<AppShell />);
     screen.getByRole("button", { name: "Edit YAML" }).click();
     expect(mockOpenYamlPane).toHaveBeenCalledOnce();
+  });
+
+  it("does not render the Scenario pane when there's no store and no authored scenarios", () => {
+    render(<AppShell />);
+    expect(screen.queryByTestId("scenario-pane")).not.toBeInTheDocument();
+  });
+
+  it("renders the Scenario pane once a scenario store exists", () => {
+    mockScenariosAvailable = true;
+    render(<AppShell />);
+    expect(screen.getByTestId("scenario-pane")).toBeInTheDocument();
+  });
+
+  it("renders the Scenario pane for authored-but-not-yet-swept scenarios even without a store", () => {
+    mockAuthoredScenarioIds = ["draft_a"];
+    render(<AppShell />);
+    expect(screen.getByTestId("scenario-pane")).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -43,7 +43,12 @@ export function AppShell() {
     openYamlPane,
   } = useLayoutStore();
   const scenariosAvailable = useScenarioStore((s) => s.available);
+  const authoredScenarioIds = useScenarioStore((s) => s.authoredIds);
   const refreshScenarios = useScenarioStore((s) => s.refresh);
+  // Show the pane once a sweep has produced a store OR the config already
+  // has authored (not-yet-swept) scenarios — otherwise a freshly authored
+  // scenario has nowhere to appear until the user runs a sweep first.
+  const showScenarioPane = scenariosAvailable || authoredScenarioIds.length > 0;
 
   // Discover available scenarios once so the right pane can appear.
   useEffect(() => {
@@ -208,7 +213,7 @@ export function AppShell() {
           )}
         </div>
         <div className="flex items-center gap-2">
-          {scenariosAvailable && <PaneToggle side="right" />}
+          {showScenarioPane && <PaneToggle side="right" />}
           <Button
             onClick={toggleTheme}
             variant="secondary"
@@ -286,7 +291,7 @@ export function AppShell() {
         </main>
 
         {/* Right scenario-inspector pane (hidden when no store / collapsed) */}
-        {scenariosAvailable && !rightCollapsed && (
+        {showScenarioPane && !rightCollapsed && (
           <>
             <PaneResizer side="right" />
             <aside

--- a/frontend/src/components/panels/ScenarioPane.test.tsx
+++ b/frontend/src/components/panels/ScenarioPane.test.tsx
@@ -18,11 +18,13 @@ let mockAvailable = true;
 let mockScenarios: Array<{ id: string; label: string; t0_K: number }> = [
   { id: "A", label: "Scenario A", t0_K: 300 },
 ];
+let mockAuthoredIds: string[] = [];
 
 vi.mock("@/stores/scenarioStore", () => ({
   useScenarioStore: () => ({
     available: mockAvailable,
     scenarios: mockScenarios,
+    authoredIds: mockAuthoredIds,
     createdAt: undefined,
     activeId: null,
     loading: false,
@@ -60,6 +62,7 @@ describe("ScenarioPane", () => {
     capturedOnSaved = undefined;
     mockAvailable = true;
     mockScenarios = [{ id: "A", label: "Scenario A", t0_K: 300 }];
+    mockAuthoredIds = [];
   });
 
   it("renaming a scenario prompts for a new id and calls renameScenario", () => {
@@ -107,5 +110,29 @@ describe("ScenarioPane", () => {
     expect(capturedOnSaved).toBeInstanceOf(Function);
     capturedOnSaved?.();
     expect(mockRefresh).toHaveBeenCalled();
+  });
+
+  it("lists authored-but-not-yet-swept scenarios before any store exists", () => {
+    mockAvailable = false;
+    mockScenarios = [];
+    mockAuthoredIds = ["draft_a", "draft_b"];
+    render(<ScenarioPane />);
+
+    expect(screen.getByText("draft_a")).toBeInTheDocument();
+    expect(screen.getByText("draft_b")).toBeInTheDocument();
+    expect(screen.getByText(/Run Sweep to solve them/)).toBeInTheDocument();
+  });
+
+  it("deleting an authored-but-unswept scenario confirms and calls deleteScenario", () => {
+    mockAvailable = false;
+    mockScenarios = [];
+    mockAuthoredIds = ["draft_a"];
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
+    render(<ScenarioPane />);
+
+    fireEvent.click(screen.getByTitle("Delete scenario"));
+
+    expect(mockDeleteScenario).toHaveBeenCalledWith("draft_a");
+    confirmSpy.mockRestore();
   });
 });

--- a/frontend/src/components/panels/ScenarioPane.tsx
+++ b/frontend/src/components/panels/ScenarioPane.tsx
@@ -28,6 +28,7 @@ export function ScenarioPane() {
   const {
     available,
     scenarios,
+    authoredIds,
     createdAt,
     activeId,
     loading,
@@ -111,9 +112,43 @@ export function ScenarioPane() {
             <Plus size={12} /> Add Scenario
           </button>
         </div>
-        <p className="text-xs text-muted-foreground">
-          No computed scenarios yet — add one, then Run Sweep.
-        </p>
+        {authoredIds.length === 0 ? (
+          <p className="text-xs text-muted-foreground">
+            No computed scenarios yet — add one, then Run Sweep.
+          </p>
+        ) : (
+          <>
+            <p className="text-xs text-muted-foreground">
+              Not computed yet — Run Sweep to solve{" "}
+              {authoredIds.length === 1 ? "it" : "them"}.
+            </p>
+            <ul className="space-y-1 max-h-[70vh] overflow-y-auto pr-1">
+              {authoredIds.map((id) => (
+                <li key={id} className="group flex items-center gap-1">
+                  <span className="flex-1 min-w-0 truncate rounded-md px-2 py-1.5 text-xs text-foreground">
+                    {id}
+                  </span>
+                  <button
+                    type="button"
+                    onClick={() => setEditingId(id)}
+                    title="Edit scenario YAML"
+                    className="shrink-0 p-1 rounded text-muted-foreground opacity-0 group-hover:opacity-100 hover:text-foreground hover:bg-muted"
+                  >
+                    <Pencil size={12} />
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => void handleDelete(id)}
+                    title="Delete scenario"
+                    className="shrink-0 p-1 rounded text-muted-foreground opacity-0 group-hover:opacity-100 hover:text-destructive hover:bg-muted"
+                  >
+                    <Trash2 size={12} />
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </>
+        )}
         <AddScenarioModal
           open={addModalOpen}
           onClose={() => setAddModalOpen(false)}

--- a/frontend/src/stores/configStore.test.ts
+++ b/frontend/src/stores/configStore.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Asserts configStore's `setOriginalYaml`: it replaces only the on-disk YAML
+ * snapshot, leaving the live graph (`config`) and `dirty` flag untouched —
+ * so an out-of-band disk write (e.g. scenario authoring) can refresh what
+ * the YAML pane displays without discarding any unsaved node/connection
+ * edits sitting in `config`.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { useConfigStore } from "./configStore";
+
+describe("configStore", () => {
+  beforeEach(() => {
+    useConfigStore.setState({
+      config: { nodes: [{ id: "a", type: "Reservoir" }], connections: [] } as never,
+      fileName: "original.yaml",
+      originalYaml: "old: yaml",
+      dirty: true,
+    });
+  });
+
+  it("setOriginalYaml replaces the yaml snapshot without touching config or dirty", () => {
+    useConfigStore.getState().setOriginalYaml("new: yaml");
+
+    const state = useConfigStore.getState();
+    expect(state.originalYaml).toBe("new: yaml");
+    expect(state.config.nodes).toHaveLength(1);
+    expect(state.dirty).toBe(true);
+    expect(state.fileName).toBe("original.yaml");
+  });
+
+  it("setOriginalYaml updates fileName when given one", () => {
+    useConfigStore.getState().setOriginalYaml("new: yaml", "renamed.yaml");
+
+    expect(useConfigStore.getState().fileName).toBe("renamed.yaml");
+  });
+
+  it("setConfig (unlike setOriginalYaml) does reset dirty and replace config", () => {
+    useConfigStore.getState().setConfig({ nodes: [], connections: [] }, undefined, "new: yaml");
+
+    const state = useConfigStore.getState();
+    expect(state.dirty).toBe(false);
+    expect(state.config.nodes).toHaveLength(0);
+  });
+});

--- a/frontend/src/stores/configStore.ts
+++ b/frontend/src/stores/configStore.ts
@@ -11,6 +11,13 @@ interface ConfigState {
 
   // Actions
   setConfig: (config: NormalizedConfig, fileName?: string | null, yaml?: string) => void;
+  /**
+   * Replace only the on-disk YAML snapshot, leaving the live graph/dirty
+   * state untouched — for edits made out-of-band (e.g. scenario authoring
+   * writes straight to the config file) that the in-memory graph doesn't
+   * need to reflect, so we don't clobber any unsaved node/connection edits.
+   */
+  setOriginalYaml: (yaml: string, fileName?: string) => void;
   resetConfig: () => void;
   addNode: (node: ConfigNode, group?: string | null) => void;
   updateNode: (id: string, updates: Partial<ConfigNode>) => void;
@@ -50,6 +57,9 @@ export const useConfigStore = create<ConfigState>((set, get) => ({
       originalYaml: yaml ?? get().originalYaml,
       dirty: false,
     }),
+
+  setOriginalYaml: (yaml, fileName) =>
+    set((s) => ({ originalYaml: yaml, fileName: fileName ?? s.fileName })),
 
   resetConfig: () =>
     set({ config: EMPTY_CONFIG, fileName: null, originalYaml: "", dirty: false }),

--- a/frontend/src/stores/scenarioStore.test.ts
+++ b/frontend/src/stores/scenarioStore.test.ts
@@ -1,9 +1,12 @@
 /**
  * Asserts scenarioStore: refresh() populates authoredIds (the full,
- * sweep-independent scenario list) and bumps revision, and that
- * create/rename/delete each refresh internally afterward — so callers never
- * have to remember to do it themselves (the bug that let Run Sweep's
- * scenario count and the Add Scenario clone-base list go stale).
+ * sweep-independent scenario list) and bumps revision; create/rename/delete
+ * each refresh internally afterward — so callers never have to remember to
+ * do it themselves (the bug that let Run Sweep's scenario count and the Add
+ * Scenario clone-base list go stale); and each of those four also pushes the
+ * freshly-written config YAML into `configStore` (the bug where the "Edit
+ * YAML" pane kept showing a load-time snapshot after a scenario write went
+ * straight to disk, unrelated to any `configStore.config`/graph state).
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
@@ -24,9 +27,20 @@ vi.mock("@/api/scenarios", () => ({
   updateScenario: vi.fn(),
 }));
 
+const mockFetchPreloadedConfig = vi.fn();
+vi.mock("@/api/configs", () => ({
+  fetchPreloadedConfig: (...args: unknown[]) => mockFetchPreloadedConfig(...args),
+}));
+
+const mockSetOriginalYaml = vi.fn();
+vi.mock("./configStore", () => ({
+  useConfigStore: { getState: () => ({ setOriginalYaml: mockSetOriginalYaml }) },
+}));
+
 describe("scenarioStore", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockFetchPreloadedConfig.mockResolvedValue({ preloaded: false });
     useScenarioStore.setState({
       available: false,
       scenarios: [],
@@ -109,5 +123,56 @@ describe("scenarioStore", () => {
 
     expect(mockListScenarios).toHaveBeenCalledOnce();
     expect(useScenarioStore.getState().activeId).toBeNull();
+  });
+
+  it("createScenario pushes the freshly-written config YAML into configStore", async () => {
+    mockCreateScenario.mockResolvedValue({ scenario_id: "C", yaml: "" });
+    mockListScenarios.mockResolvedValue({ available: false, scenarios: [], authored_ids: ["C"] });
+    mockFetchPreloadedConfig.mockResolvedValue({
+      preloaded: true,
+      yaml: "scenario:\n  C: {}\n",
+      filename: "config.yaml",
+    });
+
+    await useScenarioStore.getState().createScenario("C");
+
+    expect(mockSetOriginalYaml).toHaveBeenCalledWith("scenario:\n  C: {}\n", "config.yaml");
+  });
+
+  it("updateScenario/renameScenario/deleteScenario each also resync configStore's YAML", async () => {
+    mockRenameScenario.mockResolvedValue({ ok: true, scenario_id: "A2" });
+    mockDeleteScenario.mockResolvedValue({ ok: true, scenario_id: "A2" });
+    mockListScenarios.mockResolvedValue({ available: false, scenarios: [], authored_ids: [] });
+    mockFetchPreloadedConfig.mockResolvedValue({
+      preloaded: true,
+      yaml: "resynced",
+      filename: "config.yaml",
+    });
+
+    await useScenarioStore.getState().renameScenario("A", "A2");
+    expect(mockSetOriginalYaml).toHaveBeenCalledWith("resynced", "config.yaml");
+
+    mockSetOriginalYaml.mockClear();
+    await useScenarioStore.getState().deleteScenario("A2");
+    expect(mockSetOriginalYaml).toHaveBeenCalledWith("resynced", "config.yaml");
+  });
+
+  it("does not touch configStore when nothing is preloaded (e.g. an uploaded/pasted config)", async () => {
+    mockCreateScenario.mockResolvedValue({ scenario_id: "C", yaml: "" });
+    mockListScenarios.mockResolvedValue({ available: false, scenarios: [], authored_ids: ["C"] });
+    mockFetchPreloadedConfig.mockResolvedValue({ preloaded: false });
+
+    await useScenarioStore.getState().createScenario("C");
+
+    expect(mockSetOriginalYaml).not.toHaveBeenCalled();
+  });
+
+  it("swallows a resync fetch failure instead of rejecting the caller's promise", async () => {
+    mockCreateScenario.mockResolvedValue({ scenario_id: "C", yaml: "" });
+    mockListScenarios.mockResolvedValue({ available: false, scenarios: [], authored_ids: ["C"] });
+    mockFetchPreloadedConfig.mockRejectedValue(new Error("network error"));
+
+    await expect(useScenarioStore.getState().createScenario("C")).resolves.toBeUndefined();
+    expect(mockSetOriginalYaml).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/stores/scenarioStore.ts
+++ b/frontend/src/stores/scenarioStore.ts
@@ -8,8 +8,29 @@ import {
   updateScenario as apiUpdateScenario,
   type ScenarioMeta,
 } from "@/api/scenarios";
+import { fetchPreloadedConfig } from "@/api/configs";
+import { useConfigStore } from "./configStore";
 import { useSimulationStore } from "./simulationStore";
 import { useSelectionStore } from "./selectionStore";
+
+/**
+ * Scenario authoring (create/update/rename/delete) writes straight to the
+ * config file on disk, bypassing the in-memory graph entirely — so the YAML
+ * pane's `originalYaml` snapshot (fetched once on load) goes stale the
+ * moment a scenario changes. Re-fetch and push just that snapshot into
+ * `configStore` (not the whole `config`, which would clobber any unsaved
+ * node/connection edits) so the editor picks it up on its next refresh.
+ */
+async function resyncConfigYaml(): Promise<void> {
+  try {
+    const resp = await fetchPreloadedConfig();
+    if (resp.preloaded && resp.yaml !== undefined) {
+      useConfigStore.getState().setOriginalYaml(resp.yaml, resp.filename);
+    }
+  } catch {
+    // Best-effort — the YAML pane just keeps showing its last-known text.
+  }
+}
 
 interface ScenarioState {
   available: boolean;
@@ -86,23 +107,27 @@ export const useScenarioStore = create<ScenarioState>((set, get) => ({
     // Run Sweep's scenario count picks it up, even though `scenarios` (the
     // HDF5-derived list) won't include it until a sweep actually runs.
     await get().refresh();
+    await resyncConfigYaml();
   },
 
   updateScenario: async (id, yaml) => {
     await apiUpdateScenario(id, yaml);
     await get().refresh();
+    await resyncConfigYaml();
   },
 
   renameScenario: async (id, newId) => {
     await apiRenameScenario(id, newId);
     if (get().activeId === id) set({ activeId: newId });
     await get().refresh();
+    await resyncConfigYaml();
   },
 
   deleteScenario: async (id) => {
     await apiDeleteScenario(id);
     if (get().activeId === id) set({ activeId: null });
     await get().refresh();
+    await resyncConfigYaml();
   },
 
   setActive: async (id) => {


### PR DESCRIPTION
## Summary

Two pre-existing bugs (unrelated to `from:`-style config inheritance, which is a red herring — Boulder core has no inheritance-merging logic at all) combined to make newly-authored scenarios effectively invisible:

- **Scenario Pane never mounted.** `AppShell.tsx` only rendered `<ScenarioPane/>` when a precomputed HDF5 store already existed (`scenariosAvailable`). On a fresh config with no prior sweep, the pane's own "no scenarios yet, add one" fallback UI was unreachable — the component simply wasn't in the tree, even though scenarios were being created successfully on the backend via RunControl's "Add Scenario" menu.
  - Fix: also mount the pane when the config already has authored (not-yet-swept) scenario ids (`authoredIds.length > 0`).
  - Also improved: the empty-store fallback now actually lists those authored ids (with edit/delete), instead of a generic "add one" prompt that hid scenarios the user had already created.
- **"Edit YAML" showed stale text.** Scenario authoring (create/update/rename/delete) writes straight to the config file on disk, but never told `configStore`, whose `originalYaml` is fetched once on page load and never invalidated. So even though the backend correctly wrote the `scenario:` block, the YAML pane kept showing its load-time snapshot.
  - Fix: `configStore` gains `setOriginalYaml` (updates only the on-disk YAML snapshot, leaving any in-progress graph edits / `dirty` state untouched — so it can't clobber unsaved node/connection edits). `scenarioStore`'s four CRUD actions now re-fetch `/api/configs/preloaded` and push the fresh YAML after each write.

Verified live against a real config with authored-but-unswept scenarios: the pane now correctly lists them instead of showing nothing.

## Test plan
- [x] `cd frontend && npm run test:unit` — 149 passed (added coverage in `AppShell.test.tsx`, `ScenarioPane.test.tsx`, `scenarioStore.test.ts`, and a new `configStore.test.ts`)
- [x] `cd frontend && npm run type-check` — clean
- [x] `pre-commit run --all-files` (`make qa`) — clean
- [x] `cd frontend && npm run build` — succeeds
- [x] Manually verified in a running dev instance: a config with authored scenarios not yet swept now shows them in the Scenario Pane

Extensive AI use — code & PR fully written by Claude Sonnet 5