### PR TITLE
Add energy stream cytoscape display

### DIFF
--- a/boulder/cantera_converter.py
+++ b/boulder/cantera_converter.py
@@ -92,6 +92,21 @@ class BoulderPlugins:
     #: the Boulder title.
     branding: Optional[Dict[str, str]] = None
 
+    #: ``(config: dict) -> list[dict]`` callables that synthesize additional
+    #: display-only Cytoscape elements (nodes/edges) for
+    #: :func:`~boulder.utils.config_to_cyto_elements`, appended after its own
+    #: elements. Each callable receives the same config dict passed to
+    #: ``config_to_cyto_elements`` and must not mutate it. Lets a host
+    #: represent a concept that never becomes a real STONE node/connection
+    #: (e.g. a non-physical energy source with no meaningful composition) in
+    #: the interactive graph, without Boulder's core knowing what that
+    #: concept is. Mirrors the pattern ``config_to_cyto_elements`` already
+    #: uses internally for its own stream-point diamond synthesis, made
+    #: pluggable. Registered by an external plugin package.
+    cyto_element_synthesizers: List[Callable[[Dict[str, Any]], List[Dict[str, Any]]]] = field(
+        default_factory=list
+    )
+
     #: Per-source provenance for introspection (``boulder plugins list``).
     #: ``{"entry_point": [(ep_name, module)], "env_var": [module_name]}``.
     sources: Dict[str, List[Any]] = field(

--- a/boulder/cantera_converter.py
+++ b/boulder/cantera_converter.py
@@ -103,9 +103,9 @@ class BoulderPlugins:
     #: concept is. Mirrors the pattern ``config_to_cyto_elements`` already
     #: uses internally for its own stream-point diamond synthesis, made
     #: pluggable. Registered by an external plugin package.
-    cyto_element_synthesizers: List[Callable[[Dict[str, Any]], List[Dict[str, Any]]]] = field(
-        default_factory=list
-    )
+    cyto_element_synthesizers: List[
+        Callable[[Dict[str, Any]], List[Dict[str, Any]]]
+    ] = field(default_factory=list)
 
     #: Per-source provenance for introspection (``boulder plugins list``).
     #: ``{"entry_point": [(ep_name, module)], "env_var": [module_name]}``.

--- a/boulder/utils.py
+++ b/boulder/utils.py
@@ -344,6 +344,16 @@ def config_to_cyto_elements(config: Dict[str, Any]) -> List[Dict[str, Any]]:
             edge_data["mass_flow_rate"] = properties["mass_flow_rate"]
         if "valve_coeff" in properties:
             edge_data["valve_coeff"] = properties["valve_coeff"]
+        if "_is_energy_stream" in properties:
+            # Leading underscore: a display-only annotation, not a physical
+            # input -- kept out of the Properties panel by the same
+            # underscore convention PropertiesPanel.tsx's unfoldInitialConditions
+            # already applies. Promoted here to an edge data key of the same
+            # (still underscored) name, matched by a `[?_is_energy_stream]`
+            # Cytoscape selector -- the underscore marks "internal machinery"
+            # consistently at every layer, not just where the Properties
+            # panel happens to render it.
+            edge_data["_is_energy_stream"] = properties["_is_energy_stream"]
         elements.append({"data": edge_data})
 
     # -----------------------------------------------------------------------
@@ -378,6 +388,18 @@ def config_to_cyto_elements(config: Dict[str, Any]) -> List[Dict[str, Any]]:
             if "mass_flow_rate" in properties:
                 edge_data["mass_flow_rate"] = properties["mass_flow_rate"]
             elements.append({"data": edge_data})
+
+    # -----------------------------------------------------------------------
+    # Plugin-contributed display-only elements (e.g. a host's non-physical
+    # energy source that never becomes a real STONE node/connection). Each
+    # synthesizer receives the same `config` passed to this function and
+    # must not mutate it -- Boulder itself has no notion of what these
+    # elements represent.
+    # -----------------------------------------------------------------------
+    from .cantera_converter import get_plugins  # noqa: PLC0415 (avoid import cycle)
+
+    for synthesizer in get_plugins().cyto_element_synthesizers:
+        elements.extend(synthesizer(config))
 
     return elements
 

--- a/frontend/src/components/graph/ReactorGraph.tsx
+++ b/frontend/src/components/graph/ReactorGraph.tsx
@@ -499,6 +499,28 @@ export function ReactorGraph() {
         },
       },
       {
+        // Energy Stream (host-plugin concept, e.g. Bloc): a non-mass energy
+        // flow -- either a display-only synthesized edge (e.g. a torch's
+        // electrical power, which never becomes a real Wall/Reservoir) or a
+        // real Wall additionally flagged `_is_energy_stream` so it renders
+        // identically (e.g. a PFR's ambient heat-loss wall). Leading
+        // underscore: internal display machinery, not a user-facing data
+        // field, same convention as the Properties panel's underscore
+        // hiding rule. Dotted, blue tint to read as distinct from both
+        // material streams (solid) and generic Walls (dashed, orange).
+        // Placed after `[type='Wall']` so it overrides that rule's dashed
+        // styling for flagged real Walls.
+        selector: "[?_is_energy_stream]",
+        style: {
+          width: 1.5,
+          "line-style": "dotted",
+          "line-dash-pattern": [3, 5],
+          "target-arrow-shape": "triangle",
+          "line-color": isDark ? "#6bb0f0" : "#2a6fc0",
+          "target-arrow-color": isDark ? "#6bb0f0" : "#2a6fc0",
+        },
+      },
+      {
         // Pass-through: synthetic edge short-circuiting a hidden (skip_viz) node.
         // Rendered as a faint dotted line so the flow path is traceable without
         // implying a direct physical connection.

--- a/frontend/src/components/graph/ReactorGraph.tsx
+++ b/frontend/src/components/graph/ReactorGraph.tsx
@@ -62,11 +62,13 @@ export function ReactorGraph() {
   // whose unfolder produced visible child nodes.
   //
   // Detection heuristic: a skip_viz node is treated as a composite placeholder
-  // (hidden) if it has at least one outgoing connection TO a node whose id
-  // starts with the parent id followed by an underscore (e.g. cgr → cgr_seg1).
-  // This distinguishes synthesized reactor children from independent same-group
-  // nodes like pfr_ambient (which has an INCOMING wall connection FROM pfr, not
-  // an outgoing connection to pfr, so the direction check filters it out).
+  // (hidden) if it has at least one outgoing, non-Wall connection TO a node
+  // whose id starts with the parent id followed by an underscore (e.g.
+  // cgr → cgr_seg1, wired by mass flow). The type check matters: composite
+  // children are always wired by mass flow, never by a Wall, so a Wall to a
+  // same-group satellite (e.g. pfr → pfr_ambient, its own ambient heat-loss
+  // sink) must never count as a "child" -- regardless of which way the
+  // Wall's source/target point.
   //
   // Nodes that are skip_viz but produce no such outgoing-to-child connections are
   // rendered normally (e.g. RefractoryReactor in A3/A4 whose segments are not
@@ -77,7 +79,10 @@ export function ReactorGraph() {
       if (!node.metadata?.skip_viz) continue;
       const prefix = `${node.id}_`;
       const hasChildConn = config.connections.some(
-        (c) => c.source === node.id && c.target.startsWith(prefix),
+        (c) =>
+          c.source === node.id &&
+          c.target.startsWith(prefix) &&
+          c.type !== "Wall",
       );
       if (hasChildConn) hidden.add(node.id);
     }

--- a/frontend/src/components/panels/PropertiesPanel.test.tsx
+++ b/frontend/src/components/panels/PropertiesPanel.test.tsx
@@ -179,6 +179,34 @@ describe("PropertiesPanel delete confirmation", () => {
     expect(screen.queryByText("initial")).not.toBeInTheDocument();
   });
 
+  it("hides underscore-prefixed properties from display", () => {
+    // A leading underscore marks a property as private/internal (e.g. a
+    // plugin's own display annotation, not a physical input) -- mirrors
+    // Python's own convention. Must not appear in the panel, editable or not.
+    mockConfig = {
+      nodes: [],
+      connections: [
+        {
+          id: "pfr_loss_wall",
+          type: "Wall",
+          source: "pfr_ambient",
+          target: "pfr",
+          properties: { area: 1.0, _is_energy_stream: true },
+        },
+      ],
+    } as Record<string, unknown>;
+    mockSelectedElement = {
+      type: "edge",
+      data: { id: "pfr_loss_wall", type: "Wall" },
+    };
+
+    render(<PropertiesPanel />);
+
+    expect(screen.getByText("area")).toBeInTheDocument();
+    expect(screen.queryByText("_is_energy_stream")).not.toBeInTheDocument();
+    expect(screen.queryByText("is_energy_stream")).not.toBeInTheDocument();
+  });
+
   it("defaults to the sole stage's panel when nothing is selected and the config has one stage", () => {
     mockSelectedElement = null;
     mockConfig = {

--- a/frontend/src/components/panels/PropertiesPanel.tsx
+++ b/frontend/src/components/panels/PropertiesPanel.tsx
@@ -37,6 +37,14 @@ function unfoldInitialConditions(
       }
     }
   }
+  // Underscore-prefixed keys are private/internal by convention (mirrors
+  // Python's own convention) -- a plugin annotation for other tooling (e.g.
+  // display styling), not a physical input the user should see or edit.
+  for (const key of Object.keys(flat)) {
+    if (key.startsWith("_")) {
+      delete flat[key];
+    }
+  }
   // Re-insert trailing keys last -- deleting and re-adding moves a key to the
   // end of a plain object's insertion-order iteration.
   for (const key of _TRAILING_DISPLAY_KEYS) {

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -148,8 +148,7 @@ class TestBoulderUtils:
         assert edge["data"]["target"] == "reactor2"
 
     def test_config_to_cyto_elements_promotes_is_energy_stream_property(self):
-        """A connection's `_is_energy_stream` property promotes to the same
-        (still underscored) edge data key.
+        """A connection's `_is_energy_stream` property promotes to the edge data key.
 
         Mirrors the existing `mass_flow_rate`/`valve_coeff` promotion so a
         host plugin (e.g. a real Wall additionally flagged as an energy

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -147,6 +147,86 @@ class TestBoulderUtils:
         assert edge["data"]["source"] == "reactor1"
         assert edge["data"]["target"] == "reactor2"
 
+    def test_config_to_cyto_elements_promotes_is_energy_stream_property(self):
+        """A connection's `_is_energy_stream` property promotes to the same
+        (still underscored) edge data key.
+
+        Mirrors the existing `mass_flow_rate`/`valve_coeff` promotion so a
+        host plugin (e.g. a real Wall additionally flagged as an energy
+        stream) can drive frontend styling from a top-level data attribute,
+        the same way Cytoscape selectors already key on e.g. `[?stream_point]`.
+        The underscore prefix marks "internal display machinery, not a
+        user-facing field" consistently at every layer -- kept on the
+        promoted edge-data key too, not just the Properties-panel-facing
+        properties key.
+        """
+        config = {
+            "nodes": [
+                {"id": "a", "type": "Reservoir", "properties": {}},
+                {"id": "b", "type": "IdealGasReactor", "properties": {}},
+            ],
+            "connections": [
+                {
+                    "id": "w1",
+                    "source": "a",
+                    "target": "b",
+                    "type": "Wall",
+                    "properties": {"_is_energy_stream": True},
+                }
+            ],
+        }
+
+        elements = config_to_cyto_elements(config)
+        edges = [elem for elem in elements if "source" in elem["data"]]
+
+        assert len(edges) == 1
+        assert edges[0]["data"]["_is_energy_stream"] is True
+
+    def test_config_to_cyto_elements_invokes_plugin_synthesizers(self, monkeypatch):
+        """Registered `cyto_element_synthesizers` contribute extra elements.
+
+        Lets a host represent a concept that never becomes a real STONE
+        node/connection (e.g. a non-physical energy source) in the graph,
+        without `config_to_cyto_elements` knowing what that concept is.
+        """
+        import boulder.cantera_converter as cc
+
+        def fake_synthesizer(cfg):
+            return [{"data": {"id": "synthetic", "label": "Synthetic"}}]
+
+        plugins = cc.BoulderPlugins()
+        plugins.cyto_element_synthesizers = [fake_synthesizer]
+        monkeypatch.setattr(cc, "get_plugins", lambda: plugins)
+
+        config = {"nodes": [], "connections": []}
+        elements = config_to_cyto_elements(config)
+
+        assert elements == [{"data": {"id": "synthetic", "label": "Synthetic"}}]
+
+    def test_config_to_cyto_elements_synthesizer_receives_unmutated_config(
+        self, monkeypatch
+    ):
+        """Synthesizers must see the exact config passed in, never a copy/mutation."""
+        import boulder.cantera_converter as cc
+
+        captured = {}
+
+        def capturing_synthesizer(cfg):
+            captured["config"] = cfg
+            return []
+
+        plugins = cc.BoulderPlugins()
+        plugins.cyto_element_synthesizers = [capturing_synthesizer]
+        monkeypatch.setattr(cc, "get_plugins", lambda: plugins)
+
+        config = {
+            "nodes": [{"id": "a", "type": "Reservoir", "properties": {}}],
+            "connections": [],
+        }
+        config_to_cyto_elements(config)
+
+        assert captured["config"] is config
+
 
 @pytest.mark.unit
 class TestBoulderCallbacks:


### PR DESCRIPTION
Lets a registered plugin synthesize extra Cytoscape nodes/edges purely for display, without Boulder's Cantera build phase ever resolving them as real STONE nodes/connections. Also promotes an is_energy_stream connection property to top-level edge data so it can drive a dotted-line style, and hides underscore-prefixed properties from the Properties panel so internal
flags like this stay invisible to the user.