### PR TITLE
fix(cli): repair --sweep help text mangled by a merge conflict

### DIFF
--- a/boulder/cli.py
+++ b/boulder/cli.py
@@ -159,13 +159,13 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--sweep",
         action="store_true",
         help=(
-            "Headless run-set runner: expand the config's scenarios:/sweep: blocks, "
-            "solve every run, and serialize each into the collection store. GUI mode: opens "
+            "Expand the config's scenarios:/sweep: blocks and run the whole "
+            "run-set instead of just the base case. GUI mode (default): opens "
             "the web UI with the run-set already running (Run Sweep, not Run "
             "Simulation). With --headless: run-set runner only, no web UI — "
             "expand, solve every run, and serialize each into the collection "
             "store via a host-registered sweep runner "
-            "(BoulderPlugins.sweep_runner).
+            "(BoulderPlugins.sweep_runner)."
         ),
     )
     parser.add_argument(


### PR DESCRIPTION
## Summary

The merge of #108 (converter_class) into main happened *after* #109 (sweep
autorun) had already landed on main, and the conflict resolution on
\`--sweep\`'s argparse \`help=\` string was botched: it concatenated the
pre-#108 text with #109's autorun-aware text and dropped a closing quote,
leaving an unterminated string literal at line 168.

Result: \`import boulder.cli\` raises \`SyntaxError\`, so both \`boulder\` and
\`bloc\` fail to start at all right now on main. No pre-commit hook caught it
since there were no literal \`<<<<<<<\` conflict markers left — the merge
tool silently produced garbled-but-parseable-looking text, until it wasn't.

## Fix

Rewrote the help string to combine both intents correctly: \`scenarios:\`
(the #108 rename) + the GUI-autoruns-by-default wording (#109).

## Test plan

- [x] \`python -m py_compile\` clean (was failing before)
- [x] \`mypy boulder/cli.py\` clean
- [x] \`pre-commit run --files boulder/cli.py\` clean
- [x] \`pytest tests/test_cli_headless.py tests/test_cli_import.py\` — 7 passed
- [x] Live: \`bloc\` (no args) now starts cleanly — confirmed via log + \`/api/scenarios\` responding (previously crashed with \`AttributeError\`/\`SyntaxError\` depending on which broken commit was installed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)