### PR TITLE
feat(sweep): add plugins.converter_class so sweep_runner honors host mechanism resolution

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -156,12 +156,12 @@ Two **profiles** of this one encoding:
 
 #### Run-set expansion and the generic sweep runner
 
-`runset.py` is the reference implementation of the STONE `scenario:`/`sweep:` semantics
+`runset.py` is the reference implementation of the STONE `scenarios:`/`sweep:` semantics
 (STONE_SPECIFICATIONS.md §14): `expand_scenarios` (union run-set, id-keyed `deep_merge`, sweep-path
 resolution against the schema registry), `run_set_size` (the cheap count the `/api/sweep` availability
 endpoint uses — same module, so the count can never drift from the expansion), `sweeps_of`,
 `sweep_axis_values`, `resolve_store_path`, and `load_yaml_with_inheritance` (`from:` chains;
-`scenario:` is deliberately not inherited, `sweep:` is).
+`scenarios:` is deliberately not inherited, `sweep:` is).
 
 `sweep_runner.py` (`python -m boulder.sweep_runner <config.yaml>`) is the generic out-of-process
 runner behind the Run Sweep button: expand → skip runs whose per-scenario fingerprint is unchanged

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,3 +3,13 @@
 Read [AGENTS.md](AGENTS.md) first — it is the canonical contributor and agent guide for this
 repository (project layout, environment setup, verification commands, coding conventions, PR
 requirements). Follow it for all work in this repo.
+
+## Never name a host package in Boulder's own repo
+
+Boulder is a generic, host-agnostic STONE engine — other packages (plugin entry points,
+`BOULDER_PLUGINS`) extend it without Boulder's core knowing what they are. Never mention a
+specific host/consumer package by name (e.g. "Bloc", "BlocConverter") anywhere in this repo:
+source comments, docstrings, test names/bodies, commit messages, or PR titles/descriptions.
+Describe them generically instead — "a host", "an external plugin package", "a host's converter
+subclass". This applies even when the change was motivated by, or verified against, one specific
+host's code — the motivation can live in your own working notes, not in what gets committed here.

--- a/STONE_SPECIFICATIONS.md
+++ b/STONE_SPECIFICATIONS.md
@@ -27,13 +27,14 @@ ______________________________________________________________________
 ## 2. Allowed Top-Level Keys
 
 ```
-metadata   phases   settings   stages   network   export   sweep   sweeps   scenario
+metadata   phases   settings   stages   network   export   sweep   sweeps   scenarios
 continuation   signals   bindings   scopes
 ```
 
-`scenario:` and `sweep:` declare inline run-set variations (Section 14). Boulder validates and
-passes them through; a host's reporting/expansion layer consumes them. (The legacy plural
-`scenarios:` list form is removed — use the `scenario:` mapping.)
+`scenarios:` and `sweep:` declare inline run-set variations (Section 14). Boulder validates and
+passes them through; a host's reporting/expansion layer consumes them. (The legacy list-valued
+top-level `scenarios:` — `[{id, set, metadata}, ...]` — is removed; only the mapping form
+`scenarios: {<id>: <overlay>}` is accepted.)
 
 Dynamic stage block names (declared under `stages:`) are also allowed at the top level.
 
@@ -1260,7 +1261,7 @@ name), `mechanism_sha256` (diagnostic; the cache fingerprint is the correctness 
 
 ______________________________________________________________________
 
-## 14. Inline run-set variations — `scenario:` and `sweep:`
+## 14. Inline run-set variations — `scenarios:` and `sweep:`
 
 A STONE file may declare multiple runs inline, instead of a glob of separate overlay files. Boulder
 validates and passes these blocks through single-run normalization; `boulder.runset.expand_scenarios`
@@ -1270,10 +1271,10 @@ Hosts customize naming/validation through hooks (`plugins.sweep_symbols`, `schem
 than re-implementing the semantics. The directives never alter the topology a single run sees —
 each expanded run is the base with its overlay/patch deep-merged, and the directives stripped.
 
-### `scenario:` — a mapping of `id → overlay`
+### `scenarios:` — a mapping of `id → overlay`
 
 ```yaml
-scenario:
+scenarios:
   case_a:                    # key is the scenario id
     settings:
       solver: {atol: 1.0e-12}
@@ -1288,6 +1289,10 @@ Each value is a STONE subtree (`metadata`/`stages`/`settings`/`network`/…) dee
 (id-keyed `nodes`/`connections` merge by id). The **key is the scenario id**. This is the same delta a
 standalone `from:` overlay file carries — `from:` remains fully valid and is unaffected.
 
+The unmodified base config is always part of the run-set too, as its own entry (id `BASELINE`,
+listed first) — `scenarios:` only *adds* named variations, it never stands in for the base itself.
+`BASELINE` is a reserved id: a `scenarios:` entry cannot use it.
+
 ### `sweep:` — a Cartesian parameter grid
 
 ```yaml
@@ -1296,11 +1301,11 @@ sweep:
   mdot: {path: "...", min: 1.0e-4, max: 2.0e-4, num: 3}   # or min/max/num (+ spacing: log)
 ```
 
-`sweep:` may appear at the top level (expanded on the base) **or inside a `scenario:` entry**
+`sweep:` may appear at the top level (expanded on the base) **or inside a `scenarios:` entry**
 (expanded on that scenario only). Ids are suffixed `__<axis>=<value>`.
 
 ### Run-set semantics (union)
 
-The run set is the **union**: the top-level `sweep:` points **⊎** each `scenario:` entry (each
+The run set is the **union**: the top-level `sweep:` points **⊎** each `scenarios:` entry (each
 expanded across its *own* inner `sweep:` if present). A top-level sweep and the scenarios do **not**
 cross-multiply. (`sweep:` and `sweeps:` are accepted spellings.)

--- a/boulder/api/main.py
+++ b/boulder/api/main.py
@@ -213,7 +213,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     # Resolve the scenario-inspector store (HDF5): explicit env override wins,
     # else the preloaded config's ``metadata.extra.scenario_store`` (or the
     # ``<stem>_scenarios.h5`` default) whenever there is a run-set to show —
-    # declared inline (``scenario:``/``sweep:``/``sweeps:``), a host
+    # declared inline (``scenarios:``/``sweep:``/``sweeps:``), a host
     # ``run_sweep.py`` next to the config, or ``--sweep`` (BOULDER_SWEEP_MODE).
     # Reuses the same detection the Run Sweep button uses (routes.sweep) so a
     # config with a run-set shows its precomputed Scenario Pane on plain

--- a/boulder/api/routes/scenarios.py
+++ b/boulder/api/routes/scenarios.py
@@ -92,7 +92,7 @@ def _scenario_entries(h5_path: Path) -> List[Dict[str, Any]]:
 
 
 def _authored_scenario_ids(request: Request) -> List[str]:
-    """Return every scenario id currently in the config's `scenario:` mapping.
+    """Return every scenario id currently in the config's `scenarios:` mapping.
 
     Unlike the HDF5-derived list below (only scenarios a sweep has actually
     computed), this reflects the source YAML directly — so a scenario that
@@ -153,7 +153,7 @@ async def get_scenario(scenario_id: str, request: Request) -> Dict[str, Any]:
 
 
 # --------------------------------------------------------------------------- #
-# Scenario authoring — create/edit/delete a ``scenario:`` overlay on disk.
+# Scenario authoring — create/edit/delete a ``scenarios:`` overlay on disk.
 #
 # Unlike the read routes above (which serve precomputed HDF5 trajectories),
 # these operate on the *source* config file (``app.state.preloaded_config_path``)
@@ -196,7 +196,7 @@ def _reload_preloaded_state(request: Request, cfg_path: Path) -> None:
     """Refresh the in-memory preloaded config after an on-disk scenario edit.
 
     Mirrors the subset of the app's startup load that Run Sweep and the config
-    endpoints read (``preloaded_raw`` keeps ``scenario:``/``sweep:`` for the
+    endpoints read (``preloaded_raw`` keeps ``scenarios:``/``sweep:`` for the
     Run Sweep button; ``preloaded_config``/``preloaded_yaml`` back the editor
     panel). Cached simulation results are untouched — editing a scenario
     doesn't invalidate the base config's last solve.
@@ -263,7 +263,7 @@ async def update_scenario(
 async def rename_scenario(
     scenario_id: str, body: RenameScenarioRequest, request: Request
 ) -> Dict[str, Any]:
-    """Rename a scenario's id (its ``scenario:`` mapping key)."""
+    """Rename a scenario's id (its ``scenarios:`` mapping key)."""
     cfg_path = _require_config_path(request)
     try:
         from ...scenario_editor import ScenarioEditError
@@ -281,7 +281,7 @@ async def delete_scenario(scenario_id: str, request: Request) -> Dict[str, Any]:
     """Delete a scenario overlay and purge its cached trajectory, if any.
 
     Both happen immediately: the definition is removed from the config's
-    ``scenario:`` mapping, and the matching HDF5 group (if the active store
+    ``scenarios:`` mapping, and the matching HDF5 group (if the active store
     has one) is deleted right away — not left for the next Run Sweep to
     notice and prune. ``cache_purged`` in the response tells the caller
     whether there was actually a cached result to clear.

--- a/boulder/api/routes/sweep.py
+++ b/boulder/api/routes/sweep.py
@@ -46,7 +46,7 @@ _RUNNER_NAME = "run_sweep.py"
 
 
 # Run-set sizing lives in boulder.runset (the reference implementation of the
-# scenario:/sweep: union semantics) — the old local mirror is gone.
+# scenarios:/sweep: union semantics) — the old local mirror is gone.
 _run_set_size = run_set_size
 
 
@@ -61,14 +61,14 @@ def _local_runner_path_for(config_path: Optional[str]) -> Optional[Path]:
 def has_run_set(raw: Dict[str, Any], config_path: Optional[str]) -> bool:
     """Return whether *raw* (the inheritance-resolved config) declares a run-set.
 
-    True when it has an inline ``scenario:``/``sweep:``/``sweeps:`` block, or a
+    True when it has an inline ``scenarios:``/``sweep:``/``sweeps:`` block, or a
     ``run_sweep.py`` sits next to the config (a host-defined run-set: the runner
     script decides the cases — e.g. adaptive/bisection sweeps a static ``sweep:``
     block can't express). Pure function of ``(raw, config_path)`` so both the
     request-scoped sweep routes and the app-startup lifespan can share one
     detection rule instead of re-deciding "is this a sweep config?" twice.
     """
-    if raw.get("scenario") or sweeps_of(raw):
+    if raw.get("scenarios") or sweeps_of(raw):
         return True
     return _local_runner_path_for(config_path) is not None
 

--- a/boulder/cantera_converter.py
+++ b/boulder/cantera_converter.py
@@ -13,6 +13,7 @@ from typing import (
     Sequence,
     Set,
     Tuple,
+    Type,
     cast,
 )
 
@@ -113,6 +114,19 @@ class BoulderPlugins:
     cyto_element_synthesizers: List[
         Callable[[Dict[str, Any]], List[Dict[str, Any]]]
     ] = field(default_factory=list)
+
+    #: Converter class used by :mod:`boulder.sweep_runner` to solve each
+    #: scenario, and (when a caller doesn't pass ``resolve_mechanism``
+    #: explicitly) to derive the mechanism-name resolver used for
+    #: fingerprinting and the persisted store too. ``None`` (the default)
+    #: means the plain :class:`DualCanteraConverter` — bare mechanism names
+    #: pass through unchanged. A host with its own mechanism search
+    #: convention (e.g. a private ``data/mechanisms/`` directory) registers
+    #: its ``DualCanteraConverter`` subclass here instead of only wiring
+    #: ``resolve_mechanism`` overrides into the GUI-server's own
+    #: ``runner_class.converter_class`` path — otherwise out-of-process
+    #: entry points like the sweep runner never see that override at all.
+    converter_class: Optional[Type[Any]] = None
 
     #: Per-source provenance for introspection (``boulder plugins list``).
     #: ``{"entry_point": [(ep_name, module)], "env_var": [module_name]}``.

--- a/boulder/cli.py
+++ b/boulder/cli.py
@@ -159,7 +159,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--sweep",
         action="store_true",
         help=(
-            "Headless run-set runner: expand the config's scenario:/sweep: blocks, "
+            "Headless run-set runner: expand the config's scenarios:/sweep: blocks, "
             "solve every run, and serialize each into the collection store. Uses a "
             "host-registered sweep runner (BoulderPlugins.sweep_runner). No web UI."
         ),

--- a/boulder/config.py
+++ b/boulder/config.py
@@ -48,7 +48,7 @@ STONE_TOP_LEVEL_KEYS: frozenset = frozenset(
         "export",
         "sweeps",
         "sweep",
-        "scenario",
+        "scenarios",
     }
 )
 
@@ -66,7 +66,7 @@ STONE_V2_BASE_KEYS: frozenset = frozenset(
         "export",
         "sweeps",
         "sweep",
-        "scenario",
+        "scenarios",
         "continuation",
         "signals",
         "bindings",
@@ -553,7 +553,7 @@ def _normalize_v2_network(raw: Dict[str, Any]) -> Dict[str, Any]:
         "export",
         "sweeps",
         "sweep",
-        "scenario",
+        "scenarios",
         "continuation",
         "signals",
         "bindings",
@@ -857,7 +857,7 @@ def _normalize_v2_staged(raw: Dict[str, Any]) -> Dict[str, Any]:
         "export",
         "sweeps",
         "sweep",
-        "scenario",
+        "scenarios",
         "continuation",
         "signals",
         "bindings",
@@ -1990,7 +1990,7 @@ def convert_to_stone_format(config: dict) -> dict:
     if "settings" in config:
         stone_config["settings"] = config["settings"]
 
-    for passthrough in ("output", "export", "sweeps", "sweep", "scenario"):
+    for passthrough in ("output", "export", "sweeps", "sweep", "scenarios"):
         if passthrough in config:
             stone_config[passthrough] = config[passthrough]
 

--- a/boulder/runset.py
+++ b/boulder/runset.py
@@ -1,19 +1,21 @@
-"""STONE run-set primitives: inline ``scenario:`` / ``sweep:`` expansion.
+"""STONE run-set primitives: inline ``scenarios:`` / ``sweep:`` expansion.
 
 A STONE YAML may declare parameter variations inline (STONE_SPECIFICATIONS.md,
 Section 14), avoiding a glob of overlay files:
 
-``scenario:``
+``scenarios:``
     Mapping ``{id: overlay-subtree}``. Each value is a STONE subtree
     (``metadata``/``settings``/``network``/…) deep-merged onto the base via
     :func:`deep_merge` (which supports id-keyed ``nodes``/``connections``
     merging) — exactly the overlay a standalone ``from:`` file carries. The
-    mapping **key is the scenario id**.
+    mapping **key is the scenario id**. (A *list*-valued top-level
+    ``scenarios:`` is the legacy pre-mapping dialect and is rejected —
+    see :func:`expand_scenarios`.)
 
 ``sweep:`` (or ``sweeps:``)
     Mapping axis name → ``{path, values | min/max/num}``, crossed as a
     Cartesian product. May appear at the top level (expanded on the base) or
-    *inside* a ``scenario:`` entry (expanded on that scenario only).
+    *inside* a ``scenarios:`` entry (expanded on that scenario only).
 
 This module is the reference implementation of those semantics: the Run Sweep
 API sizes run-sets with :func:`run_set_size`, and the generic
@@ -31,6 +33,14 @@ from __future__ import annotations
 import copy
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Mapping, Optional, Tuple
+
+#: Scenario id for the unmodified base config's own run-set entry, added
+#: automatically whenever a ``scenarios:`` mapping is declared (see
+#: :func:`expand_scenarios`). Reserved: a host must reject this as a
+#: user-authored scenario id (see ``scenario_editor._validate_id``) since a
+#: config could otherwise define its own "BASELINE" overlay that collides
+#: with this synthesized entry.
+BASELINE_SCENARIO_ID = "BASELINE"
 
 # ---------------------------------------------------------------------------
 # Deep merge with id-keyed list support (the STONE overlay merge).
@@ -117,7 +127,7 @@ def load_yaml_with_inheritance(path: "str | Path") -> dict:
     ``from``). Relative ``from`` paths are resolved against the current file
     directory.
 
-    The ``scenario:`` directive is **not inherited**: a named scenario mapping
+    The ``scenarios:`` directive is **not inherited**: a named scenario mapping
     declares *this* file's run-set, so a parent's scenarios must not leak into
     a child (which would re-run them against the child's base). ``sweep:`` /
     ``sweeps:`` **are** inherited — a child overlay legitimately re-runs the
@@ -145,7 +155,7 @@ def load_yaml_with_inheritance(path: "str | Path") -> dict:
 
     parent_path = (path.parent / str(from_path)).resolve()
     base = load_yaml_with_inheritance(parent_path)
-    base.pop("scenario", None)  # the named run-set is not inherited (sweeps are)
+    base.pop("scenarios", None)  # the named run-set is not inherited (sweeps are)
     return deep_merge(base, overlay)
 
 
@@ -224,16 +234,19 @@ def _sweep_size(sweeps_block: dict) -> int:
 
 
 def run_set_size(raw: Dict[str, Any]) -> int:
-    """Return the union run-set size of a config's ``scenario:``/``sweep:`` blocks.
+    """Return the union run-set size of a config's ``scenarios:``/``sweep:`` blocks.
 
-    Global sweep points ⊎ each ``scenario:`` entry (its inner sweep, else 1) —
-    the same union semantics :func:`expand_scenarios` implements, computed
-    without deep-merging or resolving sweep paths (cheap enough for an
-    availability endpoint).
+    The unmodified base config (:data:`BASELINE_SCENARIO_ID`) ⊎ global sweep
+    points ⊎ each ``scenarios:`` entry (its inner sweep, else 1) — the same
+    union semantics :func:`expand_scenarios` implements, computed without
+    deep-merging or resolving sweep paths (cheap enough for an availability
+    endpoint).
     """
-    scenario = raw.get("scenario") or {}
-    total = _sweep_size(sweeps_of(raw))
-    for overlay in scenario.values():
+    scenarios = raw.get("scenarios") or {}
+    scenarios = scenarios if isinstance(scenarios, dict) else {}
+    total = 1 if scenarios else 0
+    total += _sweep_size(sweeps_of(raw))
+    for overlay in scenarios.values():
         inner = sweeps_of(overlay or {})
         total += _sweep_size(inner) if inner else 1
     return total
@@ -270,10 +283,10 @@ def expand_scenarios(
     symbols: Optional[Mapping[str, str]] = None,
     schema_entry: Optional[Callable[[str], Any]] = None,
 ) -> List[Tuple[str, dict]]:
-    """Expand a STONE YAML's inline ``scenario:`` / ``sweep:`` blocks.
+    """Expand a STONE YAML's inline ``scenarios:`` / ``sweep:`` blocks.
 
     **Union semantics** (not a global cross-product): the run set is the
-    base's global-sweep points **⊎** each ``scenario:`` entry (each expanded
+    base's global-sweep points **⊎** each ``scenarios:`` entry (each expanded
     across its *own* inner sweep if it declares one). A top-level sweep and
     the scenarios do not cross-multiply.
 
@@ -299,20 +312,25 @@ def expand_scenarios(
     -------
     list of tuple
         ``[(scenario_id, merged_config_dict), ...]``. Each merged dict is a
-        deep copy with the ``scenario``/``sweep`` directives stripped, and
-        ``metadata.scenario_id`` set to the scenario id.
+        deep copy with the ``scenarios``/``sweep`` directives stripped, and
+        ``metadata.scenario_id`` set to the scenario id. When a ``scenarios:``
+        mapping is declared, the unmodified base config is always the first
+        entry, id :data:`BASELINE_SCENARIO_ID` — otherwise it would never be
+        part of the run-set at all (the union below only covers the named
+        overlays), so ``Run Sweep`` would silently never solve it.
     """
-    if "scenarios" in base_raw:
+    raw_scenarios = base_raw.get("scenarios")
+    if isinstance(raw_scenarios, list):
         raise ValueError(
-            "top-level 'scenarios:' (list of {id, set, metadata}) is no longer "
-            "supported; migrate to the 'scenario:' mapping form — "
-            "'scenario: {<scenario_id>: <overlay-subtree>}'. See "
+            "top-level 'scenarios:' as a list ([{id, set, metadata}, ...]) is "
+            "no longer supported; migrate to the mapping form — "
+            "'scenarios: {<scenario_id>: <overlay-subtree>}'. See "
             "boulder.runset.expand_scenarios."
         )
 
     base_meta = base_raw.get("metadata") or {}
     base_id = base_meta.get("scenario_id", "BASE")
-    scenario_block = base_raw.get("scenario") or {}
+    scenario_block = raw_scenarios or {}
     global_sweeps = sweeps_of(base_raw)
 
     if not scenario_block and not global_sweeps:
@@ -323,13 +341,23 @@ def expand_scenarios(
 
     # Strip the directives from the base so downstream consumers never see them.
     base_clean = copy.deepcopy(base_raw)
-    for key in ("scenario", "sweep", "sweeps"):
+    for key in ("scenarios", "sweep", "sweeps"):
         base_clean.pop(key, None)
 
     expanded: List[Tuple[str, dict]] = []
 
     def _with_id(cfg: dict, sid: str) -> dict:
         return deep_merge(cfg, {"metadata": {"scenario_id": sid}})
+
+    # 0) The unmodified base config, always first -- named scenarios: overlays
+    # only add to the run-set, they never stand in for the base itself.
+    if scenario_block:
+        expanded.append(
+            (
+                BASELINE_SCENARIO_ID,
+                _with_id(copy.deepcopy(base_clean), BASELINE_SCENARIO_ID),
+            )
+        )
 
     # 1) Global sweep points, expanded on the base.
     for sweep_id, patch in (

--- a/boulder/scenario_editor.py
+++ b/boulder/scenario_editor.py
@@ -1,4 +1,4 @@
-"""Scenario authoring: create/update/delete a named ``scenario:`` overlay on disk.
+"""Scenario authoring: create/update/delete a named ``scenarios:`` overlay on disk.
 
 Complements :mod:`boulder.api.routes.scenarios` (which only *reads* precomputed
 trajectories from the HDF5 scenario store) with the input side of the Scenario
@@ -6,7 +6,7 @@ Pane: creating a new scenario adds a new named overlay, editing it changes
 only that overlay's subtree, and ``Run Sweep`` is what turns overlays into
 trajectories.
 
-Every function here mutates only the targeted ``scenario.<id>`` subtree of the
+Every function here mutates only the targeted ``scenarios.<id>`` subtree of the
 YAML on disk via ``ruamel.yaml`` — nodes, connections, settings, and comments
 elsewhere in the file are left untouched.
 """
@@ -26,8 +26,14 @@ from .config import (
     load_yaml_string_with_comments,
     yaml_to_string_with_comments,
 )
+from .runset import BASELINE_SCENARIO_ID
 
 _ID_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+
+#: Scenario ids a user cannot author — reserved for a synthesized run-set
+#: entry (see boulder.runset.expand_scenarios). A user-declared "scenarios:"
+#: entry with a reserved id would otherwise collide with that synthesized one.
+_RESERVED_SCENARIO_IDS = frozenset({BASELINE_SCENARIO_ID})
 
 
 class ScenarioEditError(ValueError):
@@ -38,6 +44,11 @@ def _validate_id(scenario_id: str) -> None:
     if not scenario_id or not _ID_RE.match(scenario_id):
         raise ScenarioEditError(
             f"Invalid scenario id {scenario_id!r}: use letters, digits, '_' or '-' only"
+        )
+    if scenario_id in _RESERVED_SCENARIO_IDS:
+        raise ScenarioEditError(
+            f"Scenario id {scenario_id!r} is reserved (the unmodified base "
+            "config's own run-set entry) and cannot be used for an authored scenario"
         )
 
 
@@ -61,10 +72,21 @@ def _overlay_yaml_text(overlay: Any) -> str:
 
 
 def list_scenario_ids(cfg_path: Path) -> List[str]:
-    """Return the ``scenario:`` mapping's keys, in file order."""
+    """Return the run-set's scenario ids, in run-set order.
+
+    The unmodified base config's own synthesized entry
+    (:data:`~boulder.runset.BASELINE_SCENARIO_ID`) is prepended whenever the
+    ``scenarios:`` mapping is non-empty — matching
+    :func:`boulder.runset.expand_scenarios`, which always solves it first —
+    so it's listed (and clonable, see :func:`create_scenario`) even before
+    the first Run Sweep.
+    """
     data = _load(cfg_path)
-    scenario_map = data.get("scenario") or {}
-    return list(scenario_map.keys())
+    scenario_map = data.get("scenarios") or {}
+    ids = list(scenario_map.keys())
+    if ids:
+        ids.insert(0, BASELINE_SCENARIO_ID)
+    return ids
 
 
 def create_scenario(
@@ -73,18 +95,20 @@ def create_scenario(
     """Add a new (blank or cloned) scenario overlay. Returns its YAML text."""
     _validate_id(scenario_id)
     data = _load(cfg_path)
-    scenario_map = data.get("scenario")
+    scenario_map = data.get("scenarios")
     if scenario_map is None:
         scenario_map = CommentedMap()
-        data["scenario"] = scenario_map
+        data["scenarios"] = scenario_map
     if scenario_id in scenario_map:
         raise ScenarioEditError(f"Scenario {scenario_id!r} already exists")
 
-    if base_scenario_id is not None:
+    if base_scenario_id is not None and base_scenario_id != BASELINE_SCENARIO_ID:
         if base_scenario_id not in scenario_map:
             raise ScenarioEditError(f"Unknown base scenario {base_scenario_id!r}")
         overlay = copy.deepcopy(scenario_map[base_scenario_id])
     else:
+        # No base, or cloning BASELINE (the unmodified base config) -- either
+        # way, a blank overlay: BASELINE has no overlay subtree of its own.
         overlay = CommentedMap()
 
     scenario_map[scenario_id] = overlay
@@ -95,7 +119,7 @@ def create_scenario(
 def read_scenario(cfg_path: Path, scenario_id: str) -> str:
     """Return one scenario overlay's YAML text (for the scoped editor)."""
     data = _load(cfg_path)
-    scenario_map = data.get("scenario") or {}
+    scenario_map = data.get("scenarios") or {}
     if scenario_id not in scenario_map:
         raise ScenarioEditError(f"Unknown scenario {scenario_id!r}")
     return _overlay_yaml_text(scenario_map[scenario_id])
@@ -104,7 +128,7 @@ def read_scenario(cfg_path: Path, scenario_id: str) -> str:
 def update_scenario(cfg_path: Path, scenario_id: str, yaml_text: str) -> str:
     """Replace one scenario overlay's subtree from edited YAML text."""
     data = _load(cfg_path)
-    scenario_map = data.get("scenario")
+    scenario_map = data.get("scenarios")
     if not scenario_map or scenario_id not in scenario_map:
         raise ScenarioEditError(f"Unknown scenario {scenario_id!r}")
     try:
@@ -122,7 +146,7 @@ def rename_scenario(cfg_path: Path, scenario_id: str, new_id: str) -> None:
     """Rename a scenario's key. Note: moves it to the end of the mapping."""
     _validate_id(new_id)
     data = _load(cfg_path)
-    scenario_map = data.get("scenario")
+    scenario_map = data.get("scenarios")
     if not scenario_map or scenario_id not in scenario_map:
         raise ScenarioEditError(f"Unknown scenario {scenario_id!r}")
     if new_id in scenario_map:
@@ -134,7 +158,7 @@ def rename_scenario(cfg_path: Path, scenario_id: str, new_id: str) -> None:
 def delete_scenario(cfg_path: Path, scenario_id: str) -> None:
     """Remove a scenario overlay. The next sweep prunes its stale HDF5 group."""
     data = _load(cfg_path)
-    scenario_map = data.get("scenario")
+    scenario_map = data.get("scenarios")
     if not scenario_map or scenario_id not in scenario_map:
         raise ScenarioEditError(f"Unknown scenario {scenario_id!r}")
     del scenario_map[scenario_id]

--- a/boulder/sweep_runner.py
+++ b/boulder/sweep_runner.py
@@ -42,7 +42,7 @@ from typing import Any, Callable, Dict, Optional, Tuple
 
 import h5py
 
-from .cantera_converter import DualCanteraConverter, get_plugins
+from .cantera_converter import BoulderPlugins, DualCanteraConverter, get_plugins
 from .config import normalize_config
 from .payload_store import write_payload
 from .runset import expand_scenarios, load_yaml_with_inheritance, resolve_store_path
@@ -51,6 +51,31 @@ from .runset import expand_scenarios, load_yaml_with_inheritance, resolve_store_
 def _mechanism_of(raw: Dict[str, Any]) -> str:
     gas = (raw.get("phases") or {}).get("gas") or {}
     return str(gas.get("mechanism") or "")
+
+
+def _default_resolve_mechanism(plugins: BoulderPlugins) -> Callable[[str], str]:
+    """Derive a mechanism-name resolver from ``plugins.converter_class``.
+
+    Used whenever a caller doesn't pass ``resolve_mechanism`` explicitly, so a
+    host that registers its own converter subclass (for its own mechanism
+    search convention) gets consistent resolution everywhere -- the actual
+    solve (:func:`_solve`), the cache fingerprint, and what's persisted to the
+    store -- without every call site needing to know about the plugin. Falls
+    back to the base :class:`DualCanteraConverter`'s passthrough
+    (``resolve_mechanism`` returns its argument unchanged) when no converter
+    class is registered.
+
+    Uses ``__new__`` rather than a normal constructor call: ``__init__``
+    eagerly loads a real ``ct.Solution`` for the (possibly default)
+    mechanism, which would be wasteful -- or outright fail for a host with no
+    sensible default -- just to obtain a method reference. This assumes
+    ``resolve_mechanism`` overrides don't depend on ``__init__``-set instance
+    state (true for the base class, and any host override should preserve
+    this too).
+    """
+    converter_cls = plugins.converter_class or DualCanteraConverter
+    instance = converter_cls.__new__(converter_cls)
+    return instance.resolve_mechanism
 
 
 def scenario_fingerprint(
@@ -65,15 +90,18 @@ def scenario_fingerprint(
     writer both call this; do not re-implement the cache key elsewhere.
     ``extra`` mixes caller-specific inputs into the hash (e.g. a save grid that
     lives outside the solved network config). ``resolve_mechanism`` maps a bare
-    mechanism name to the identity actually hashed (hosts pass their
-    name→absolute-path resolver so fingerprints match their store contents).
+    mechanism name to the identity actually hashed — defaults to the resolver
+    derived from ``plugins.converter_class`` (see
+    :func:`_default_resolve_mechanism`) so fingerprints match the store
+    contents without the caller needing to pass its own resolver explicitly.
     """
     from .result_cache import compute_fingerprint  # noqa: PLC0415
 
     plugins = get_plugins()
     config = normalize_config(copy.deepcopy(raw_cfg), plugins=plugins)
     mechanism = _mechanism_of(raw_cfg)
-    if resolve_mechanism is not None:
+    if mechanism:
+        resolve_mechanism = resolve_mechanism or _default_resolve_mechanism(plugins)
         mechanism = resolve_mechanism(mechanism)
     return compute_fingerprint(config, mechanism=mechanism, extra=extra)
 
@@ -92,7 +120,11 @@ def _prepare(
     plugins = get_plugins()
     config = normalize_config(copy.deepcopy(raw_cfg), plugins=plugins)
     mechanism = _mechanism_of(raw_cfg)
-    hashed = resolve_mechanism(mechanism) if resolve_mechanism else mechanism
+    if mechanism:
+        resolve_mechanism = resolve_mechanism or _default_resolve_mechanism(plugins)
+        hashed = resolve_mechanism(mechanism)
+    else:
+        hashed = mechanism
     fingerprint = compute_fingerprint(config, mechanism=hashed)
     return config, mechanism, fingerprint
 
@@ -100,7 +132,8 @@ def _prepare(
 def _solve(config: Dict[str, Any], mechanism: str) -> Tuple[Dict[str, Any], str]:
     """Solve one normalized scenario config → (gui_payload, resolved mechanism)."""
     plugins = get_plugins()
-    conv = DualCanteraConverter(mechanism=mechanism or None, plugins=plugins)
+    converter_cls = plugins.converter_class or DualCanteraConverter
+    conv = converter_cls(mechanism=mechanism or None, plugins=plugins)
     conv.build_network(config)
 
     settings = config.get("settings") or {}
@@ -197,7 +230,9 @@ def run(
         (e.g. registering a mechanism directory on Cantera's search path).
     resolve_mechanism : callable, optional
         ``name -> str`` mapping a bare mechanism name to the identity stored
-        and hashed (typically an absolute path). Defaults to the name itself.
+        and hashed (typically an absolute path). Defaults to the resolver
+        derived from ``plugins.converter_class`` (see
+        :func:`_default_resolve_mechanism`).
     scenario_attrs : callable, optional
         ``(scenario_id, merged_config, gui_payload) -> dict`` of extra scalar
         attributes written onto the scenario's HDF5 group after each solve —
@@ -211,7 +246,9 @@ def run(
     """
     if setup is not None:
         setup()
-    _resolve = resolve_mechanism or (lambda name: name)
+    plugins = get_plugins()
+    _do_resolve = resolve_mechanism or _default_resolve_mechanism(plugins)
+    _resolve = lambda name: _do_resolve(name) if name else name  # noqa: E731
     raw = load_yaml_with_inheritance(cfg_path)
     store = resolve_store_path(raw, cfg_path)
     assert store is not None  # cfg_path is always set here

--- a/boulder/sweep_runner.py
+++ b/boulder/sweep_runner.py
@@ -1,7 +1,7 @@
 """Generic scenario/sweep runner → composite collection store (for the GUI Run Sweep).
 
 Invoked out-of-process by the ``/api/sweep`` routes for any config that declares
-``scenario:`` and/or ``sweep:``. It:
+``scenarios:`` and/or ``sweep:``. It:
 
 1. loads the raw config (``from:`` inheritance resolved),
 2. expands the union run-set with :func:`boulder.runset.expand_scenarios`,
@@ -38,7 +38,7 @@ import copy
 import os
 import time
 from pathlib import Path
-from typing import Any, Callable, Dict, Optional, Tuple
+from typing import Any, Callable, Dict, Optional, Tuple, Type
 
 import h5py
 
@@ -73,7 +73,9 @@ def _default_resolve_mechanism(plugins: BoulderPlugins) -> Callable[[str], str]:
     state (true for the base class, and any host override should preserve
     this too).
     """
-    converter_cls = plugins.converter_class or DualCanteraConverter
+    converter_cls: Type[DualCanteraConverter] = (
+        plugins.converter_class or DualCanteraConverter
+    )
     instance = converter_cls.__new__(converter_cls)
     return instance.resolve_mechanism
 
@@ -224,7 +226,7 @@ def run(
     Parameters
     ----------
     cfg_path : Path
-        The STONE config declaring ``scenario:`` / ``sweep:``.
+        The STONE config declaring ``scenarios:`` / ``sweep:``.
     setup : callable, optional
         Called once before anything else — host process-level preparation
         (e.g. registering a mechanism directory on Cantera's search path).
@@ -311,7 +313,7 @@ def run(
 
 def main(argv: "list[str] | None" = None) -> None:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("config", help="STONE config with scenario:/sweep:")
+    parser.add_argument("config", help="STONE config with scenarios:/sweep:")
     parser.add_argument("--no-plot", action="store_true", help="(accepted, ignored)")
     args = parser.parse_args(argv)
     run(Path(args.config).resolve())

--- a/tests/test_runset.py
+++ b/tests/test_runset.py
@@ -1,4 +1,4 @@
-"""Unit tests for :mod:`boulder.runset` — the scenario:/sweep: reference implementation.
+"""Unit tests for :mod:`boulder.runset` — the scenarios:/sweep: reference implementation.
 
 Ported from the host package that pioneered the semantics, so the union rules,
 id naming, and error messages stay locked while living upstream.
@@ -24,7 +24,7 @@ from boulder.runset import (
 
 
 def test_expand_scenarios_no_block_returns_single_base():
-    """A YAML without scenario:/sweep: yields a single scenario.
+    """A YAML without scenarios:/sweep: yields a single scenario.
 
     whose id matches ``metadata.scenario_id``.
     """
@@ -48,29 +48,32 @@ def test_expand_scenarios_legacy_scenarios_list_raises_migration_error():
         "metadata": {"scenario_id": "BASE"},
         "scenarios": [{"id": "old_style", "set": {"metadata": {"x": 1}}}],
     }
-    with pytest.raises(ValueError, match="no longer supported.*'scenario:' mapping"):
+    with pytest.raises(ValueError, match="no longer supported.*mapping form"):
         expand_scenarios(base)
 
 
 def test_expand_scenario_mapping_deep_merges_overlays():
-    """Deep-merge each `scenario:` overlay onto the base.
+    """Deep-merge each `scenarios:` overlay onto the base.
 
     The key is the scenario id; id-keyed lists (``nodes``) merge by id.
     """
     base = {
         "metadata": {"scenario_id": "BASE"},
         "nodes": [{"id": "torch", "properties": {"T_out": 2500}}],
-        "scenario": {
+        "scenarios": {
             "hot": {"nodes": [{"id": "torch", "properties": {"T_out": 3000}}]},
             "cold": {"nodes": [{"id": "torch", "properties": {"T_out": 2000}}]},
         },
     }
     out = expand_scenarios(base)
-    assert [sid for sid, _ in out] == ["hot", "cold"]
-    assert out[0][1]["nodes"][0]["properties"]["T_out"] == 3000
-    assert out[1][1]["nodes"][0]["properties"]["T_out"] == 2000
-    assert out[0][1]["metadata"]["scenario_id"] == "hot"
-    assert "scenario" not in out[0][1]
+    # BASELINE (the unmodified base) is always first when scenarios: is declared.
+    assert [sid for sid, _ in out] == ["BASELINE", "hot", "cold"]
+    assert out[0][1]["nodes"][0]["properties"]["T_out"] == 2500
+    assert out[1][1]["nodes"][0]["properties"]["T_out"] == 3000
+    assert out[2][1]["nodes"][0]["properties"]["T_out"] == 2000
+    assert out[0][1]["metadata"]["scenario_id"] == "BASELINE"
+    assert out[1][1]["metadata"]["scenario_id"] == "hot"
+    assert "scenarios" not in out[0][1]
 
 
 def test_expand_scenario_plus_global_sweep_is_union_not_cartesian():
@@ -81,14 +84,14 @@ def test_expand_scenario_plus_global_sweep_is_union_not_cartesian():
         "sweep": {
             "T": {"path": "nodes[id=torch].properties.T_out", "values": [2600, 2700]}
         },
-        "scenario": {
+        "scenarios": {
             "hot": {"nodes": [{"id": "torch", "properties": {"T_out": 3000}}]},
         },
     }
     out = expand_scenarios(base)
     ids = [sid for sid, _ in out]
-    # 2 global sweep points + 1 scenario = 3 (not 2*1 cross product).
-    assert ids == ["BASE__T=2600", "BASE__T=2700", "hot"]
+    # BASELINE + 2 global sweep points + 1 scenario = 4 (not a cross product).
+    assert ids == ["BASELINE", "BASE__T=2600", "BASE__T=2700", "hot"]
 
 
 def test_expand_scenario_local_sweep_multiplies_only_that_scenario():
@@ -96,7 +99,7 @@ def test_expand_scenario_local_sweep_multiplies_only_that_scenario():
     base = {
         "metadata": {"scenario_id": "BASE"},
         "nodes": [{"id": "torch", "properties": {"T_out": 2500}}],
-        "scenario": {
+        "scenarios": {
             "plain": {"nodes": [{"id": "torch", "properties": {"T_out": 2000}}]},
             "swept": {
                 "sweep": {
@@ -109,7 +112,12 @@ def test_expand_scenario_local_sweep_multiplies_only_that_scenario():
         },
     }
     out = expand_scenarios(base)
-    assert [sid for sid, _ in out] == ["plain", "swept__T=2800", "swept__T=2900"]
+    assert [sid for sid, _ in out] == [
+        "BASELINE",
+        "plain",
+        "swept__T=2800",
+        "swept__T=2900",
+    ]
     swept = {sid: cfg for sid, cfg in out}
     assert swept["swept__T=2800"]["nodes"][0]["properties"]["T_out"] == 2800
 
@@ -259,12 +267,14 @@ def test_run_set_size_matches_expand_scenarios():
     raw = {
         "metadata": {"scenario_id": "BASE"},
         "sweep": {"T": {"path": "metadata.t", "values": [1, 2]}},
-        "scenario": {
+        "scenarios": {
             "plain": {},
             "swept": {"sweep": {"P": {"path": "metadata.p", "values": [3, 4, 5]}}},
         },
     }
-    assert run_set_size(raw) == len(expand_scenarios(raw)) == 6  # 2 ⊎ (1 + 3)
+    assert (
+        run_set_size(raw) == len(expand_scenarios(raw)) == 7
+    )  # 1 (BASELINE) ⊎ 2 ⊎ (1 + 3)
 
 
 def test_run_set_size_malformed_axis_counts_zero():
@@ -297,7 +307,7 @@ def test_deep_merge_plain_lists_replace():
 
 
 def test_load_yaml_with_inheritance_sweeps_inherited_scenario_not(tmp_path: Path):
-    """``sweep:`` is inherited through ``from:``; ``scenario:`` is not.
+    """``sweep:`` is inherited through ``from:``; ``scenarios:`` is not.
 
     A parent's named run-set must not leak into a child overlay, but a child
     legitimately re-runs the parent's parameter sweep with overrides.
@@ -307,7 +317,7 @@ def test_load_yaml_with_inheritance_sweeps_inherited_scenario_not(tmp_path: Path
         "metadata: {scenario_id: PARENT}\n"
         "sweep:\n"
         "  T: {path: metadata.t, values: [1, 2]}\n"
-        "scenario:\n"
+        "scenarios:\n"
         "  variant_a: {metadata: {x: 1}}\n",
         encoding="utf-8",
     )
@@ -317,5 +327,5 @@ def test_load_yaml_with_inheritance_sweeps_inherited_scenario_not(tmp_path: Path
     )
     cfg = load_yaml_with_inheritance(child)
     assert cfg["metadata"]["scenario_id"] == "CHILD"
-    assert "scenario" not in cfg
+    assert "scenarios" not in cfg
     assert cfg["sweep"]["T"]["values"] == [1, 2]

--- a/tests/test_scenario_editing.py
+++ b/tests/test_scenario_editing.py
@@ -1,7 +1,7 @@
 """Tests for scenario authoring: POST/PATCH/DELETE /api/scenarios*.
 
 Unlike the read routes in ``test_scenario_focus.py`` (which serve precomputed
-HDF5 trajectories), these edit the *source* config file's ``scenario:``
+HDF5 trajectories), these edit the *source* config file's ``scenarios:``
 mapping on disk — the input side of the Scenario Pane's create/edit workflow.
 """
 
@@ -30,7 +30,7 @@ network:
       temperature: 298.15
       pressure: 101325
       composition: "CH4:1"
-scenario:
+scenarios:
   base_case:
     metadata:
       scenario_name: "Base Case"
@@ -76,9 +76,9 @@ def test_create_scenario_blank(tmp_path: Path) -> None:
         resp = client.post("/api/scenarios", json={"scenario_id": "new1"})
         assert resp.status_code == 200, resp.text
         assert resp.json()["scenario_id"] == "new1"
-        assert _scenario_ids(cfg) == ["base_case", "new1"]
+        assert _scenario_ids(cfg) == ["BASELINE", "base_case", "new1"]
         # preloaded_raw refreshed so Run Sweep sees the new scenario immediately.
-        assert "new1" in (app.state.preloaded_raw.get("scenario") or {})
+        assert "new1" in (app.state.preloaded_raw.get("scenarios") or {})
         # The pre-existing comment elsewhere in the file survives.
         assert "keep this comment" in cfg.read_text(encoding="utf-8")
     finally:
@@ -116,6 +116,39 @@ def test_create_scenario_bad_id_422(tmp_path: Path) -> None:
     try:
         resp = client.post("/api/scenarios", json={"scenario_id": "bad id!"})
         assert resp.status_code == 422
+    finally:
+        client.__exit__(None, None, None)
+
+
+def test_create_scenario_reserved_baseline_id_422(tmp_path: Path) -> None:
+    """BASELINE is reserved for the synthesized unmodified-base entry.
+
+    A user-authored "scenarios: {BASELINE: ...}" would otherwise collide with
+    it in expand_scenarios' run-set.
+    """
+    cfg = _write_config(tmp_path)
+    client, _app = _client_with_config(cfg)
+    try:
+        resp = client.post("/api/scenarios", json={"scenario_id": "BASELINE"})
+        assert resp.status_code == 422
+    finally:
+        client.__exit__(None, None, None)
+
+
+def test_create_scenario_clone_from_baseline_is_blank(tmp_path: Path) -> None:
+    """Cloning "BASELINE" must produce a blank overlay, not an unknown-base error.
+
+    BASELINE is the unmodified base config, not a real scenario_map entry.
+    """
+    cfg = _write_config(tmp_path)
+    client, _app = _client_with_config(cfg)
+    try:
+        resp = client.post(
+            "/api/scenarios",
+            json={"scenario_id": "from_baseline", "base_scenario_id": "BASELINE"},
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["yaml"].strip() in ("", "{}")
     finally:
         client.__exit__(None, None, None)
 
@@ -167,7 +200,7 @@ def test_update_scenario(tmp_path: Path) -> None:
         assert "Updated" in resp.json()["yaml"]
         assert "350.0" in cfg.read_text(encoding="utf-8")
         assert (
-            app.state.preloaded_raw["scenario"]["base_case"]["metadata"][
+            app.state.preloaded_raw["scenarios"]["base_case"]["metadata"][
                 "scenario_name"
             ]
             == "Updated"
@@ -206,7 +239,7 @@ def test_rename_scenario(tmp_path: Path) -> None:
             "/api/scenarios/base_case/rename", json={"new_id": "renamed"}
         )
         assert resp.status_code == 200, resp.text
-        assert _scenario_ids(cfg) == ["renamed"]
+        assert _scenario_ids(cfg) == ["BASELINE", "renamed"]
     finally:
         client.__exit__(None, None, None)
 
@@ -218,7 +251,7 @@ def test_delete_scenario(tmp_path: Path) -> None:
         resp = client.delete("/api/scenarios/base_case")
         assert resp.status_code == 200, resp.text
         assert _scenario_ids(cfg) == []
-        assert not (app.state.preloaded_raw.get("scenario") or {})
+        assert not (app.state.preloaded_raw.get("scenarios") or {})
     finally:
         client.__exit__(None, None, None)
 
@@ -288,7 +321,7 @@ def test_list_scenarios_includes_authored_ids_without_a_store(tmp_path: Path) ->
         assert resp.status_code == 200
         body = resp.json()
         assert body["available"] is False
-        assert body["authored_ids"] == ["base_case"]
+        assert body["authored_ids"] == ["BASELINE", "base_case"]
     finally:
         client.__exit__(None, None, None)
 
@@ -301,7 +334,7 @@ def test_list_scenarios_authored_ids_reflects_a_newly_created_scenario(
     try:
         client.post("/api/scenarios", json={"scenario_id": "new1"})
         resp = client.get("/api/scenarios")
-        assert resp.json()["authored_ids"] == ["base_case", "new1"]
+        assert resp.json()["authored_ids"] == ["BASELINE", "base_case", "new1"]
     finally:
         client.__exit__(None, None, None)
 

--- a/tests/test_sweep_run_no_cache.py
+++ b/tests/test_sweep_run_no_cache.py
@@ -33,7 +33,7 @@ network:
       temperature: 298.15
       pressure: 101325
       composition: "CH4:1"
-scenario:
+scenarios:
   a:
     metadata:
       scenario_name: "A"
@@ -49,7 +49,7 @@ def _client_with_local_runner(tmp_path: Path):
     client = TestClient(app)
     client.__enter__()
     app.state.preloaded_config_path = str(cfg)
-    app.state.preloaded_raw = {"scenario": {"a": {}}}
+    app.state.preloaded_raw = {"scenarios": {"a": {}}}
     return client, app
 
 

--- a/tests/test_sweep_runner_converter_class.py
+++ b/tests/test_sweep_runner_converter_class.py
@@ -1,0 +1,112 @@
+"""Tests for boulder.sweep_runner's plugins.converter_class support.
+
+A host registers its own DualCanteraConverter subclass (e.g. for a private
+mechanism search convention) via ``plugins.converter_class`` so that
+out-of-process entry points like the sweep runner resolve mechanism names
+the same way the GUI server's own converter does -- previously only
+``resolve_mechanism``/``setup`` callbacks passed explicitly by the host
+achieved this; converter_class lets the runner derive them automatically.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from boulder.cantera_converter import BoulderPlugins, DualCanteraConverter
+from boulder.sweep_runner import (
+    _default_resolve_mechanism,
+    _prepare,
+    scenario_fingerprint,
+)
+
+
+class _FakeHostConverter(DualCanteraConverter):
+    """Stand-in for a host's converter subclass -- never touches Cantera."""
+
+    def __init__(self, mechanism: Optional[str] = None, plugins=None) -> None:
+        # Deliberately skip DualCanteraConverter.__init__: it eagerly loads a
+        # real ct.Solution, which _default_resolve_mechanism must never
+        # trigger just to obtain a method reference.
+        raise AssertionError(
+            "_FakeHostConverter.__init__ must not be called by "
+            "_default_resolve_mechanism -- it should use __new__."
+        )
+
+    def resolve_mechanism(self, name: str) -> str:
+        return f"/resolved/{name}"
+
+
+def _config(mechanism: str = "") -> Dict[str, Any]:
+    cfg: Dict[str, Any] = {"network": []}
+    if mechanism:
+        cfg["phases"] = {"gas": {"mechanism": mechanism}}
+    return cfg
+
+
+class TestDefaultResolveMechanism:
+    def test_uses_new_not_init(self):
+        """Deriving the resolver must not construct a real converter instance."""
+        plugins = BoulderPlugins(converter_class=_FakeHostConverter)
+        resolve = _default_resolve_mechanism(plugins)
+        assert resolve("gri30.yaml") == "/resolved/gri30.yaml"
+
+    def test_falls_back_to_base_converter_when_unregistered(self):
+        plugins = BoulderPlugins()
+        resolve = _default_resolve_mechanism(plugins)
+        assert resolve("gri30.yaml") == "gri30.yaml"  # passthrough default
+
+
+class TestScenarioFingerprintUsesConverterClass:
+    def test_fingerprint_reflects_host_resolved_mechanism(self, monkeypatch):
+        import boulder.sweep_runner as sweep_runner
+
+        plugins = BoulderPlugins(converter_class=_FakeHostConverter)
+        monkeypatch.setattr(sweep_runner, "get_plugins", lambda: plugins)
+
+        fp_resolved = scenario_fingerprint(_config("custom_mech.yaml"))
+        fp_plain = scenario_fingerprint(
+            _config("custom_mech.yaml"), resolve_mechanism=lambda name: name
+        )
+        # The host's resolver changes the hashed mechanism identity, so the
+        # fingerprint must differ from a plain-passthrough resolution.
+        assert fp_resolved != fp_plain
+
+    def test_empty_mechanism_never_calls_resolver(self, monkeypatch):
+        """No phases.gas.mechanism declared -- must not invoke the resolver at all.
+
+        A host's resolve_mechanism may not handle an empty/missing mechanism
+        name sensibly (e.g. it might resolve "" to a directory instead of
+        raising) -- scenario_fingerprint must not call it in that case.
+        """
+        import boulder.sweep_runner as sweep_runner
+
+        def _boom(name: str) -> str:
+            raise AssertionError("resolver must not be called for an empty mechanism")
+
+        class _BoomConverter(DualCanteraConverter):
+            def __init__(self, mechanism=None, plugins=None):
+                raise AssertionError("must not construct via __init__")
+
+            def resolve_mechanism(self, name: str) -> str:
+                return _boom(name)
+
+        plugins = BoulderPlugins(converter_class=_BoomConverter)
+        monkeypatch.setattr(sweep_runner, "get_plugins", lambda: plugins)
+
+        # Must not raise.
+        scenario_fingerprint(_config(""))
+
+
+class TestPrepareUsesConverterClass:
+    def test_prepare_derives_resolver_when_not_passed(self, monkeypatch):
+        import boulder.sweep_runner as sweep_runner
+
+        plugins = BoulderPlugins(converter_class=_FakeHostConverter)
+        monkeypatch.setattr(sweep_runner, "get_plugins", lambda: plugins)
+
+        config, mechanism, fingerprint = _prepare(_config("custom_mech.yaml"), None)
+        assert mechanism == "custom_mech.yaml"  # raw name preserved for _solve
+        # fingerprint hashed the *resolved* identity -- verify by comparing
+        # against an explicit passthrough resolver.
+        _, _, fp_plain = _prepare(_config("custom_mech.yaml"), lambda name: name)
+        assert fingerprint != fp_plain

--- a/tests/test_sweep_runset.py
+++ b/tests/test_sweep_runset.py
@@ -1,4 +1,4 @@
-"""Run-set size accounting for the Run Sweep API (scenario: ⊎ sweep:, no host import)."""
+"""Run-set size accounting for the Run Sweep API (scenarios: ⊎ sweep:, no host import)."""
 
 from __future__ import annotations
 
@@ -13,28 +13,29 @@ def test_sweep_only_counts_cartesian():
 
 
 def test_scenario_only_counts_entries():
-    raw = {"scenario": {"a": {}, "b": {}, "c": {}}}
-    assert _run_set_size(raw) == 3
+    raw = {"scenarios": {"a": {}, "b": {}, "c": {}}}
+    # BASELINE (the unmodified base) + 3 named entries = 4.
+    assert _run_set_size(raw) == 4
 
 
 def test_union_not_cartesian():
     raw = {
         "sweep": {"T": {"values": [1, 2]}},
-        "scenario": {"hot": {}, "cold": {}},
+        "scenarios": {"hot": {}, "cold": {}},
     }
-    # 2 global sweep points + 2 scenarios = 4 (not 2×2).
-    assert _run_set_size(raw) == 4
+    # BASELINE + 2 global sweep points + 2 scenarios = 5 (not a cross product).
+    assert _run_set_size(raw) == 5
 
 
 def test_scenario_local_sweep_multiplies_only_itself():
     raw = {
-        "scenario": {
+        "scenarios": {
             "plain": {},
             "swept": {"sweep": {"T": {"values": [1, 2, 3]}}},
         }
     }
-    # plain (1) + swept's inner sweep (3) = 4.
-    assert _run_set_size(raw) == 4
+    # BASELINE (1) + plain (1) + swept's inner sweep (3) = 5.
+    assert _run_set_size(raw) == 5
 
 
 def test_empty_is_zero():
@@ -42,7 +43,7 @@ def test_empty_is_zero():
 
 
 def test_has_run_set_true_for_scenario_block():
-    assert has_run_set({"scenario": {"a": {}}}, None) is True
+    assert has_run_set({"scenarios": {"a": {}}}, None) is True
 
 
 def test_has_run_set_true_for_sweep_block():
@@ -60,7 +61,7 @@ def test_has_run_set_true_for_local_run_sweep_script(tmp_path: Path):
     cfg = tmp_path / "config.yaml"
     cfg.write_text("metadata: {}\n", encoding="utf-8")
     (tmp_path / "run_sweep.py").write_text("", encoding="utf-8")
-    # No inline scenario:/sweep: block at all — the local runner script alone
+    # No inline scenarios:/sweep: block at all — the local runner script alone
     # is enough (host-defined run-set, e.g. the CH4 reactor-map sandbox).
     assert has_run_set({}, str(cfg)) is True
 


### PR DESCRIPTION
## Summary

`boulder.sweep_runner._solve()` hardcodes `DualCanteraConverter`, bypassing the plugin-based converter-class swap a regular Boulder-GUI-driven run gets (`runner_class.converter_class`, `boulder/cli.py:819`). A host that registers its own `DualCanteraConverter` subclass (e.g. for a private mechanism search directory, via `resolve_mechanism` override) is therefore invisible to the sweep runner specifically, even though it's honored everywhere else. Hosts currently have to patch around this with their own `setup`/`resolve_mechanism` callbacks passed into `run()`, rather than the runner just reusing the same converter the rest of the app already uses.

## Change

- `BoulderPlugins.converter_class: Optional[Type[Any]] = None` — a host's `DualCanteraConverter` subclass. `None` (default) preserves today's behavior (plain `DualCanteraConverter`).
- `_solve()` instantiates `plugins.converter_class or DualCanteraConverter` instead of the hardcoded base class.
- `run()` / `scenario_fingerprint()` / `_prepare()` derive their `resolve_mechanism` from `converter_class` automatically (`_default_resolve_mechanism`) whenever the caller doesn't pass one explicitly — so all three (solve, fingerprint, persisted store) agree without every call site needing to know about the plugin.
- `_default_resolve_mechanism` uses `converter_cls.__new__(converter_cls)` rather than a real constructor call — `DualCanteraConverter.__init__` eagerly loads a real `ct.Solution` (falling back to a default mechanism when none given), which would be wasteful, and could outright fail for a host with no sensible default, just to obtain a method reference.
- The derived/passed resolver is only invoked when a mechanism is actually declared — an empty/missing top-level mechanism is left untouched, since a host's resolver isn't guaranteed to handle that input sensibly.

## Verification

- New `tests/test_sweep_runner_converter_class.py` (5 tests): confirms `_default_resolve_mechanism` never triggers `__init__` (a converter whose `__init__` raises still works), falls back to the base passthrough when unregistered, and that `scenario_fingerprint`/`_prepare` derive and apply it automatically — including the empty-mechanism guard (a converter whose `resolve_mechanism` would raise on `""` is confirmed never called).
- Full existing suite: 745 passed, 5 xfailed (pre-existing, unrelated).