### PR TITLE
feat(runset): upstream scenario/sweep expansion + generic sweep runner

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -152,7 +152,25 @@ Two **profiles** of this one encoding:
 |---|---|---|
 | File | `<cache>/<fp>/result.h5` (+ `meta.json` carries config_snapshot) | `results/<map>_scenarios.h5` |
 | Holds | one result (1..n reactors, groups `r0`,`r1`,…) | many single-reactor results, one group per scenario |
-| Producer / reader | `result_cache.save_result` / `load_result*` | `run_sweep.py` (host) / `api/routes/scenarios.py` |
+| Producer / reader | `result_cache.save_result` / `load_result*` | `sweep_runner.py` (or a host `run_sweep.py`) / `api/routes/scenarios.py` |
+
+#### Run-set expansion and the generic sweep runner
+
+`runset.py` is the reference implementation of the STONE `scenario:`/`sweep:` semantics
+(STONE_SPECIFICATIONS.md §14): `expand_scenarios` (union run-set, id-keyed `deep_merge`, sweep-path
+resolution against the schema registry), `run_set_size` (the cheap count the `/api/sweep` availability
+endpoint uses — same module, so the count can never drift from the expansion), `sweeps_of`,
+`sweep_axis_values`, `resolve_store_path`, and `load_yaml_with_inheritance` (`from:` chains;
+`scenario:` is deliberately not inherited, `sweep:` is).
+
+`sweep_runner.py` (`python -m boulder.sweep_runner <config.yaml>`) is the generic out-of-process
+runner behind the Run Sweep button: expand → skip runs whose per-scenario fingerprint is unchanged
+(incremental cache; `BOULDER_NO_CACHE` recreates the store) → solve via `DualCanteraConverter` →
+`write_payload` one group per scenario → prune groups whose id left the run-set. Host packages that
+need process setup (mechanism search paths), mechanism-path resolution, or extra per-scenario KPI
+attrs register their own thin wrapper via `plugins.sweep_runner` and pass the `setup` /
+`resolve_mechanism` / `scenario_attrs` hooks to `sweep_runner.run`; sweep-id naming is customized via
+`plugins.sweep_symbols`.
 
 Both call `payload_store.gui_payload_from_solution_array` to rebuild the same `SimulationResults` the
 GUI renders. `CACHE_VERSION` (in `result_cache.py`) gates cache entries; `PAYLOAD_SCHEMA` (== the root

--- a/STONE_SPECIFICATIONS.md
+++ b/STONE_SPECIFICATIONS.md
@@ -1263,9 +1263,12 @@ ______________________________________________________________________
 ## 14. Inline run-set variations — `scenario:` and `sweep:`
 
 A STONE file may declare multiple runs inline, instead of a glob of separate overlay files. Boulder
-validates and passes these blocks through; a host's expansion/reporting layer turns them into the
-run set (one config per run). They never alter the topology a single run sees — each expanded run is
-the base with its overlay/patch deep-merged, and the directives stripped.
+validates and passes these blocks through single-run normalization; `boulder.runset.expand_scenarios`
+is the **reference implementation** that turns them into the run set (one config per run), and
+`python -m boulder.sweep_runner` is the generic runner that solves it into the collection store.
+Hosts customize naming/validation through hooks (`plugins.sweep_symbols`, `schema_entry`) rather
+than re-implementing the semantics. The directives never alter the topology a single run sees —
+each expanded run is the base with its overlay/patch deep-merged, and the directives stripped.
 
 ### `scenario:` — a mapping of `id → overlay`
 

--- a/boulder/api/routes/sweep.py
+++ b/boulder/api/routes/sweep.py
@@ -25,6 +25,10 @@ from typing import Any, Dict, Optional
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel
 
+from ...runset import resolve_store_path, run_set_size, sweeps_of
+
+__all__ = ["has_run_set", "resolve_store_path", "router"]
+
 router = APIRouter()
 
 
@@ -41,41 +45,9 @@ _SCENARIO_RE = re.compile(r"scenario\s+(\d+)\s*/\s*(\d+)", re.IGNORECASE)
 _RUNNER_NAME = "run_sweep.py"
 
 
-def _sweep_points(sweeps: Dict[str, Any]) -> int:
-    """Cartesian-product size of a sweep block's axes (generic; no host import)."""
-    if not isinstance(sweeps, dict) or not sweeps:
-        return 0
-    total = 1
-    for axis in sweeps.values():
-        if not isinstance(axis, dict):
-            continue
-        if axis.get("values") is not None:
-            n = len(axis["values"])
-        elif axis.get("num") is not None:
-            n = int(axis["num"])
-        elif axis.get("npoints") is not None:
-            n = int(axis["npoints"])
-        else:
-            n = 0
-        total *= max(n, 0)
-    return total
-
-
-def _sweep_block(d: Dict[str, Any]) -> Dict[str, Any]:
-    return d.get("sweep") or d.get("sweeps") or {}
-
-
-def _run_set_size(raw: Dict[str, Any]) -> int:
-    """Return the union run-set size (mirrors expand_scenarios without importing it).
-
-    Global sweep points ⊎ each `scenario:` entry (its inner sweep, else 1).
-    """
-    scenario = raw.get("scenario") or {}
-    total = _sweep_points(_sweep_block(raw))  # global sweep points (0 if none)
-    for overlay in scenario.values():
-        inner = _sweep_block(overlay or {})
-        total += _sweep_points(inner) if inner else 1
-    return total
+# Run-set sizing lives in boulder.runset (the reference implementation of the
+# scenario:/sweep: union semantics) — the old local mirror is gone.
+_run_set_size = run_set_size
 
 
 def _local_runner_path_for(config_path: Optional[str]) -> Optional[Path]:
@@ -96,28 +68,9 @@ def has_run_set(raw: Dict[str, Any], config_path: Optional[str]) -> bool:
     request-scoped sweep routes and the app-startup lifespan can share one
     detection rule instead of re-deciding "is this a sweep config?" twice.
     """
-    if raw.get("scenario") or _sweep_block(raw):
+    if raw.get("scenario") or sweeps_of(raw):
         return True
     return _local_runner_path_for(config_path) is not None
-
-
-def resolve_store_path(
-    raw: Dict[str, Any], config_path: Optional[str]
-) -> Optional[Path]:
-    """Return the collection store a run-set writes to, or ``None``.
-
-    Declared via ``metadata.extra.scenario_store`` or the ``<stem>_scenarios.h5``
-    default (must match the runner's default). ``None`` when *config_path* is
-    unset — there is no config to resolve a default against.
-    """
-    if not config_path:
-        return None
-    cfg = Path(config_path).resolve()
-    rel = ((raw.get("metadata") or {}).get("extra") or {}).get("scenario_store")
-    if rel:
-        p = Path(rel)
-        return p if p.is_absolute() else cfg.parent / p
-    return cfg.parent / f"{cfg.stem}_scenarios.h5"
 
 
 def _local_runner_path(request: Request) -> Optional[Path]:

--- a/boulder/cantera_converter.py
+++ b/boulder/cantera_converter.py
@@ -87,6 +87,13 @@ class BoulderPlugins:
     #: sits next to the config. Registered by an external plugin package.
     sweep_runner: Optional[List[str]] = None
 
+    #: Axis-name/path-leaf → symbol mapping used by
+    #: :func:`boulder.runset.expand_scenarios` to label sweep points in
+    #: scenario ids (e.g. ``diameter`` → ``TF_D`` gives ``BASE__TF_D=0.03``).
+    #: Registered by an external plugin package so sweep ids stay consistent
+    #: between the GUI and out-of-process runners. ``None`` → plain axis names.
+    sweep_symbols: Optional[Dict[str, str]] = None
+
     #: GUI branding set by a host plugin: ``{"name": "MyApp", "version": "1.2"}``.
     #: When set, the frontend header shows the host name and version next to
     #: the Boulder title.

--- a/boulder/runset.py
+++ b/boulder/runset.py
@@ -1,0 +1,579 @@
+"""STONE run-set primitives: inline ``scenario:`` / ``sweep:`` expansion.
+
+A STONE YAML may declare parameter variations inline (STONE_SPECIFICATIONS.md,
+Section 14), avoiding a glob of overlay files:
+
+``scenario:``
+    Mapping ``{id: overlay-subtree}``. Each value is a STONE subtree
+    (``metadata``/``settings``/``network``/…) deep-merged onto the base via
+    :func:`deep_merge` (which supports id-keyed ``nodes``/``connections``
+    merging) — exactly the overlay a standalone ``from:`` file carries. The
+    mapping **key is the scenario id**.
+
+``sweep:`` (or ``sweeps:``)
+    Mapping axis name → ``{path, values | min/max/num}``, crossed as a
+    Cartesian product. May appear at the top level (expanded on the base) or
+    *inside* a ``scenario:`` entry (expanded on that scenario only).
+
+This module is the reference implementation of those semantics: the Run Sweep
+API sizes run-sets with :func:`run_set_size`, and the generic
+:mod:`boulder.sweep_runner` expands them with :func:`expand_scenarios`. Host
+packages should call these functions rather than re-implementing the rules.
+
+Everything here is pure config manipulation — no solving, no I/O beyond
+:func:`load_yaml_with_inheritance` — and host-agnostic: host-specific naming
+(axis-label symbols) and schema knowledge enter only through the
+``plugins.sweep_symbols`` registry and the ``schema_entry`` hook.
+"""
+
+from __future__ import annotations
+
+import copy
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Mapping, Optional, Tuple
+
+# ---------------------------------------------------------------------------
+# Deep merge with id-keyed list support (the STONE overlay merge).
+# ---------------------------------------------------------------------------
+
+
+def _is_id_based_list(lst: list) -> bool:
+    """Return whether *lst* is a non-empty list of dicts that all carry ``id``."""
+    return bool(lst) and all(
+        isinstance(item, dict) and "id" in item for item in lst
+    )
+
+
+def _merge_lists_by_id(base_list: list, overlay_list: list) -> list:
+    """Merge two id-keyed lists element-wise by ``id``.
+
+    Elements present in both lists are deep-merged; base-only elements are
+    kept; overlay-only elements are appended (in overlay order).
+    """
+    overlay_by_id = {item["id"]: item for item in overlay_list}
+    result: list = []
+    used_ids: set = set()
+
+    for base_item in base_list:
+        item_id = base_item["id"]
+        if item_id in overlay_by_id:
+            merged = deep_merge(base_item, overlay_by_id[item_id])
+            result.append(merged)
+            used_ids.add(item_id)
+        else:
+            result.append(copy.deepcopy(base_item))
+
+    for overlay_item in overlay_list:
+        item_id = overlay_item["id"]
+        if item_id not in used_ids:
+            result.append(copy.deepcopy(overlay_item))
+
+    return result
+
+
+def deep_merge(base: dict, overlay: dict) -> dict:
+    """Deep-merge *overlay* into *base*. Overlay values win.
+
+    Dicts merge recursively. Lists whose elements all carry an ``id`` field
+    (``nodes``, ``connections``, stage lists) merge element-wise by id instead
+    of being replaced wholesale — the STONE overlay semantics.
+
+    Parameters
+    ----------
+    base : dict
+        The base dictionary.
+    overlay : dict
+        The overlay dictionary (overrides take precedence).
+
+    Returns
+    -------
+    dict
+        A new dictionary with the merged result.
+    """
+    result = copy.deepcopy(base)
+    for key, overlay_value in overlay.items():
+        if (
+            key in result
+            and isinstance(result[key], dict)
+            and isinstance(overlay_value, dict)
+        ):
+            result[key] = deep_merge(result[key], overlay_value)
+        elif (
+            key in result
+            and isinstance(result[key], list)
+            and isinstance(overlay_value, list)
+            and _is_id_based_list(result[key])
+            and _is_id_based_list(overlay_value)
+        ):
+            result[key] = _merge_lists_by_id(result[key], overlay_value)
+        else:
+            result[key] = copy.deepcopy(overlay_value)
+    return result
+
+
+def load_yaml_with_inheritance(path: "str | Path") -> dict:
+    """Load a STONE YAML with optional ``from:`` inheritance.
+
+    If a top-level ``from`` key is present, that file is loaded first
+    (recursively) and deep-merged with the current file content (excluding
+    ``from``). Relative ``from`` paths are resolved against the current file
+    directory.
+
+    The ``scenario:`` directive is **not inherited**: a named scenario mapping
+    declares *this* file's run-set, so a parent's scenarios must not leak into
+    a child (which would re-run them against the child's base). ``sweep:`` /
+    ``sweeps:`` **are** inherited — a child overlay legitimately re-runs the
+    parent's parameter sweep with overrides (e.g. a different mechanism).
+    """
+    from ruamel.yaml import YAML  # noqa: PLC0415 — heavy import kept lazy
+
+    yaml = YAML()
+    yaml.preserve_quotes = True
+    path = Path(path)
+
+    with open(path, "r", encoding="utf-8", errors="replace") as f:
+        data = yaml.load(f)
+
+    if data is None:
+        return {}
+
+    data_dict = dict(data)
+    from_path = data_dict.get("from")
+    if not from_path:
+        return data_dict
+
+    overlay = copy.deepcopy(data_dict)
+    overlay.pop("from", None)
+
+    parent_path = (path.parent / str(from_path)).resolve()
+    base = load_yaml_with_inheritance(parent_path)
+    base.pop("scenario", None)  # the named run-set is not inherited (sweeps are)
+    return deep_merge(base, overlay)
+
+
+# ---------------------------------------------------------------------------
+# Sweep-axis primitives.
+# ---------------------------------------------------------------------------
+
+
+def sweeps_of(block: dict) -> dict:
+    """Return the sweep block of a config/overlay, accepting ``sweep:`` or ``sweeps:``."""
+    return block.get("sweeps") or block.get("sweep") or {}
+
+
+def sweep_axis_values(axis_spec: dict) -> list:
+    """Return the explicit list of sweep values for one axis spec.
+
+    Two forms are supported:
+
+    * ``values: [v0, v1, ...]`` — an explicit list (returned as-is).
+    * ``min`` / ``max`` / ``num`` — a generated, evenly spaced range.
+      ``num`` (alias ``npoints``) is the number of points, inclusive of both
+      endpoints.  Spacing is linear by default; set ``spacing: log`` for a
+      geometric (log-spaced) range.  Generated values are rounded to remove
+      floating-point noise so scenario ids stay clean.
+
+    An explicit ``values`` list takes precedence when both are present.
+    Returns an empty list when the spec declares neither form.
+    """
+    if axis_spec.get("values") is not None:
+        return list(axis_spec["values"])
+
+    if axis_spec.get("min") is None or axis_spec.get("max") is None:
+        return []
+
+    import numpy as np  # noqa: PLC0415
+
+    lo = float(axis_spec["min"])
+    hi = float(axis_spec["max"])
+    num = axis_spec.get("num", axis_spec.get("npoints"))
+    if num is None:
+        raise ValueError("sweep range requires 'num' (or 'npoints')")
+    num = int(num)
+    if num < 1:
+        raise ValueError(f"sweep 'num' must be >= 1, got {num}")
+
+    spacing = str(axis_spec.get("spacing", "linear")).lower()
+    if spacing in ("linear", "lin", "linspace"):
+        values = np.linspace(lo, hi, num)
+    elif spacing in ("log", "logspace", "geometric"):
+        if lo <= 0 or hi <= 0:
+            raise ValueError("log-spaced sweep requires positive 'min' and 'max'")
+        values = np.logspace(np.log10(lo), np.log10(hi), num)
+    else:
+        raise ValueError(f"unknown sweep spacing {spacing!r}; use 'linear' or 'log'")
+
+    return [round(float(v), 10) for v in values]
+
+
+def _sweep_size(sweeps_block: dict) -> int:
+    """Cartesian-product size of a sweep block's axes (0 for an empty block).
+
+    Never raises: a malformed axis counts as 0 so availability endpoints can
+    report a size for any config; :func:`expand_scenarios` is where malformed
+    axes fail loudly.
+    """
+    if not isinstance(sweeps_block, dict) or not sweeps_block:
+        return 0
+    total = 1
+    for axis in sweeps_block.values():
+        try:
+            n = len(sweep_axis_values(axis)) if isinstance(axis, dict) else 0
+        except ValueError:
+            n = 0
+        total *= max(n, 0)
+    return total
+
+
+def run_set_size(raw: Dict[str, Any]) -> int:
+    """Return the union run-set size of a config's ``scenario:``/``sweep:`` blocks.
+
+    Global sweep points ⊎ each ``scenario:`` entry (its inner sweep, else 1) —
+    the same union semantics :func:`expand_scenarios` implements, computed
+    without deep-merging or resolving sweep paths (cheap enough for an
+    availability endpoint).
+    """
+    scenario = raw.get("scenario") or {}
+    total = _sweep_size(sweeps_of(raw))
+    for overlay in scenario.values():
+        inner = sweeps_of(overlay or {})
+        total += _sweep_size(inner) if inner else 1
+    return total
+
+
+def resolve_store_path(
+    raw: Dict[str, Any], config_path: "Optional[str | Path]"
+) -> Optional[Path]:
+    """Return the collection store a run-set writes to, or ``None``.
+
+    Declared via ``metadata.extra.scenario_store`` (resolved relative to the
+    config), else the ``<config-stem>_scenarios.h5`` default next to the
+    config. ``None`` when *config_path* is unset — there is no config to
+    resolve a default against.
+    """
+    if not config_path:
+        return None
+    cfg = Path(config_path).resolve()
+    rel = ((raw.get("metadata") or {}).get("extra") or {}).get("scenario_store")
+    if rel:
+        p = Path(rel)
+        return p if p.is_absolute() else cfg.parent / p
+    return cfg.parent / f"{cfg.stem}_scenarios.h5"
+
+
+# ---------------------------------------------------------------------------
+# Run-set expansion.
+# ---------------------------------------------------------------------------
+
+
+def expand_scenarios(
+    base_raw: dict,
+    *,
+    symbols: Optional[Mapping[str, str]] = None,
+    schema_entry: Optional[Callable[[str], Any]] = None,
+) -> List[Tuple[str, dict]]:
+    """Expand a STONE YAML's inline ``scenario:`` / ``sweep:`` blocks.
+
+    **Union semantics** (not a global cross-product): the run set is the
+    base's global-sweep points **⊎** each ``scenario:`` entry (each expanded
+    across its *own* inner sweep if it declares one). A top-level sweep and
+    the scenarios do not cross-multiply.
+
+    When neither block is present, returns a single ``(scenario_id, base)``
+    tuple using ``metadata.scenario_id`` or ``"BASE"``.
+
+    Parameters
+    ----------
+    base_raw : dict
+        The raw (``from:``-resolved) config. Not mutated.
+    symbols : Mapping[str, str], optional
+        Axis-name/path-leaf → symbol mapping used to label sweep points in
+        scenario ids (e.g. ``diameter`` → ``TF_D`` gives ``BASE__TF_D=0.03``).
+        Defaults to the host-registered ``plugins.sweep_symbols`` (empty when
+        no host registered one). An axis's explicit ``symbol:`` always wins.
+    schema_entry : callable, optional
+        ``kind -> ReactorSchemaEntry | None`` used to expand short-form sweep
+        paths and validate path leaves against registered node schemas.
+        Defaults to :func:`boulder.schema_registry.get_schema_entry`. Hosts
+        that lazily register their schemas can pass their own accessor.
+
+    Returns
+    -------
+    list of tuple
+        ``[(scenario_id, merged_config_dict), ...]``. Each merged dict is a
+        deep copy with the ``scenario``/``sweep`` directives stripped, and
+        ``metadata.scenario_id`` set to the scenario id.
+    """
+    if "scenarios" in base_raw:
+        raise ValueError(
+            "top-level 'scenarios:' (list of {id, set, metadata}) is no longer "
+            "supported; migrate to the 'scenario:' mapping form — "
+            "'scenario: {<scenario_id>: <overlay-subtree>}'. See "
+            "boulder.runset.expand_scenarios."
+        )
+
+    base_meta = base_raw.get("metadata") or {}
+    base_id = base_meta.get("scenario_id", "BASE")
+    scenario_block = base_raw.get("scenario") or {}
+    global_sweeps = sweeps_of(base_raw)
+
+    if not scenario_block and not global_sweeps:
+        return [(base_id, copy.deepcopy(base_raw))]
+
+    if symbols is None:
+        symbols = _default_symbols()
+
+    # Strip the directives from the base so downstream consumers never see them.
+    base_clean = copy.deepcopy(base_raw)
+    for key in ("scenario", "sweep", "sweeps"):
+        base_clean.pop(key, None)
+
+    expanded: List[Tuple[str, dict]] = []
+
+    def _with_id(cfg: dict, sid: str) -> dict:
+        return deep_merge(cfg, {"metadata": {"scenario_id": sid}})
+
+    # 1) Global sweep points, expanded on the base.
+    for sweep_id, patch in (
+        _expand_sweep_block(global_sweeps, base_clean, symbols, schema_entry)
+        if global_sweeps
+        else []
+    ):
+        sid = f"{base_id}__{sweep_id}" if sweep_id else base_id
+        expanded.append((sid, _with_id(deep_merge(base_clean, patch), sid)))
+
+    # 2) Each scenario overlay; a scenario-local sweep multiplies only itself.
+    for key, overlay in scenario_block.items():
+        overlay = dict(overlay or {})
+        inner_sweeps = sweeps_of(overlay)
+        overlay_clean = copy.deepcopy(overlay)
+        overlay_clean.pop("sweep", None)
+        overlay_clean.pop("sweeps", None)
+        scen_base = deep_merge(base_clean, overlay_clean)
+        if inner_sweeps:
+            for sweep_id, patch in _expand_sweep_block(
+                inner_sweeps, scen_base, symbols, schema_entry
+            ):
+                sid = f"{key}__{sweep_id}" if sweep_id else key
+                expanded.append((sid, _with_id(deep_merge(scen_base, patch), sid)))
+        else:
+            expanded.append((key, _with_id(scen_base, key)))
+
+    return expanded
+
+
+def _default_symbols() -> Mapping[str, str]:
+    """Return the host-registered sweep symbol map (``plugins.sweep_symbols``)."""
+    try:
+        from .cantera_converter import get_plugins  # noqa: PLC0415
+
+        return get_plugins().sweep_symbols or {}
+    except Exception:  # noqa: BLE001 — no plugins available: plain axis names
+        return {}
+
+
+def _expand_sweep_block(
+    sweeps_block: dict,
+    base_for_paths: dict,
+    symbols: Mapping[str, str],
+    schema_entry: Optional[Callable[[str], Any]],
+) -> List[Tuple[str, dict]]:
+    """Cartesian-expand a sweeps block → ``[(sweep_id, patch_dict), ...]``.
+
+    Each axis is ``{path: "<dotted.path>", values: [...]}`` (or ``min``/``max``/
+    ``num``); all axes are crossed. ``base_for_paths`` is used only to resolve
+    short-form / id-selector paths. Raises ``ValueError`` on a malformed axis.
+    """
+    from itertools import product  # noqa: PLC0415
+
+    def _axis_label(axis_name: str, axis_spec: Dict[str, Any]) -> str:
+        explicit_symbol = axis_spec.get("symbol")
+        if explicit_symbol:
+            return str(explicit_symbol)
+        path = str(axis_spec.get("path", ""))
+        leaf = path.rsplit(".", 1)[-1] if path else axis_name
+        return symbols.get(leaf) or symbols.get(axis_name) or axis_name
+
+    axes = []
+    for axis_name, axis_spec in sweeps_block.items():
+        axis_path = axis_spec.get("path") if isinstance(axis_spec, dict) else None
+        axis_values = (
+            sweep_axis_values(axis_spec) if isinstance(axis_spec, dict) else None
+        )
+        if not axis_path or not axis_values:
+            raise ValueError(
+                f"sweep.{axis_name} must be a dict with 'path' and either "
+                f"'values: [...]' or 'min'/'max'/'num'; got {axis_spec!r}"
+            )
+        axis_path = _resolve_sweep_path(
+            axis_name, axis_path, base_for_paths, schema_entry
+        )
+        axes.append((_axis_label(axis_name, axis_spec), axis_path, list(axis_values)))
+
+    points: List[Tuple[str, dict]] = []
+    for combo in product(*[a[2] for a in axes]):
+        label_parts: List[str] = []
+        patch: dict = {}
+        for (label, axis_path, _), value in zip(axes, combo, strict=True):
+            label_parts.append(f"{label}={value}")
+            _set_dotted(patch, axis_path, value)
+        points.append(("__".join(label_parts), patch))
+    return points
+
+
+def _resolve_sweep_path(
+    axis_name: str,
+    axis_path: str,
+    base_config: dict,
+    schema_entry: Optional[Callable[[str], Any]] = None,
+) -> str:
+    """Expand short-form sweep paths and validate against registered schemas.
+
+    Behaviour:
+
+    * If *axis_path* starts with ``nodes[`` we trust it and only validate the
+      target field exists on the node's registered schema (if any).
+    * Otherwise it is treated as a short-form property key.  The YAML is
+      scanned for nodes whose kind is registered in the schema registry and
+      whose schema declares the key.  When exactly one node matches, the path
+      is expanded to ``nodes[id=<that-id>].properties.<key>``.  Ambiguity or
+      absence raises :class:`ValueError` with the full list of candidates, so
+      users can pick a specific node explicitly.
+    """
+    if schema_entry is None:
+        try:
+            from .schema_registry import get_schema_entry  # noqa: PLC0415
+
+            schema_entry = get_schema_entry
+        except ImportError:
+            return axis_path
+
+    if axis_path.startswith("nodes["):
+        _validate_sweep_path_leaf(axis_name, axis_path, base_config, schema_entry)
+        return axis_path
+
+    if axis_path.startswith("network["):
+        # STONE v2: network[id=<X>].<KindKey>.<field> — trusted as-is.
+        return axis_path
+
+    if "." in axis_path:
+        return axis_path  # non-node dotted paths (metadata, phases, ...) are OK
+
+    key = axis_path
+    candidates: List[str] = []
+    # Check both internal (nodes) and STONE v2 (network) item lists.
+    items = list(base_config.get("nodes") or []) + list(
+        base_config.get("network") or []
+    )
+    for node in items:
+        kind = node.get("type")
+        if not kind:
+            continue
+        entry = schema_entry(kind)
+        if entry is None or entry.schema is None:
+            continue
+        fields = getattr(entry.schema, "model_fields", None) or {}
+        if key in fields:
+            candidates.append(node.get("id"))
+
+    if len(candidates) == 1:
+        return f"nodes[id={candidates[0]}].properties.{key}"
+    if len(candidates) > 1:
+        raise ValueError(
+            f"sweeps.{axis_name}.path={axis_path!r} is ambiguous: matches "
+            f"nodes {candidates}. Qualify the path explicitly, e.g. "
+            f"nodes[id={candidates[0]}].properties.{key}."
+        )
+    raise ValueError(
+        f"sweeps.{axis_name}.path={axis_path!r} matches no registered "
+        "reactor field. Either pass a full dotted path (metadata.*, phases.*, "
+        "nodes[id=...]... or network[id=...]...) or register a schema that declares this field."
+    )
+
+
+def _validate_sweep_path_leaf(
+    axis_name: str,
+    axis_path: str,
+    base_config: dict,
+    schema_entry: Callable[[str], Any],
+) -> None:
+    """Best-effort leaf validation for ``nodes[id=...].properties.FIELD`` paths."""
+    import re  # noqa: PLC0415
+
+    match = re.match(
+        r"^nodes\[id=(?P<nid>[^\]]+)\]\.properties\.(?P<leaf>[^.]+)$",
+        axis_path,
+    )
+    if not match:
+        return
+    nid = match.group("nid")
+    leaf = match.group("leaf")
+    target = next(
+        (n for n in base_config.get("nodes") or [] if n.get("id") == nid), None
+    )
+    if target is None:
+        raise ValueError(f"sweeps.{axis_name}: node id {nid!r} not found in config.")
+    kind = target.get("type")
+    if not kind:
+        return
+    entry = schema_entry(kind)
+    if entry is None or entry.schema is None:
+        return
+    fields = getattr(entry.schema, "model_fields", None) or {}
+    if leaf not in fields:
+        raise ValueError(
+            f"sweeps.{axis_name}: node {nid!r} (kind {kind!r}) has no "
+            f"schema field {leaf!r}. Known fields: {sorted(fields)}."
+        )
+
+
+def _set_dotted(target: dict, dotted_path: str, value: Any) -> None:
+    """Set *value* at *dotted_path* inside *target*.
+
+    Supports two segment forms:
+
+    * Plain keys: ``metadata.scenario_id``.
+    * Id-keyed list selection: ``nodes[id=torch].properties.T_out`` — the
+      current node is expected to be a list of dicts; the segment looks up
+      (or appends) the element with matching ``id`` field.  This mirrors
+      the id-based list merging behavior of :func:`deep_merge`.
+
+    Intermediate dicts / list elements are created as needed.
+    """
+    import re  # noqa: PLC0415
+
+    segments = dotted_path.split(".")
+    bracket_re = re.compile(r"^([^\[]+)\[([^=\]]+)=([^\]]+)\]$")
+
+    cur: Any = target
+    for i, seg in enumerate(segments):
+        is_last = i == len(segments) - 1
+        m = bracket_re.match(seg)
+        if m:
+            list_key, match_key, match_val = m.group(1), m.group(2), m.group(3)
+            if list_key not in cur or not isinstance(cur[list_key], list):
+                cur[list_key] = []
+            lst = cur[list_key]
+            found = None
+            for item in lst:
+                if isinstance(item, dict) and str(item.get(match_key)) == match_val:
+                    found = item
+                    break
+            if found is None:
+                found = {match_key: match_val}
+                lst.append(found)
+            if is_last:
+                raise ValueError(
+                    f"Cannot set value at list-selector segment {seg!r}; "
+                    "end the path with a plain key after the selector."
+                )
+            cur = found
+        else:
+            if is_last:
+                cur[seg] = value
+                return
+            nxt = cur.get(seg) if isinstance(cur, dict) else None
+            if not isinstance(nxt, dict):
+                nxt = {}
+                cur[seg] = nxt
+            cur = nxt

--- a/boulder/runset.py
+++ b/boulder/runset.py
@@ -39,9 +39,7 @@ from typing import Any, Callable, Dict, List, Mapping, Optional, Tuple
 
 def _is_id_based_list(lst: list) -> bool:
     """Return whether *lst* is a non-empty list of dicts that all carry ``id``."""
-    return bool(lst) and all(
-        isinstance(item, dict) and "id" in item for item in lst
-    )
+    return bool(lst) and all(isinstance(item, dict) and "id" in item for item in lst)
 
 
 def _merge_lists_by_id(base_list: list, overlay_list: list) -> list:

--- a/boulder/sweep_runner.py
+++ b/boulder/sweep_runner.py
@@ -1,0 +1,284 @@
+"""Generic scenario/sweep runner → composite collection store (for the GUI Run Sweep).
+
+Invoked out-of-process by the ``/api/sweep`` routes for any config that declares
+``scenario:`` and/or ``sweep:``. It:
+
+1. loads the raw config (``from:`` inheritance resolved),
+2. expands the union run-set with :func:`boulder.runset.expand_scenarios`,
+3. solves each run through the Boulder converter, and
+4. writes each result as a **composite** payload into the collection store
+   (``metadata.extra.scenario_store``, default ``<stem>_scenarios.h5``), one
+   ``<scenario_id>/`` group per run,
+
+printing ``scenario N/M`` per run so the sweep API can show progress. The
+Scenario Pane then lists every run and opens each instantly.
+
+Caching is incremental by default: each group carries the Boulder cache
+fingerprint of its config (:func:`scenario_fingerprint`), and runs whose
+fingerprint is unchanged are skipped. ``BOULDER_NO_CACHE`` (the Scenario
+Pane's "Regenerate cache" action) recreates the store from scratch. Groups
+whose scenario id left the run-set are pruned.
+
+Usage: ``python -m boulder.sweep_runner <config.yaml> [--no-plot]``
+
+Host packages with extra needs keep their own entry point (registered via
+``plugins.sweep_runner``) as a thin wrapper around :func:`run`, passing hooks:
+``setup`` for process-level preparation (e.g. putting a private mechanism
+directory on Cantera's search path), ``resolve_mechanism`` to turn bare
+mechanism names into absolute paths (so the GUI server can read the store
+without the host's search-path setup), and ``scenario_attrs`` to attach extra
+scalar KPI attributes to each scenario group (what the Sweep Results plot
+reads).
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import os
+import time
+from pathlib import Path
+from typing import Any, Callable, Dict, Optional, Tuple
+
+import h5py
+
+from .cantera_converter import DualCanteraConverter, get_plugins
+from .config import normalize_config
+from .payload_store import write_payload
+from .runset import expand_scenarios, load_yaml_with_inheritance, resolve_store_path
+
+
+def _mechanism_of(raw: Dict[str, Any]) -> str:
+    gas = (raw.get("phases") or {}).get("gas") or {}
+    return str(gas.get("mechanism") or "")
+
+
+def scenario_fingerprint(
+    raw_cfg: Dict[str, Any],
+    *,
+    extra: Optional[Dict[str, Any]] = None,
+    resolve_mechanism: Optional[Callable[[str], str]] = None,
+) -> str:
+    """Boulder cache fingerprint for one merged (``from:``-resolved) scenario.
+
+    THE fingerprint every scenario store uses — this runner and any host batch
+    writer both call this; do not re-implement the cache key elsewhere.
+    ``extra`` mixes caller-specific inputs into the hash (e.g. a save grid that
+    lives outside the solved network config). ``resolve_mechanism`` maps a bare
+    mechanism name to the identity actually hashed (hosts pass their
+    name→absolute-path resolver so fingerprints match their store contents).
+    """
+    from .result_cache import compute_fingerprint  # noqa: PLC0415
+
+    plugins = get_plugins()
+    config = normalize_config(copy.deepcopy(raw_cfg), plugins=plugins)
+    mechanism = _mechanism_of(raw_cfg)
+    if resolve_mechanism is not None:
+        mechanism = resolve_mechanism(mechanism)
+    return compute_fingerprint(config, mechanism=mechanism, extra=extra)
+
+
+def _prepare(
+    raw_cfg: Dict[str, Any],
+    resolve_mechanism: Optional[Callable[[str], str]],
+) -> Tuple[Dict[str, Any], str, str]:
+    """Normalize a merged scenario config → ``(config, mechanism, fingerprint)``.
+
+    The fingerprint (Boulder's cache key) lets the run skip scenarios that are
+    already cached unchanged — computed without building/solving the network.
+    """
+    from .result_cache import compute_fingerprint  # noqa: PLC0415
+
+    plugins = get_plugins()
+    config = normalize_config(copy.deepcopy(raw_cfg), plugins=plugins)
+    mechanism = _mechanism_of(raw_cfg)
+    hashed = resolve_mechanism(mechanism) if resolve_mechanism else mechanism
+    fingerprint = compute_fingerprint(config, mechanism=hashed)
+    return config, mechanism, fingerprint
+
+
+def _solve(config: Dict[str, Any], mechanism: str) -> Tuple[Dict[str, Any], str]:
+    """Solve one normalized scenario config → (gui_payload, resolved mechanism)."""
+    plugins = get_plugins()
+    conv = DualCanteraConverter(mechanism=mechanism or None, plugins=plugins)
+    conv.build_network(config)
+
+    settings = config.get("settings") or {}
+    sim_t = float(settings.get("end_time") or 0.0)
+    if sim_t <= 0.0:
+        sim_t = 1.0
+        if not settings.get("solver"):
+            # A solver grid (e.g. from a host config transform) overrides the
+            # nominal end_time; without either, flag the silent 1 s default.
+            print(
+                "  WARNING: settings.end_time missing — defaulting to 1.0 s. "
+                "Declare settings.end_time (or a settings.solver grid) for a "
+                "meaningful trajectory.",
+                flush=True,
+            )
+    dt = float(settings.get("dt") or 0.0) or (sim_t / 10.0)
+    results, code = conv.run_streaming_simulation(
+        simulation_time=sim_t, time_step=dt, config=config
+    )
+
+    gui = {
+        "status": "complete",
+        "is_running": False,
+        "is_complete": True,
+        "error_message": None,
+        "times": results.get("time", []),
+        "reactors_series": results.get("reactors", {}),
+        "reactor_reports": {},
+        "connection_reports": {},
+        "code_str": code,
+        "summary": results.get("summary", []),
+        "sankey_links": results.get("sankey_links"),
+        "sankey_nodes": results.get("sankey_nodes"),
+        "elapsed_time": None,
+        "updated_nodes": None,
+        "updated_connections": None,
+    }
+    return gui, conv.mechanism
+
+
+def existing_fingerprints(store: Path) -> Dict[str, str]:
+    """Per-scenario fingerprints already in the store (group id → fingerprint).
+
+    Shared cache primitive: any writer of a collection store (this runner, a
+    host batch writer) reads its cache state through this.
+    """
+    found: Dict[str, str] = {}
+    if not store.exists():
+        return found
+    with h5py.File(str(store), "r") as handle:
+        for sid, node in handle.items():
+            if isinstance(node, h5py.Group) and "payload_json" in node:
+                fp = node.attrs.get("fingerprint")
+                if fp:
+                    found[sid] = str(fp)
+    return found
+
+
+def prune_stale_groups(store: Path, run_ids: set) -> list:
+    """Delete groups whose scenario id is no longer in the run set.
+
+    Renamed or removed scenarios would otherwise linger in the GUI's Scenario
+    Pane forever (only ``--no-cache`` recreates the file). Returns the deleted
+    group names.
+    """
+    with h5py.File(str(store), "a") as handle:
+        stale = [
+            sid
+            for sid, node in handle.items()
+            if isinstance(node, h5py.Group) and sid not in run_ids
+        ]
+        for sid in stale:
+            del handle[sid]
+    return stale
+
+
+def run(
+    cfg_path: Path,
+    *,
+    setup: Optional[Callable[[], None]] = None,
+    resolve_mechanism: Optional[Callable[[str], str]] = None,
+    scenario_attrs: Optional[
+        Callable[[str, Dict[str, Any], Dict[str, Any]], Dict[str, Any]]
+    ] = None,
+) -> Path:
+    """Expand and solve *cfg_path*'s run-set into its collection store.
+
+    Parameters
+    ----------
+    cfg_path : Path
+        The STONE config declaring ``scenario:`` / ``sweep:``.
+    setup : callable, optional
+        Called once before anything else — host process-level preparation
+        (e.g. registering a mechanism directory on Cantera's search path).
+    resolve_mechanism : callable, optional
+        ``name -> str`` mapping a bare mechanism name to the identity stored
+        and hashed (typically an absolute path). Defaults to the name itself.
+    scenario_attrs : callable, optional
+        ``(scenario_id, merged_config, gui_payload) -> dict`` of extra scalar
+        attributes written onto the scenario's HDF5 group after each solve —
+        the per-run KPIs the Sweep Results plot reads (``t0_K``,
+        ``final_X_<species>``, …).
+
+    Returns
+    -------
+    Path
+        The collection store written.
+    """
+    if setup is not None:
+        setup()
+    _resolve = resolve_mechanism or (lambda name: name)
+    raw = load_yaml_with_inheritance(cfg_path)
+    store = resolve_store_path(raw, cfg_path)
+    assert store is not None  # cfg_path is always set here
+    store.parent.mkdir(parents=True, exist_ok=True)
+
+    # Incremental by default: keep the store and skip scenarios whose fingerprint
+    # is unchanged. ``--no-cache`` (BOULDER_NO_CACHE) forces a full recompute.
+    no_cache = bool(os.environ.get("BOULDER_NO_CACHE"))
+    if no_cache and store.exists():
+        store.unlink()
+    cached_fps = {} if no_cache else existing_fingerprints(store)
+
+    runs = expand_scenarios(raw)
+    total = len(runs)
+    run_ids = {sid for sid, _ in runs}
+    mechanism = _mechanism_of(raw)
+    n_cached = 0
+    for i, (sid, cfg) in enumerate(runs):
+        config, mech_name, fingerprint = _prepare(cfg, resolve_mechanism)
+        label = str((cfg.get("metadata") or {}).get("scenario_name") or sid)
+        if cached_fps.get(sid) == fingerprint:
+            n_cached += 1
+            print(f"scenario {i + 1}/{total} ({sid}): cached, skipped", flush=True)
+            # Display attrs still track the YAML (reorderings / renamed labels)
+            # even when the solve itself is skipped.
+            with h5py.File(str(store), "a") as handle:
+                attrs = handle[sid].attrs
+                attrs["label"] = label
+                attrs["order"] = int(i)
+            continue
+        print(f"scenario {i + 1}/{total} ({sid})", flush=True)
+        gui, resolved_mech = _solve(config, mech_name)
+        write_payload(store, gui, _resolve(resolved_mech), group=sid, fresh=False)
+        with h5py.File(str(store), "a") as handle:
+            attrs = handle[sid].attrs
+            attrs["label"] = label
+            attrs["order"] = int(i)
+            attrs["fingerprint"] = fingerprint
+            attrs["computed_at"] = float(time.time())
+            if scenario_attrs is not None:
+                for key, value in (scenario_attrs(sid, cfg, gui) or {}).items():
+                    attrs[key] = value
+
+    stale = prune_stale_groups(store, run_ids)
+    if stale:
+        print(f"Pruned {len(stale)} stale scenario group(s): {', '.join(stale)}")
+
+    with h5py.File(str(store), "a") as handle:
+        handle.attrs["map_config"] = cfg_path.name
+        handle.attrs["mechanism"] = _resolve(mechanism)
+        handle.attrs["mechanism_name"] = Path(mechanism).name if mechanism else ""
+        handle.attrs["created_at"] = float(time.time())
+    print(
+        f"Wrote {store} ({total} scenarios; {n_cached} cached, "
+        f"{total - n_cached} solved)",
+        flush=True,
+    )
+    return store
+
+
+def main(argv: "list[str] | None" = None) -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("config", help="STONE config with scenario:/sweep:")
+    parser.add_argument("--no-plot", action="store_true", help="(accepted, ignored)")
+    args = parser.parse_args(argv)
+    run(Path(args.config).resolve())
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_runset.py
+++ b/tests/test_runset.py
@@ -1,0 +1,321 @@
+"""Unit tests for :mod:`boulder.runset` — the scenario:/sweep: reference implementation.
+
+Ported from the host package that pioneered the semantics, so the union rules,
+id naming, and error messages stay locked while living upstream.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from boulder.runset import (
+    deep_merge,
+    expand_scenarios,
+    load_yaml_with_inheritance,
+    run_set_size,
+    sweep_axis_values,
+)
+
+# ---------------------------------------------------------------------------
+# expand_scenarios
+# ---------------------------------------------------------------------------
+
+
+def test_expand_scenarios_no_block_returns_single_base():
+    """A YAML without scenario:/sweep: yields a single scenario.
+
+    whose id matches ``metadata.scenario_id``.
+    """
+    base = {"metadata": {"scenario_id": "MY_BASE"}, "nodes": []}
+    out = expand_scenarios(base)
+    assert len(out) == 1
+    sid, cfg = out[0]
+    assert sid == "MY_BASE"
+    assert "scenarios" not in cfg
+    assert "sweeps" not in cfg
+
+
+def test_expand_scenarios_legacy_scenarios_list_raises_migration_error():
+    """The pre-2026-06 ``scenarios:`` (list) schema fails loudly, not silently.
+
+    A config carrying the legacy key must raise an actionable migration error
+    instead of expanding to just the base (which would silently drop every
+    variant and later fail downstream on an unknown top-level key).
+    """
+    base = {
+        "metadata": {"scenario_id": "BASE"},
+        "scenarios": [{"id": "old_style", "set": {"metadata": {"x": 1}}}],
+    }
+    with pytest.raises(ValueError, match="no longer supported.*'scenario:' mapping"):
+        expand_scenarios(base)
+
+
+def test_expand_scenario_mapping_deep_merges_overlays():
+    """Deep-merge each `scenario:` overlay onto the base.
+
+    The key is the scenario id; id-keyed lists (``nodes``) merge by id.
+    """
+    base = {
+        "metadata": {"scenario_id": "BASE"},
+        "nodes": [{"id": "torch", "properties": {"T_out": 2500}}],
+        "scenario": {
+            "hot": {"nodes": [{"id": "torch", "properties": {"T_out": 3000}}]},
+            "cold": {"nodes": [{"id": "torch", "properties": {"T_out": 2000}}]},
+        },
+    }
+    out = expand_scenarios(base)
+    assert [sid for sid, _ in out] == ["hot", "cold"]
+    assert out[0][1]["nodes"][0]["properties"]["T_out"] == 3000
+    assert out[1][1]["nodes"][0]["properties"]["T_out"] == 2000
+    assert out[0][1]["metadata"]["scenario_id"] == "hot"
+    assert "scenario" not in out[0][1]
+
+
+def test_expand_scenario_plus_global_sweep_is_union_not_cartesian():
+    """Top-level sweep + scenarios run as a union (M+N), not a cross product."""
+    base = {
+        "metadata": {"scenario_id": "BASE"},
+        "nodes": [{"id": "torch", "properties": {"T_out": 2500}}],
+        "sweep": {
+            "T": {"path": "nodes[id=torch].properties.T_out", "values": [2600, 2700]}
+        },
+        "scenario": {
+            "hot": {"nodes": [{"id": "torch", "properties": {"T_out": 3000}}]},
+        },
+    }
+    out = expand_scenarios(base)
+    ids = [sid for sid, _ in out]
+    # 2 global sweep points + 1 scenario = 3 (not 2*1 cross product).
+    assert ids == ["BASE__T=2600", "BASE__T=2700", "hot"]
+
+
+def test_expand_scenario_local_sweep_multiplies_only_that_scenario():
+    """A `sweep:` inside one scenario expands that scenario only."""
+    base = {
+        "metadata": {"scenario_id": "BASE"},
+        "nodes": [{"id": "torch", "properties": {"T_out": 2500}}],
+        "scenario": {
+            "plain": {"nodes": [{"id": "torch", "properties": {"T_out": 2000}}]},
+            "swept": {
+                "sweep": {
+                    "T": {
+                        "path": "nodes[id=torch].properties.T_out",
+                        "values": [2800, 2900],
+                    }
+                }
+            },
+        },
+    }
+    out = expand_scenarios(base)
+    assert [sid for sid, _ in out] == ["plain", "swept__T=2800", "swept__T=2900"]
+    swept = {sid: cfg for sid, cfg in out}
+    assert swept["swept__T=2800"]["nodes"][0]["properties"]["T_out"] == 2800
+
+
+def test_expand_scenarios_sweep_with_id_selector_targets_list_element():
+    """A sweep path with ``[id=...]`` selector overrides one element.
+
+    A single element inside an id-keyed list is patched instead of the list
+    being replaced.
+    """
+    base = {
+        "metadata": {"scenario_id": "S"},
+        "nodes": [
+            {"id": "torch", "properties": {"T_out": 2500}},
+            {"id": "psr", "properties": {"volume": 1e-3}},
+        ],
+        "sweeps": {
+            "T": {
+                "path": "nodes[id=torch].properties.T_out",
+                "values": [2500, 3000],
+            },
+        },
+    }
+    out = expand_scenarios(base)
+    assert len(out) == 2
+    t_values = [cfg["nodes"][0]["properties"]["T_out"] for _, cfg in out]
+    assert t_values == [2500, 3000]
+    # psr node must be preserved across sweep points
+    for _, cfg in out:
+        assert cfg["nodes"][1]["properties"]["volume"] == 1e-3
+
+
+def test_expand_scenarios_sweep_min_max_num_expands_like_values():
+    """A `min`/`max`/`num` sweep expands to the same scenarios as an explicit list."""
+    base = {
+        "metadata": {"scenario_id": "BASE"},
+        "network": [{"id": "r", "Foo": {"t": 0}}],
+        "sweeps": {
+            "t": {
+                "path": "network[id=r].Foo.t",
+                "min": 0.0,
+                "max": 10.0,
+                "num": 3,
+            }
+        },
+    }
+    out = expand_scenarios(base)
+    assert len(out) == 3
+    temps = [cfg["network"][0]["Foo"]["t"] for _sid, cfg in out]
+    assert temps == [0.0, 5.0, 10.0]
+
+
+def test_expand_scenarios_sweep_malformed_axis_raises():
+    """A sweep axis missing 'path' or 'values' raises ValueError."""
+    base = {"metadata": {"scenario_id": "S"}, "sweeps": {"T": {"path": "x"}}}
+    with pytest.raises(ValueError, match="must be a dict with 'path'"):
+        expand_scenarios(base)
+
+
+def test_expand_scenarios_sweep_uses_symbols_mapping_for_axis_labels():
+    """Sweep ids use the host symbol mapping instead of raw axis names.
+
+    The ``symbols`` hook (or the registered ``plugins.sweep_symbols``) maps the
+    path leaf / axis name to the symbol used in scenario ids.
+    """
+    base = {
+        "metadata": {"scenario_id": "BASE"},
+        "sweeps": {
+            "diameter": {
+                "path": "nodes[id=tube_furnace].TubeFurnace.diameter",
+                "values": [0.03],
+            }
+        },
+    }
+    out = expand_scenarios(base, symbols={"diameter": "TF_D"})
+    assert len(out) == 1
+    assert out[0][0] == "BASE__TF_D=0.03"
+
+
+def test_expand_scenarios_sweep_prefers_explicit_symbol_override():
+    """An axis ``symbol:`` override wins over the symbols mapping."""
+    base = {
+        "metadata": {"scenario_id": "BASE"},
+        "sweeps": {
+            "diameter": {
+                "path": "nodes[id=tube_furnace].TubeFurnace.diameter",
+                "values": [0.03],
+                "symbol": "MY_D",
+            }
+        },
+    }
+    out = expand_scenarios(base, symbols={"diameter": "TF_D"})
+    assert len(out) == 1
+    assert out[0][0] == "BASE__MY_D=0.03"
+
+
+# ---------------------------------------------------------------------------
+# sweep_axis_values
+# ---------------------------------------------------------------------------
+
+
+def test_sweep_axis_values_error_paths():
+    """Malformed range specs raise ValueError with actionable messages."""
+    with pytest.raises(ValueError, match="requires 'num'"):
+        sweep_axis_values({"min": 0.0, "max": 1.0})
+    with pytest.raises(ValueError, match="must be >= 1"):
+        sweep_axis_values({"min": 0.0, "max": 1.0, "num": 0})
+    with pytest.raises(ValueError, match="positive 'min' and 'max'"):
+        sweep_axis_values({"min": 0.0, "max": 1.0, "num": 3, "spacing": "log"})
+    with pytest.raises(ValueError, match="unknown sweep spacing"):
+        sweep_axis_values({"min": 0.0, "max": 1.0, "num": 3, "spacing": "lgo"})
+
+
+def test_sweep_axis_values_min_max_num_matches_explicit_list():
+    """`min`/`max`/`num` generates the same evenly spaced list as an explicit one."""
+    generated = sweep_axis_values({"min": 1273.15, "max": 2573.15, "num": 21})
+    expected = [1273.15 + 65.0 * i for i in range(21)]
+    assert generated == pytest.approx(expected)
+    assert generated[0] == 1273.15 and generated[-1] == 2573.15
+
+
+def test_sweep_axis_values_log_spacing():
+    """`spacing: log` yields a geometric series across the range."""
+    assert sweep_axis_values(
+        {"min": 1e-4, "max": 10.0, "num": 6, "spacing": "log"}
+    ) == pytest.approx([1e-4, 1e-3, 1e-2, 1e-1, 1.0, 10.0])
+
+
+# ---------------------------------------------------------------------------
+# run_set_size — must agree with expand_scenarios
+# ---------------------------------------------------------------------------
+
+
+def test_run_set_size_counts_min_max_num_ranges():
+    """Range-form axes count by their generated length (the old mirror guessed)."""
+    raw = {
+        "sweep": {
+            "T": {"path": "metadata.x", "min": 0.0, "max": 10.0, "num": 5},
+            "P": {"path": "metadata.y", "values": [1, 2]},
+        }
+    }
+    assert run_set_size(raw) == 10  # 5 × 2
+
+
+def test_run_set_size_matches_expand_scenarios():
+    """The cheap count and the real expansion agree on the union semantics."""
+    raw = {
+        "metadata": {"scenario_id": "BASE"},
+        "sweep": {"T": {"path": "metadata.t", "values": [1, 2]}},
+        "scenario": {
+            "plain": {},
+            "swept": {"sweep": {"P": {"path": "metadata.p", "values": [3, 4, 5]}}},
+        },
+    }
+    assert run_set_size(raw) == len(expand_scenarios(raw)) == 6  # 2 ⊎ (1 + 3)
+
+
+def test_run_set_size_malformed_axis_counts_zero():
+    """Sizing never raises — malformed axes count 0 (expansion fails loudly)."""
+    assert run_set_size({"sweep": {"T": {"min": 0.0, "max": 1.0}}}) == 0
+
+
+# ---------------------------------------------------------------------------
+# deep_merge / load_yaml_with_inheritance
+# ---------------------------------------------------------------------------
+
+
+def test_deep_merge_id_keyed_lists_merge_by_id():
+    """Lists of dicts that all carry ``id`` merge element-wise, not wholesale."""
+    base = {
+        "nodes": [
+            {"id": "a", "properties": {"x": 1, "y": 2}},
+            {"id": "b", "properties": {"x": 3}},
+        ]
+    }
+    overlay = {"nodes": [{"id": "a", "properties": {"x": 10}}]}
+    merged = deep_merge(base, overlay)
+    assert merged["nodes"][0]["properties"] == {"x": 10, "y": 2}
+    assert merged["nodes"][1] == {"id": "b", "properties": {"x": 3}}
+
+
+def test_deep_merge_plain_lists_replace():
+    """Lists without ids are replaced by the overlay, not concatenated."""
+    assert deep_merge({"v": [1, 2, 3]}, {"v": [9]}) == {"v": [9]}
+
+
+def test_load_yaml_with_inheritance_sweeps_inherited_scenario_not(tmp_path: Path):
+    """``sweep:`` is inherited through ``from:``; ``scenario:`` is not.
+
+    A parent's named run-set must not leak into a child overlay, but a child
+    legitimately re-runs the parent's parameter sweep with overrides.
+    """
+    parent = tmp_path / "parent.yaml"
+    parent.write_text(
+        "metadata: {scenario_id: PARENT}\n"
+        "sweep:\n"
+        "  T: {path: metadata.t, values: [1, 2]}\n"
+        "scenario:\n"
+        "  variant_a: {metadata: {x: 1}}\n",
+        encoding="utf-8",
+    )
+    child = tmp_path / "child.yaml"
+    child.write_text(
+        "from: parent.yaml\nmetadata: {scenario_id: CHILD}\n", encoding="utf-8"
+    )
+    cfg = load_yaml_with_inheritance(child)
+    assert cfg["metadata"]["scenario_id"] == "CHILD"
+    assert "scenario" not in cfg
+    assert cfg["sweep"]["T"]["values"] == [1, 2]

--- a/tests/test_sweep_runner_store.py
+++ b/tests/test_sweep_runner_store.py
@@ -1,0 +1,45 @@
+"""Unit tests for :mod:`boulder.sweep_runner` collection-store cache primitives."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import h5py
+
+from boulder.sweep_runner import existing_fingerprints, prune_stale_groups
+
+
+def _make_store(path: Path, groups: dict) -> None:
+    """Create a collection store with ``{group_id: fingerprint | None}``."""
+    with h5py.File(str(path), "w") as handle:
+        for sid, fingerprint in groups.items():
+            group = handle.create_group(sid)
+            group.create_dataset("payload_json", data="{}")
+            if fingerprint:
+                group.attrs["fingerprint"] = fingerprint
+
+
+def test_existing_fingerprints_reads_groups_with_payload(tmp_path: Path):
+    store = tmp_path / "map_scenarios.h5"
+    _make_store(store, {"a": "fp-a", "b": "fp-b", "unfingerprinted": None})
+    assert existing_fingerprints(store) == {"a": "fp-a", "b": "fp-b"}
+
+
+def test_existing_fingerprints_empty_for_missing_store(tmp_path: Path):
+    assert existing_fingerprints(tmp_path / "nope.h5") == {}
+
+
+def test_existing_fingerprints_ignores_groups_without_payload(tmp_path: Path):
+    store = tmp_path / "map_scenarios.h5"
+    with h5py.File(str(store), "w") as handle:
+        handle.create_group("half_written").attrs["fingerprint"] = "fp"
+    assert existing_fingerprints(store) == {}
+
+
+def test_prune_stale_groups_removes_ids_that_left_the_run_set(tmp_path: Path):
+    store = tmp_path / "map_scenarios.h5"
+    _make_store(store, {"keep": "fp-1", "renamed_away": "fp-2"})
+    stale = prune_stale_groups(store, {"keep", "brand_new"})
+    assert stale == ["renamed_away"]
+    with h5py.File(str(store), "r") as handle:
+        assert list(handle.keys()) == ["keep"]


### PR DESCRIPTION
## Why

The STONE `scenario:`/`sweep:` blocks are specified here (STONE_SPECIFICATIONS.md §14) and authored here (scenario editor, `/api/scenarios`), but until now the **expansion and execution semantics lived only in the host package**, and `api/routes/sweep.py` had to *mirror* the union run-set sizing without importing it (`_sweep_points`/`_run_set_size` — the docstring admitted as much). Two implementations of the same normative semantics = silent drift risk: if the host changed the expansion rules, the GUI's `n_scenarios` count would quietly diverge.

This PR makes Boulder the reference implementation, with host specifics injected through hooks.

## What

**`boulder/runset.py`** — the STONE §14 semantics, upstreamed:
- `expand_scenarios(raw, *, symbols=None, schema_entry=None)` — union run-set (global sweep points ⊎ each scenario entry, scenario-local sweeps multiply only their scenario), id-keyed `deep_merge`, sweep-path resolution/validation against the schema registry, `__<axis>=<value>` id naming.
- `sweep_axis_values` (`values:` list or `min`/`max`/`num` + `spacing: linear|log`), `sweeps_of`, `run_set_size` (cheap count, never raises), `resolve_store_path`, `load_yaml_with_inheritance` (`from:` chains; `scenario:` deliberately not inherited, `sweep:` is).
- Host naming enters via the new **`BoulderPlugins.sweep_symbols`** registry (or the `symbols=` parameter); host schema access via the `schema_entry` hook.

**`boulder/sweep_runner.py`** — generic out-of-process Run Sweep runner (`python -m boulder.sweep_runner <config.yaml>`): expand → skip runs whose per-scenario fingerprint (`boulder.result_cache.compute_fingerprint`) is unchanged → solve via `DualCanteraConverter` → `write_payload` one group per scenario → prune groups whose id left the run-set. `BOULDER_NO_CACHE` recreates the store (the Scenario Pane's "Regenerate cache"). Hosts wrap `run()` via `plugins.sweep_runner` with hooks: `setup` (process prep, e.g. mechanism search paths), `resolve_mechanism` (bare name → absolute path), `scenario_attrs` (per-run KPI attrs for the Sweep Results plot).

**`api/routes/sweep.py`** — the mirror is deleted; counting goes through `boulder.runset.run_set_size`. `resolve_store_path` moved to runset (re-exported for compat). Behavior unchanged.

## Tests & docs

- `tests/test_runset.py`: the expansion suite ported upstream (union semantics, id naming, id-selector paths, min/max/num, symbols hook, migration error for legacy `scenarios:` list, run_set_size ↔ expand_scenarios agreement) — these rules are normative STONE behavior and are now tested where they're specified.
- `tests/test_sweep_runner_store.py`: collection-store cache primitives.
- `tests/test_sweep_runset.py` unchanged and passing (routes re-export).
- STONE spec §14 + ARCHITECTURE.md run-set section updated.

**728 passed, 2 skipped, 5 xfailed** locally (full python suite); mypy and ruff clean on changed files. No frontend changes.

## Notes

- No host identifiers introduced (checked with the usual grep guard).
- A companion host-package PR delegates its expansion/runner to this module; that host needs a PyPI release cut from this once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)