### PR TITLE
Fix simulations getting stuck at "Running..." forever on NaN results

### DIFF
--- a/boulder/api/routes/simulations.py
+++ b/boulder/api/routes/simulations.py
@@ -75,6 +75,21 @@ def _require_positive(value: float, name: str) -> None:
         raise HTTPException(status_code=422, detail=f"{name} must be > 0")
 
 
+def _first_finite(*values: Any, default: float) -> float:
+    """Return the first non-``None`` value in *values*, else *default*.
+
+    Used to resolve a run-duration/step field from an ordered list of
+    fallback sources (body override, legacy config keys, the current
+    grid/advance_time schema) without a nested ``dict.get(key, dict.get(...))``
+    chain, which mypy cannot always narrow to a definite non-``None`` type by
+    the time it reaches the final ``float(...)`` call.
+    """
+    for v in values:
+        if v is not None:
+            return float(v)
+    return default
+
+
 def _resolve_run_grid(
     config: Dict[str, Any],
     body_simulation_time: Optional[float],
@@ -91,28 +106,21 @@ def _resolve_run_grid(
     settings = config.get("settings", {}) or {}
     solver = settings.get("solver") or {}
     grid = solver.get("grid")
+    grid = grid if isinstance(grid, dict) else {}
     # The current schema (settings.solver.grid.{start,stop,dt} for advance_grid/
     # micro_step, or settings.solver.advance_time for the flat "advance" kind)
     # is checked before the legacy top-level end_time/max_time/dt/time_step
     # keys, so total_time/progress reporting reflects the real grid even
     # though nothing here writes those legacy keys.
-    grid_stop = grid.get("stop") if isinstance(grid, dict) else None
-    grid_dt = grid.get("dt") if isinstance(grid, dict) else None
-    settings_simulation_time = float(
-        settings.get(
-            "end_time",
-            settings.get(
-                "max_time",
-                grid_stop
-                if grid_stop is not None
-                else solver.get("advance_time", 10.0),
-            ),
-        )
+    settings_simulation_time = _first_finite(
+        settings.get("end_time"),
+        settings.get("max_time"),
+        grid.get("stop"),
+        solver.get("advance_time"),
+        default=10.0,
     )
-    settings_time_step = float(
-        settings.get(
-            "dt", settings.get("time_step", grid_dt if grid_dt is not None else 1.0)
-        )
+    settings_time_step = _first_finite(
+        settings.get("dt"), settings.get("time_step"), grid.get("dt"), default=1.0
     )
     simulation_time = (
         body_simulation_time

--- a/boulder/api/routes/simulations.py
+++ b/boulder/api/routes/simulations.py
@@ -19,7 +19,7 @@ from pydantic import BaseModel
 from ...cantera_converter import DualCanteraConverter
 from ...config import TRANSIENT_SOLVER_KINDS, synthesize_default_group
 from ...simulation_worker import SimulationWorker
-from ..sse import simulation_event_stream
+from ..sse import sanitize_for_json, simulation_event_stream
 
 logger = logging.getLogger(__name__)
 
@@ -89,10 +89,31 @@ def _resolve_run_grid(
     transform the submitted config exactly like a run would.
     """
     settings = config.get("settings", {}) or {}
+    solver = settings.get("solver") or {}
+    grid = solver.get("grid")
+    # The current schema (settings.solver.grid.{start,stop,dt} for advance_grid/
+    # micro_step, or settings.solver.advance_time for the flat "advance" kind)
+    # is checked before the legacy top-level end_time/max_time/dt/time_step
+    # keys, so total_time/progress reporting reflects the real grid even
+    # though nothing here writes those legacy keys.
+    grid_stop = grid.get("stop") if isinstance(grid, dict) else None
+    grid_dt = grid.get("dt") if isinstance(grid, dict) else None
     settings_simulation_time = float(
-        settings.get("end_time", settings.get("max_time", 10.0))
+        settings.get(
+            "end_time",
+            settings.get(
+                "max_time",
+                grid_stop
+                if grid_stop is not None
+                else solver.get("advance_time", 10.0),
+            ),
+        )
     )
-    settings_time_step = float(settings.get("dt", settings.get("time_step", 1.0)))
+    settings_time_step = float(
+        settings.get(
+            "dt", settings.get("time_step", grid_dt if grid_dt is not None else 1.0)
+        )
+    )
     simulation_time = (
         body_simulation_time
         if body_simulation_time is not None
@@ -269,13 +290,15 @@ async def get_simulation_results(sim_id: str, cleanup: bool = False) -> Dict[str
     progress = worker.get_progress()
 
     if not progress.is_complete and not progress.error_message:
-        return {
-            "status": "running",
-            "is_complete": False,
-            "times": progress.times,
-            "reactors_series": progress.reactors_series,
-            "total_time": progress.total_time,
-        }
+        return sanitize_for_json(
+            {
+                "status": "running",
+                "is_complete": False,
+                "times": progress.times,
+                "reactors_series": progress.reactors_series,
+                "total_time": progress.total_time,
+            }
+        )
 
     from ..sse import _serialise_reports
 
@@ -300,7 +323,7 @@ async def get_simulation_results(sim_id: str, cleanup: bool = False) -> Dict[str
     if cleanup:
         del _simulations[sim_id]
 
-    return result
+    return sanitize_for_json(result)
 
 
 @router.delete("/{sim_id}")
@@ -374,13 +397,19 @@ async def check_simulation_cache(
         fingerprint[:12],
     )
     meta = cached.get("meta", {})
-    return {
-        "cached": True,
-        "fingerprint": fingerprint,
-        "result": cached.get("gui_payload", {}),
-        "config_snapshot": cached.get("config_snapshot", {}),
-        "meta": meta,
-    }
+    # gui_payload was written to disk unsanitized (result_cache/payload_store
+    # both dump the raw worker output) — a cached NaN/Infinity would otherwise
+    # reproduce the exact silent-hang bug this endpoint's live-run sibling
+    # (get_simulation_results) already guards against.
+    return sanitize_for_json(
+        {
+            "cached": True,
+            "fingerprint": fingerprint,
+            "result": cached.get("gui_payload", {}),
+            "config_snapshot": cached.get("config_snapshot", {}),
+            "meta": meta,
+        }
+    )
 
 
 @router.get("/cached")
@@ -397,13 +426,15 @@ async def get_cached_result(request: Request) -> Dict[str, Any]:
         return {"cached": False}
 
     meta = cached.get("meta", {})
-    return {
-        "cached": True,
-        "fingerprint": fingerprint,
-        "result": cached.get("gui_payload", {}),
-        "config_snapshot": cached.get("config_snapshot", {}),
-        "meta": meta,
-    }
+    return sanitize_for_json(
+        {
+            "cached": True,
+            "fingerprint": fingerprint,
+            "result": cached.get("gui_payload", {}),
+            "config_snapshot": cached.get("config_snapshot", {}),
+            "meta": meta,
+        }
+    )
 
 
 @router.get("/cached/artifacts/{artifact_name}")

--- a/boulder/api/sse.py
+++ b/boulder/api/sse.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import math
 from typing import Any, AsyncGenerator, Dict
 
 from ..simulation_worker import SimulationWorker
@@ -75,8 +76,31 @@ async def simulation_event_stream(
 
 def _sse_event(event_type: str, data: dict) -> str:
     """Format a single SSE event string."""
-    payload = json.dumps(data, default=str)
+    payload = json.dumps(sanitize_for_json(data), default=str)
     return f"event: {event_type}\ndata: {payload}\n\n"
+
+
+def sanitize_for_json(obj: Any) -> Any:
+    """Recursively replace NaN/Infinity/-Infinity floats with ``None``.
+
+    ``json.dumps`` emits the bare tokens ``NaN``/``Infinity``/``-Infinity``
+    for these values by default (``allow_nan=True``) — valid Python, but
+    **not valid JSON**: a strict consumer (JavaScript's ``JSON.parse``,
+    which every browser uses) throws a ``SyntaxError`` on them. A single
+    NaN anywhere in a large payload (e.g. a derived reactor-report field
+    that divides by zero) then silently breaks the whole parse for
+    whichever caller wraps it in a bare ``try/catch`` — the simulation
+    completes on the backend but the frontend never finds out. Returns a
+    new structure; never mutates the input (some of it, like
+    ``progress.reactors_series``, is live/actively-appended-to state).
+    """
+    if isinstance(obj, float):
+        return obj if math.isfinite(obj) else None
+    if isinstance(obj, dict):
+        return {k: sanitize_for_json(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [sanitize_for_json(v) for v in obj]
+    return obj
 
 
 def _serialise_reports(reports: Dict[str, Any]) -> Dict[str, Any]:

--- a/frontend/src/components/panels/SimulateCard.tsx
+++ b/frontend/src/components/panels/SimulateCard.tsx
@@ -29,9 +29,16 @@ export function SimulateCard() {
   // Steady/Transient mode and its tolerances are edited from the Stage panel
   // (StageCard) — this card only needs to read them to run a simulation.
   const mode = useSolverStore((s) => s.mode);
+  const kind = useSolverStore((s) => s.kind);
   const simTime = useSolverStore((s) => s.simTime);
   const timeStep = useSolverStore((s) => s.timeStep);
   const syncSolverFromConfig = useSolverStore((s) => s.syncFromConfig);
+
+  // Only the flat "advance" kind takes a simulation_time/time_step override —
+  // advance_grid/micro_step carry their own authoritative grid in
+  // settings.solver, which these overrides would otherwise clobber (see
+  // _resolve_run_grid in the backend).
+  const sendTimeOverride = mode === "transient" && kind === "advance";
 
   const [guiActions, setGuiActions] = useState<GuiActionMeta[]>([]);
   const [runningActionId, setRunningActionId] = useState<string | null>(null);
@@ -103,8 +110,8 @@ export function SimulateCard() {
         const cacheResp = await checkSimulationCache(
           cfgRaw,
           mechStr,
-          mode === "transient" ? parseFloat(simTime) : undefined,
-          mode === "transient" ? parseFloat(timeStep) : undefined,
+          sendTimeOverride ? parseFloat(simTime) : undefined,
+          sendTimeOverride ? parseFloat(timeStep) : undefined,
         );
         if (cacheResp.cached) {
           setResults(cacheResp.result);
@@ -123,8 +130,8 @@ export function SimulateCard() {
     try {
       const resp = await startSimulation(
         config,
-        mode === "transient" ? parseFloat(simTime) : undefined,
-        mode === "transient" ? parseFloat(timeStep) : undefined,
+        sendTimeOverride ? parseFloat(simTime) : undefined,
+        sendTimeOverride ? parseFloat(timeStep) : undefined,
       );
       setStarted(resp.simulation_id);
     } catch (err) {
@@ -132,7 +139,7 @@ export function SimulateCard() {
       toast.error(`Failed: ${msg}`);
       setError(msg);
     }
-  }, [config, simTime, timeStep, mode, beginSimulationRun, setStarted, setError, setResults]);
+  }, [config, simTime, timeStep, sendTimeOverride, beginSimulationRun, setStarted, setError, setResults]);
 
   const handleDownloadPy = useCallback(() => {
     if (!pythonCode) return;

--- a/frontend/src/components/panels/SolverDetailsModal.test.tsx
+++ b/frontend/src/components/panels/SolverDetailsModal.test.tsx
@@ -13,7 +13,8 @@ function renderModal(kind: (typeof STEADY_KINDS)[number] = "advance_to_steady_st
   return render(
     <SolverDetailsModal
       open
-      onClose={vi.fn()}
+      onCancel={vi.fn()}
+      onDone={vi.fn()}
       mode="steady"
       kind={kind}
       kinds={STEADY_KINDS}
@@ -24,6 +25,8 @@ function renderModal(kind: (typeof STEADY_KINDS)[number] = "advance_to_steady_st
       onAtolChange={vi.fn()}
       maxSteps="10000"
       onMaxStepsChange={vi.fn()}
+      startTime="0"
+      onStartTimeChange={vi.fn()}
       simTime="10"
       onSimTimeChange={vi.fn()}
       timeStep="1"

--- a/frontend/src/components/panels/SolverDetailsModal.tsx
+++ b/frontend/src/components/panels/SolverDetailsModal.tsx
@@ -10,7 +10,10 @@ import {
 
 interface SolverDetailsModalProps {
   open: boolean;
-  onClose: () => void;
+  /** Dismiss without persisting (✕, backdrop click, Escape). */
+  onCancel: () => void;
+  /** Persist the edited fields, then dismiss ("Done"). */
+  onDone: () => void;
   mode: SolverMode;
   kind: SolverKind;
   kinds: SolverKind[];
@@ -21,6 +24,8 @@ interface SolverDetailsModalProps {
   onAtolChange: (v: string) => void;
   maxSteps: string;
   onMaxStepsChange: (v: string) => void;
+  startTime: string;
+  onStartTimeChange: (v: string) => void;
   simTime: string;
   onSimTimeChange: (v: string) => void;
   timeStep: string;
@@ -29,7 +34,8 @@ interface SolverDetailsModalProps {
 
 export function SolverDetailsModal({
   open,
-  onClose,
+  onCancel,
+  onDone,
   mode,
   kind,
   kinds,
@@ -40,6 +46,8 @@ export function SolverDetailsModal({
   onAtolChange,
   maxSteps,
   onMaxStepsChange,
+  startTime,
+  onStartTimeChange,
   simTime,
   onSimTimeChange,
   timeStep,
@@ -48,11 +56,11 @@ export function SolverDetailsModal({
   useEffect(() => {
     if (!open) return;
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
+      if (e.key === "Escape") onCancel();
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [open, onClose]);
+  }, [open, onCancel]);
 
   if (!open) return null;
 
@@ -61,7 +69,7 @@ export function SolverDetailsModal({
       data-testid="solver-details-modal"
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
       onClick={(e) => {
-        if (e.target === e.currentTarget) onClose();
+        if (e.target === e.currentTarget) onCancel();
       }}
     >
       <div
@@ -73,7 +81,7 @@ export function SolverDetailsModal({
           <h2 id="solver-details-title" className="text-lg font-semibold text-foreground">
             Solver details
           </h2>
-          <Button onClick={onClose} variant="ghost" size="icon" className="text-lg" aria-label="Close">
+          <Button onClick={onCancel} variant="ghost" size="icon" className="text-lg" aria-label="Close">
             ×
           </Button>
         </div>
@@ -159,8 +167,21 @@ export function SolverDetailsModal({
 
           {mode === "transient" && (
             <div className="grid grid-cols-2 gap-2">
+              {kind === "advance_grid" && (
+                <label className="block text-xs text-muted-foreground col-span-2">
+                  Start (s)
+                  <input
+                    data-testid="transient-start"
+                    type="number"
+                    value={startTime}
+                    onChange={(e) => onStartTimeChange(e.target.value)}
+                    className="block w-full mt-1 px-2 py-1.5 text-sm rounded-md bg-input text-foreground border border-border"
+                    step="0.1"
+                  />
+                </label>
+              )}
               <label className="block text-xs text-muted-foreground">
-                Time (s)
+                {kind === "advance_grid" ? "Stop (s)" : "Time (s)"}
                 <input
                   data-testid="transient-time"
                   type="number"
@@ -188,7 +209,10 @@ export function SolverDetailsModal({
         </div>
 
         <div className="flex justify-end gap-2 p-4 border-t border-border shrink-0">
-          <Button onClick={onClose} variant="primary" size="sm">
+          <Button onClick={onCancel} variant="secondary" size="sm">
+            Cancel
+          </Button>
+          <Button onClick={onDone} variant="primary" size="sm">
             Done
           </Button>
         </div>

--- a/frontend/src/components/panels/StageCard.test.tsx
+++ b/frontend/src/components/panels/StageCard.test.tsx
@@ -155,6 +155,38 @@ describe("StageCard", () => {
       expect(grid.dt).toBeCloseTo(0.5);
     });
 
+    it("dismissing Solver Details via Cancel does not write anything back into config.settings.solver", () => {
+      mockConfig = {
+        ...mockConfig,
+        settings: { solver: { kind: "advance_grid", mode: "transient", grid: { start: 0, stop: 5e-8, dt: 1e-11 } } },
+      };
+      useSolverStore.setState({ mode: "transient", kind: "advance_grid", simTime: "10", timeStep: "1", startTime: "0" });
+      render(<StageCard stageId="torch_stage" />);
+      openSolverDetails();
+      fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+      expect(mockSetConfig).not.toHaveBeenCalled();
+    });
+
+    it('Solver Details "Done" merges into an existing grid, preserving grid.start', () => {
+      mockConfig = {
+        ...mockConfig,
+        settings: { solver: { kind: "advance_grid", mode: "transient", grid: { start: 3, stop: 5e-8, dt: 1e-11 } } },
+      };
+      useSolverStore.setState({ mode: "transient", kind: "advance_grid", startTime: "3", simTime: "20", timeStep: "0.5" });
+      render(<StageCard stageId="torch_stage" />);
+      openSolverDetails();
+      mockSetConfig.mockClear();
+      closeSolverDetailsDone();
+      expect(mockSetConfig).toHaveBeenCalledOnce();
+      const [updatedConfig] = mockSetConfig.mock.calls[0];
+      const solver = (updatedConfig.settings as Record<string, unknown>)
+        .solver as Record<string, unknown>;
+      const grid = solver.grid as Record<string, unknown>;
+      expect(grid.start).toBeCloseTo(3);
+      expect(grid.stop).toBeCloseTo(20);
+      expect(grid.dt).toBeCloseTo(0.5);
+    });
+
     it("a single materialized group (e.g. 'default') still edits config.settings.solver, not config.groups", () => {
       const groups = {
         default: { stage_order: 1, mechanism: "gri30.yaml", solver: { kind: "advance_to_steady_state" } },

--- a/frontend/src/components/panels/StageCard.tsx
+++ b/frontend/src/components/panels/StageCard.tsx
@@ -27,6 +27,7 @@ function deriveLocalSolverState(solver: Record<string, unknown> | undefined) {
     rtol: solver?.rtol != null ? String(solver.rtol) : "1e-9",
     atol: solver?.atol != null ? String(solver.atol) : "1e-15",
     maxSteps: solver?.max_steps != null ? String(solver.max_steps) : "10000",
+    startTime: String(grid?.start ?? "0"),
     simTime: String(grid?.stop ?? solver?.advance_time ?? "10"),
     timeStep: String(grid?.dt ?? "1"),
   };
@@ -63,6 +64,7 @@ export function StageCard({ stageId }: Props) {
   const globalRtol = useSolverStore((s) => s.rtol);
   const globalAtol = useSolverStore((s) => s.atol);
   const globalMaxSteps = useSolverStore((s) => s.maxSteps);
+  const globalStartTime = useSolverStore((s) => s.startTime);
   const globalSimTime = useSolverStore((s) => s.simTime);
   const globalTimeStep = useSolverStore((s) => s.timeStep);
   const setGlobalMode = useSolverStore((s) => s.setMode);
@@ -70,6 +72,7 @@ export function StageCard({ stageId }: Props) {
   const setGlobalRtol = useSolverStore((s) => s.setRtol);
   const setGlobalAtol = useSolverStore((s) => s.setAtol);
   const setGlobalMaxSteps = useSolverStore((s) => s.setMaxSteps);
+  const setGlobalStartTime = useSolverStore((s) => s.setStartTime);
   const setGlobalSimTime = useSolverStore((s) => s.setSimTime);
   const setGlobalTimeStep = useSolverStore((s) => s.setTimeStep);
 
@@ -83,12 +86,13 @@ export function StageCard({ stageId }: Props) {
   // --- Local, per-stage-scoped solver state (multi-stage configs only) ---
   const stageSolver = config.groups?.[stageId]?.solver;
   const [localState, setLocalState] = useState(() => deriveLocalSolverState(stageSolver));
-  const { mode: localMode, kind: localKind, rtol: localRtol, atol: localAtol, maxSteps: localMaxSteps, simTime: localSimTime, timeStep: localTimeStep } = localState;
+  const { mode: localMode, kind: localKind, rtol: localRtol, atol: localAtol, maxSteps: localMaxSteps, startTime: localStartTime, simTime: localSimTime, timeStep: localTimeStep } = localState;
   const setLocalMode = (v: SolverMode) => setLocalState((s) => ({ ...s, mode: v }));
   const setLocalKind = (v: SolverKind) => setLocalState((s) => ({ ...s, kind: v }));
   const setLocalRtol = (v: string) => setLocalState((s) => ({ ...s, rtol: v }));
   const setLocalAtol = (v: string) => setLocalState((s) => ({ ...s, atol: v }));
   const setLocalMaxSteps = (v: string) => setLocalState((s) => ({ ...s, maxSteps: v }));
+  const setLocalStartTime = (v: string) => setLocalState((s) => ({ ...s, startTime: v }));
   const setLocalSimTime = (v: string) => setLocalState((s) => ({ ...s, simTime: v }));
   const setLocalTimeStep = (v: string) => setLocalState((s) => ({ ...s, timeStep: v }));
 
@@ -111,11 +115,13 @@ export function StageCard({ stageId }: Props) {
   const rtol = isMultiStage ? localRtol : globalRtol;
   const atol = isMultiStage ? localAtol : globalAtol;
   const maxSteps = isMultiStage ? localMaxSteps : globalMaxSteps;
+  const startTime = isMultiStage ? localStartTime : globalStartTime;
   const simTime = isMultiStage ? localSimTime : globalSimTime;
   const timeStep = isMultiStage ? localTimeStep : globalTimeStep;
   const onRtolChange = isMultiStage ? setLocalRtol : setGlobalRtol;
   const onAtolChange = isMultiStage ? setLocalAtol : setGlobalAtol;
   const onMaxStepsChange = isMultiStage ? setLocalMaxSteps : setGlobalMaxSteps;
+  const onStartTimeChange = isMultiStage ? setLocalStartTime : setGlobalStartTime;
   const onSimTimeChange = isMultiStage ? setLocalSimTime : setGlobalSimTime;
   const onTimeStepChange = isMultiStage ? setLocalTimeStep : setGlobalTimeStep;
 
@@ -201,24 +207,54 @@ export function StageCard({ stageId }: Props) {
     [config, fileName, isMultiStage, stageId, setConfig, setGlobalKind],
   );
 
+  // Builds the transient-specific fields, merging into (not replacing) an
+  // existing grid dict so unrelated keys (e.g. an explicit list grid, or a
+  // `start` the modal doesn't have a field for on other kinds) survive.
+  const buildTransientExtra = useCallback(
+    (currentSolver: Record<string, unknown>): Record<string, unknown> => {
+      if (mode !== "transient") return {};
+      if (kind === "advance") return { advance_time: parseFloat(simTime) };
+      if (kind === "advance_grid") {
+        const currentGrid = currentSolver.grid;
+        const gridBase =
+          currentGrid && typeof currentGrid === "object" && !Array.isArray(currentGrid)
+            ? (currentGrid as Record<string, unknown>)
+            : {};
+        return {
+          grid: {
+            ...gridBase,
+            start: parseFloat(startTime),
+            stop: parseFloat(simTime),
+            dt: parseFloat(timeStep),
+          },
+        };
+      }
+      // micro_step isn't represented by this modal's fields (it uses
+      // t_total/chunk_dt/max_dt, not grid.start/stop/dt) — leave it alone.
+      return {};
+    },
+    [mode, kind, startTime, simTime, timeStep],
+  );
+
   // Persists tolerance and transient-grid values from the modal into
   // whichever solver block this stage's panel is editing.
   const handleSolverDetailsDone = useCallback(() => {
     const rtolNum = parseFloat(rtol);
     const atolNum = parseFloat(atol);
     const maxStepsNum = parseInt(maxSteps, 10);
+    const currentGroups = config.groups ?? {};
+    const currentGroup = currentGroups[stageId] ?? {};
+    const currentSettings = (config.settings as Record<string, unknown>) ?? {};
+    const currentSolver = (isMultiStage
+      ? (currentGroup.solver ?? {})
+      : (currentSettings.solver ?? {})) as Record<string, unknown>;
     const extra: Record<string, unknown> = {
       ...(Number.isFinite(rtolNum) ? { rtol: rtolNum } : {}),
       ...(Number.isFinite(atolNum) ? { atol: atolNum } : {}),
       ...(Number.isFinite(maxStepsNum) ? { max_steps: maxStepsNum } : {}),
-      ...(mode === "transient"
-        ? { grid: { stop: parseFloat(simTime), dt: parseFloat(timeStep) } }
-        : {}),
+      ...buildTransientExtra(currentSolver),
     };
     if (isMultiStage) {
-      const currentGroups = config.groups ?? {};
-      const currentGroup = currentGroups[stageId] ?? {};
-      const currentSolver = currentGroup.solver ?? {};
       setConfig(
         {
           ...config,
@@ -230,8 +266,6 @@ export function StageCard({ stageId }: Props) {
         fileName,
       );
     } else {
-      const currentSettings = (config.settings as Record<string, unknown>) ?? {};
-      const currentSolver = (currentSettings.solver as Record<string, unknown>) ?? {};
       setConfig(
         {
           ...config,
@@ -247,14 +281,19 @@ export function StageCard({ stageId }: Props) {
     rtol,
     atol,
     maxSteps,
-    mode,
-    simTime,
-    timeStep,
+    buildTransientExtra,
     isMultiStage,
     stageId,
     setConfig,
     setDetailsOpen,
   ]);
+
+  // Dismiss without persisting — the ✕ button, backdrop click, and Escape
+  // key should not silently commit whatever's in the (possibly-unedited)
+  // fields back into the config.
+  const handleSolverDetailsCancel = useCallback(() => {
+    setDetailsOpen(false);
+  }, [setDetailsOpen]);
 
   const kinds = mode === "steady" ? STEADY_KINDS : TRANSIENT_KINDS;
 
@@ -366,7 +405,8 @@ export function StageCard({ stageId }: Props) {
 
       <SolverDetailsModal
         open={detailsOpen}
-        onClose={handleSolverDetailsDone}
+        onCancel={handleSolverDetailsCancel}
+        onDone={handleSolverDetailsDone}
         mode={mode}
         kind={kind}
         kinds={kinds}
@@ -377,6 +417,8 @@ export function StageCard({ stageId }: Props) {
         onAtolChange={onAtolChange}
         maxSteps={maxSteps}
         onMaxStepsChange={onMaxStepsChange}
+        startTime={startTime}
+        onStartTimeChange={onStartTimeChange}
         simTime={simTime}
         onSimTimeChange={onSimTimeChange}
         timeStep={timeStep}

--- a/frontend/src/components/simulation/SimulationOverlay.tsx
+++ b/frontend/src/components/simulation/SimulationOverlay.tsx
@@ -2,7 +2,7 @@ import { useSimulationStore } from "@/stores/simulationStore";
 
 // Sub-steps within a single stage, in order.
 // Each occupies an equal slice of that stage's bar segment.
-const SUBSTEPS = ["Building", "Integrating", "Outputs"] as const;
+const SUBSTEPS = ["Building", "Integrating", "Generating output"] as const;
 type Substep = typeof SUBSTEPS[number];
 
 function currentSubstep(
@@ -11,7 +11,7 @@ function currentSubstep(
 ): Substep {
   if (!buildComplete) return "Building";
   if (integrationPoints > 1) return "Integrating";
-  return "Outputs";
+  return "Generating output";
 }
 
 export function SimulationOverlay() {

--- a/frontend/src/hooks/useSimulationSSE.ts
+++ b/frontend/src/hooks/useSimulationSSE.ts
@@ -24,8 +24,12 @@ export function useSimulationSSE() {
       try {
         const data = JSON.parse(e.data) as SimulationProgress;
         updateProgress(data);
-      } catch {
-        /* ignore parse errors */
+      } catch (err) {
+        // Non-fatal (unlike the "complete" handler below): a dropped
+        // intermediate tick self-heals on the next poll, so this only logs
+        // rather than surfacing a run error the user would have to dismiss.
+        // eslint-disable-next-line no-console
+        console.error("Failed to process simulation 'progress' event:", err);
       }
     });
 
@@ -85,8 +89,19 @@ export function useSimulationSSE() {
             })),
           });
         }
-      } catch {
-        /* ignore parse errors */
+      } catch (err) {
+        // A parse/processing failure here must not leave the caller stuck
+        // in isRunning=true forever with no feedback — surface it as a run
+        // error (this previously failed silently, e.g. when the payload
+        // contained a NaN, invalid JSON per the JSON spec even though
+        // Python's json.dumps emits it by default).
+        // eslint-disable-next-line no-console
+        console.error("Failed to process simulation 'complete' event:", err);
+        setError(
+          err instanceof Error
+            ? `Failed to parse simulation results: ${err.message}`
+            : "Failed to parse simulation results.",
+        );
       }
       source.close();
     });

--- a/frontend/src/stores/solverStore.ts
+++ b/frontend/src/stores/solverStore.ts
@@ -10,6 +10,7 @@ interface SolverState {
   rtol: string;
   atol: string;
   maxSteps: string;
+  startTime: string;
   simTime: string;
   timeStep: string;
 
@@ -18,10 +19,11 @@ interface SolverState {
   setRtol: (v: string) => void;
   setAtol: (v: string) => void;
   setMaxSteps: (v: string) => void;
+  setStartTime: (v: string) => void;
   setSimTime: (v: string) => void;
   setTimeStep: (v: string) => void;
 
-  /** Re-derive mode/kind/rtol/atol/maxSteps from a freshly loaded config.settings. */
+  /** Re-derive mode/kind/rtol/atol/maxSteps/startTime/simTime/timeStep from a freshly loaded config.settings. */
   syncFromConfig: (settings: unknown) => void;
 }
 
@@ -48,6 +50,7 @@ export const useSolverStore = create<SolverState>((set, get) => ({
   rtol: "1e-9",
   atol: "1e-15",
   maxSteps: "10000",
+  startTime: "0",
   simTime: "10",
   timeStep: "1",
 
@@ -56,6 +59,7 @@ export const useSolverStore = create<SolverState>((set, get) => ({
   setRtol: (rtol) => set({ rtol }),
   setAtol: (atol) => set({ atol }),
   setMaxSteps: (maxSteps) => set({ maxSteps }),
+  setStartTime: (startTime) => set({ startTime }),
   setSimTime: (simTime) => set({ simTime }),
   setTimeStep: (timeStep) => set({ timeStep }),
 
@@ -63,6 +67,7 @@ export const useSolverStore = create<SolverState>((set, get) => ({
     const solver = (settings as Record<string, unknown> | null | undefined)?.solver as
       | Record<string, unknown>
       | undefined;
+    const grid = solver?.grid as Record<string, unknown> | undefined;
     const k = solver?.kind as string | undefined;
     const m = solver?.mode as SolverMode | undefined;
     const state = get();
@@ -72,6 +77,9 @@ export const useSolverStore = create<SolverState>((set, get) => ({
       rtol: solver?.rtol != null ? String(solver.rtol) : state.rtol,
       atol: solver?.atol != null ? String(solver.atol) : state.atol,
       maxSteps: solver?.max_steps != null ? String(solver.max_steps) : state.maxSteps,
+      startTime: grid?.start != null ? String(grid.start) : state.startTime,
+      simTime: String(grid?.stop ?? solver?.advance_time ?? state.simTime),
+      timeStep: grid?.dt != null ? String(grid.dt) : state.timeStep,
     });
   },
 }));

--- a/tests/test_result_cache.py
+++ b/tests/test_result_cache.py
@@ -23,6 +23,7 @@ from unittest.mock import MagicMock
 import pytest
 from fastapi import FastAPI
 
+from boulder.api.routes.simulations import _resolve_run_grid
 from boulder.result_cache import (
     CACHE_VERSION,
     CacheContributorPlugin,
@@ -108,6 +109,73 @@ class TestComputeFingerprint:
         fp1 = compute_fingerprint(SIMPLE_CONFIG)
         fp2 = compute_fingerprint(SIMPLE_CONFIG, extra={"simulation_time": 10.0})
         assert fp1 != fp2
+
+
+# ---------------------------------------------------------------------------
+# _resolve_run_grid
+# ---------------------------------------------------------------------------
+
+
+class TestResolveRunGrid:
+    """_resolve_run_grid's settings-derived fallback (no body override).
+
+    Regression coverage for a bug where an advance_grid/advance config's
+    real settings.solver.grid.{stop,dt} (or advance_time) was ignored in
+    favor of a hard-coded 10.0/1.0 default, because the fallback only ever
+    looked at the legacy top-level settings.end_time/max_time/dt/time_step
+    keys. That wrong total_time/time_step fed the "Using config parameters"
+    log line and progress.total_time (the run itself, driven by
+    groups.<stage>.solver, was unaffected).
+    """
+
+    def test_advance_grid_stop_dt_used_when_no_legacy_keys_or_override(self):
+        config = {
+            "settings": {
+                "solver": {
+                    "kind": "advance_grid",
+                    "grid": {"start": 0.0, "stop": 5e-8, "dt": 1e-11},
+                }
+            }
+        }
+        simulation_time, time_step = _resolve_run_grid(config, None, None)
+        assert simulation_time == pytest.approx(5e-8)
+        assert time_step == pytest.approx(1e-11)
+        # No override was passed, so the grid must be left untouched.
+        assert config["settings"]["solver"]["grid"] == {
+            "start": 0.0,
+            "stop": 5e-8,
+            "dt": 1e-11,
+        }
+
+    def test_advance_time_used_for_flat_advance_kind(self):
+        config = {"settings": {"solver": {"kind": "advance", "advance_time": 2.5e-6}}}
+        simulation_time, time_step = _resolve_run_grid(config, None, None)
+        assert simulation_time == pytest.approx(2.5e-6)
+        assert time_step == pytest.approx(1.0)  # no dt concept for "advance"
+
+    def test_legacy_end_time_dt_still_take_priority_over_grid(self):
+        config = {
+            "settings": {
+                "end_time": 3.0,
+                "dt": 0.1,
+                "solver": {"kind": "advance_grid", "grid": {"stop": 5e-8, "dt": 1e-11}},
+            }
+        }
+        simulation_time, time_step = _resolve_run_grid(config, None, None)
+        assert simulation_time == pytest.approx(3.0)
+        assert time_step == pytest.approx(0.1)
+
+    def test_body_override_still_takes_priority_over_grid(self):
+        config = {
+            "settings": {
+                "solver": {"kind": "advance_grid", "grid": {"stop": 5e-8, "dt": 1e-11}}
+            }
+        }
+        simulation_time, time_step = _resolve_run_grid(config, 20.0, 0.5)
+        assert simulation_time == pytest.approx(20.0)
+        assert time_step == pytest.approx(0.5)
+        # An explicit override IS authoritative and does get written back.
+        assert config["settings"]["solver"]["grid"]["stop"] == pytest.approx(20.0)
 
 
 # ---------------------------------------------------------------------------
@@ -569,6 +637,57 @@ class TestCachedEndpoint:
         assert data["result"]["status"] == "complete"
         assert "fingerprint" in data
         assert "meta" in data
+
+    def test_cached_endpoint_sanitizes_nan_in_payload(self, tmp_path: Path):
+        """GET /cached and POST /check-cache must not resurrect a cached NaN.
+
+        Regression: gui_payload is written to disk unsanitized (a NaN in a
+        derived reactor-report field survives a save/load round-trip just
+        fine on the Python side), so these two cache-hit endpoints carried
+        the exact same silent-hang bug as the live-run SSE stream — a NaN
+        reaching the browser as the invalid-JSON bare token `NaN` instead of
+        `null`. Both must run their response through the same sanitizer.
+        """
+        from boulder.config import synthesize_default_group
+
+        poisoned_payload = copy.deepcopy(SIMPLE_PAYLOAD)
+        poisoned_payload["reactors_series"]["r1"]["k"] = [float("nan")]
+        # /check-cache fingerprints the submitted config AFTER default-group
+        # synthesis, so the cached snapshot must match that shape (same
+        # normalization used by client_with_cache above).
+        snapshot = copy.deepcopy(SIMPLE_CONFIG)
+        synthesize_default_group(snapshot)
+
+        fingerprint = "n" * 64
+        artifacts_dir = tmp_path / "artifacts_nan"
+        artifacts_dir.mkdir()
+        cache_data = {
+            "fingerprint": fingerprint,
+            "gui_payload": poisoned_payload,
+            "config_snapshot": snapshot,
+            "meta": {"cache_version": CACHE_VERSION, "created_at": time.time()},
+            "artifacts_dir": artifacts_dir,
+        }
+        app = create_app()
+        with TestClient(app) as client:
+            app.state.preloaded_result = cache_data
+            app.state.preloaded_fingerprint = fingerprint
+
+            resp = client.get("/api/simulations/cached")
+            assert resp.status_code == 200
+            body = resp.text
+            assert "NaN" not in body
+            assert resp.json()["result"]["reactors_series"]["r1"]["k"] == [None]
+
+            cfg = tmp_path / "case.yaml"
+            cfg.write_text("x: 1", encoding="utf-8")
+            app.state.preloaded_config_path = str(cfg)
+            resp2 = client.post(
+                "/api/simulations/check-cache", json={"config": SIMPLE_CONFIG}
+            )
+        assert resp2.status_code == 200
+        assert "NaN" not in resp2.text
+        assert resp2.json()["result"]["reactors_series"]["r1"]["k"] == [None]
 
     def test_artifact_missing_returns_404(self, client_with_cache: TestClient):
         """GET /api/simulations/cached/artifacts/missing.txt returns 404."""

--- a/tests/test_sse.py
+++ b/tests/test_sse.py
@@ -1,0 +1,69 @@
+"""Tests for boulder.api.sse.
+
+Asserts:
+- sanitize_for_json replaces NaN/Infinity/-Infinity floats with None, recursively
+  through dicts and lists, leaving everything else untouched.
+- The resulting structure survives a real json.dumps round-trip (regression for
+  a bug where a NaN anywhere in a simulation's reactors_series/reactor_reports
+  made json.dumps emit the bare, non-standard token `NaN` — invalid per the
+  JSON spec, so a strict consumer like JavaScript's JSON.parse throws on it.
+  The frontend's SSE "complete" handler wrapped that parse in a bare try/catch,
+  so the failure was completely silent: the run had finished on the backend,
+  but the UI stayed in "Running..." forever with no results and no error shown).
+"""
+
+from __future__ import annotations
+
+import json
+import math
+
+from boulder.api.sse import sanitize_for_json
+
+
+def test_replaces_nan_with_none():
+    assert sanitize_for_json(float("nan")) is None
+
+
+def test_replaces_infinity_with_none():
+    assert sanitize_for_json(float("inf")) is None
+    assert sanitize_for_json(float("-inf")) is None
+
+
+def test_leaves_finite_floats_and_other_types_untouched():
+    assert sanitize_for_json(1.5) == 1.5
+    assert sanitize_for_json(0.0) == 0.0
+    assert sanitize_for_json("k") == "k"
+    assert sanitize_for_json(None) is None
+    assert sanitize_for_json(True) is True
+
+
+def test_recurses_through_nested_dicts_and_lists():
+    data = {
+        "times": [0.0, 1e-11, 2e-11],
+        "reactors_series": {
+            "plasma": {
+                "radius": [5e-4, 5e-4, 5e-4],
+                "k": [float("nan")] * 3,
+            },
+        },
+        "nested": [{"a": float("inf")}, {"a": 1.0}],
+    }
+    result = sanitize_for_json(data)
+    assert result["reactors_series"]["plasma"]["k"] == [None, None, None]
+    assert result["reactors_series"]["plasma"]["radius"] == [5e-4, 5e-4, 5e-4]
+    assert result["nested"][0]["a"] is None
+    assert result["nested"][1]["a"] == 1.0
+    # Original is untouched (progress.reactors_series is live/actively-appended-to).
+    assert math.isnan(data["reactors_series"]["plasma"]["k"][0])
+
+
+def test_sanitized_payload_survives_strict_json_round_trip():
+    """The actual regression: json.dumps must not emit a bare NaN/Infinity token."""
+    data = {"k": [float("nan"), float("inf"), float("-inf"), 1.23]}
+    payload = json.dumps(sanitize_for_json(data))
+    assert "NaN" not in payload
+    assert "Infinity" not in payload
+    # A strict JSON parser (any real one) would reject this if NaN/Infinity had
+    # leaked through; re-parsing it here is itself part of the regression check.
+    reparsed = json.loads(payload)
+    assert reparsed["k"] == [None, None, None, 1.23]


### PR DESCRIPTION
## Summary

A simulation whose results contain a non-finite float (`NaN`/`Infinity` — e.g. a derived reactor-report field that divides by zero somewhere) would complete **successfully on the backend** but leave the frontend stuck showing **"Running..." forever**, with no results and no error message anywhere.

**Root cause**: `json.dumps` serializes `float('nan')` as the bare token `NaN` by default — valid Python, but **not valid JSON** (the JSON spec has no `NaN`/`Infinity` literal). JavaScript's `JSON.parse` is strict and throws a `SyntaxError` on it. The SSE `"complete"` event handler wrapped that parse in an empty `catch {}` block, so the failure was completely silent — the backend had already written the cache entry and moved on, but the frontend never found out.

## Changes

- `boulder/api/sse.py`: new `sanitize_for_json()` — recursively replaces non-finite floats with `None` before every `json.dumps` call, applied to both the SSE stream (`_sse_event`, covers "progress" and "complete" events) and the REST `/results` endpoint.
- `boulder/api/routes/simulations.py`: the same sanitizer also applied to `/check-cache` and `/cached` — these return `gui_payload` straight from the on-disk cache (written unsanitized), so they carried the identical bug via the cache-hit path, independent of any particular live run. Also extended `_resolve_run_grid`'s fallback chain to consult `settings.solver.grid.{start,stop,dt}` / `advance_time` (the current schema) before defaulting to a hardcoded 10s/1s, since that wrong value was feeding `progress.total_time` and made the "Integrating" progress bar always read ~0%.
- `frontend/src/hooks/useSimulationSSE.ts`: the `"complete"` handler now logs and surfaces a run error (`setError`) instead of silently swallowing a parse failure — this is terminal, so failing loudly is correct. The `"progress"` handler now logs (not `setError`, since a dropped intermediate tick self-heals on the next 0.5s poll).
- A related bug found while chasing this: the Solver Details panel and "Run Simulation" button showed/sent stale hardcoded defaults (`simTime="10"`, `timeStep="1"`) instead of the loaded config's real `grid.start/stop/dt`, and always sent a time/step override that clobbered an `advance_grid`/`micro_step` config's own authoritative grid on every single run. Fixed in `solverStore.ts`, `StageCard.tsx`, `SolverDetailsModal.tsx`, `SimulateCard.tsx`.

## Tests

- `tests/test_sse.py` (new): `sanitize_for_json` unit tests, including a real `json.dumps`/`json.loads` round-trip regression check.
- `tests/test_result_cache.py`: new `TestResolveRunGrid` class (grid/legacy-key/override precedence) + a new `/cached` + `/check-cache` regression test that injects a `NaN` into a cached payload and asserts the response never contains a bare `NaN` token.
- `frontend`: extended `StageCard.test.tsx` (Cancel doesn't persist stale values; Done merges into an existing grid, preserving `start`) and `SolverDetailsModal.test.tsx`.

## Test plan

- [x] `pytest tests/test_result_cache.py tests/test_sse.py` — 44 passed
- [x] `npm run type-check` / `npm run test:unit` (155 passed) / `npm run build` — all clean
- [x] `make qa` (pre-commit --all-files) — clean on the touched files
- [x] Verified live in the browser: a config with a persistently-NaN derived signal now completes and renders results instead of hanging; confirmed via a direct `curl` inspection of the raw SSE bytes that the payload no longer contains a bare `NaN`/`Infinity` token anywhere

🤖 Generated with [Claude Code](https://claude.com/claude-code)