### PR TITLE
docs: document how to run scenario sweeps (GUI split button + CLI flags)

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,20 @@ boulder config.yaml --headless --download output.py  # headless code generation
 boulder --dev                                # run in development mode with Vite dev server
 ```
 
+### Running scenario sweeps
+
+A config declaring a top-level `scenarios:` block (mapping of `id -> overlay`)
+and/or `sweep:`/`sweeps:` block can be run as a whole run-set instead of just
+its base case — see [`docs/usage.rst`](docs/usage.rst#running-scenario-sweeps)
+for the full walkthrough (GUI split button + caret menu, Scenario Pane, and
+the CLI's `--sweep` / `--sweep --headless` flags).
+
+```bash
+boulder some_file.yaml --sweep              # GUI, run-set auto-started on load
+boulder some_file.yaml --sweep --headless   # no GUI: run every scenario, write
+                                             # <config-stem>_scenarios.h5
+```
+
 ### Development Mode
 
 You can start both the backend and frontend development server with a single command:

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -23,6 +23,70 @@ Optional flags::
     boulder --host 0.0.0.0 --port 8050 --debug
     boulder some_file.yaml --no-open
 
+Running scenario sweeps
+------------------------
+
+A STONE config may declare extra cases inline via a top-level ``scenarios:``
+block (a mapping of ``id -> overlay``) and/or a ``sweep:``/``sweeps:`` block
+(a Cartesian-product parameter sweep). See ``STONE_SPECIFICATIONS.md``
+(Section 14) for the full schema. Whenever ``scenarios:`` is declared,
+Boulder always adds an unmodified copy of the base config as its own
+``BASELINE`` entry, first in the run set.
+
+**From the GUI**
+
+The sidebar's "Run Simulation" button is a **split button**: a small
+caret/chevron sits to its right (accessible name "Choose run action").
+Clicking it opens a menu with:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Option
+     - Description
+   * - Run Simulation
+     - Solve the single reactor as configured.
+   * - Force Run
+     - Solve ignoring cache.
+   * - Run Sweep
+     - Run *N* scenarios (the count is read live from the config).
+   * - Add Scenario…
+     - Create a new scenario overlay and edit its YAML.
+
+Selecting "Run Sweep" switches the split button's primary action to "Run
+Sweep (N scenarios)" — you then click the (now relabeled) primary button to
+actually start it. Passing ``--sweep`` on the command line (see below) skips
+this: the run-set starts automatically as soon as the page loads.
+
+The right-hand **Scenario Pane** lists every declared scenario (id, plus
+"Edit scenario YAML" / "Delete scenario" actions per entry) and an "Add
+Scenario" button to create new ones — before a sweep has run, it reads
+"Not computed yet — Run Sweep to solve them."
+
+.. note::
+
+   Screenshot placeholder — the sidebar with the "Run Simulation" split
+   button and its caret menu expanded (showing Run Simulation / Force Run /
+   Run Sweep / Add Scenario…), plus the Scenario Pane listing BASELINE and
+   the declared scenario ids.
+
+**From the CLI**
+
+::
+
+    boulder some_file.yaml --sweep              # GUI, run-set auto-started on load
+    boulder some_file.yaml --sweep --headless    # no GUI: run every scenario, print
+                                                  # "scenario N/M" progress, and write
+                                                  # <config-stem>_scenarios.h5
+
+**Both flags are required for a true headless run.** ``--sweep`` alone still
+starts a web server (with the run-set auto-started instead of requiring a
+click); ``--headless`` is what skips the server entirely and runs everything
+in the terminal. This is implemented by a host-registered
+``BoulderPlugins.sweep_runner`` (see :func:`boulder.sweep_runner.run`); a
+plain ``boulder`` install without a host plugin falls back to
+:class:`~boulder.cantera_converter.DualCanteraConverter` directly.
+
 Environment variables
 ---------------------
 


### PR DESCRIPTION
## Summary

Neither `docs/usage.rst` nor `README.md` mentioned `scenarios:`/`sweep:` at
all. The only way to learn that the GUI's "Run Sweep" is a caret dropdown on
"Run Simulation" (not a distinct button), or that `--sweep` needs
`--headless` for a true no-server run, was tribal knowledge or reading
source. Adds a "Running scenario sweeps" section to both:

- The split button's caret menu (Run Simulation / Force Run / Run Sweep /
  Add Scenario…) and what each option does.
- The Scenario Pane (lists declared scenarios, "Not computed yet" state,
  Add/Edit/Delete actions).
- The two CLI invocations (`--sweep` for GUI-with-autorun, `--sweep
  --headless` for a true no-server run) and why both flags matter.

Prompted by a user report (`spark-cleantech-l3/bloc#301`) that
`--sweep` alone "only solves the base case" and the sweep button was hard to
find — root cause was pure discoverability, already fixed in #109; this PR
is the documentation half of that fix.

## Known gap

A screenshot of the expanded caret menu + Scenario Pane would help here but
isn't included — browser screenshot tooling wasn't available while writing
this. Left as a `.. note::` placeholder in `docs/usage.rst` so a follow-up
can drop one in without restructuring anything.

## Test plan

- [x] `sphinx-build -b html docs docs/_build` — no new warnings/errors from
  `usage.rst` (verified by diffing warnings before/after this change)
- [x] Rendered HTML manually inspected — new section reads correctly
- [x] `pre-commit run --files docs/usage.rst README.md` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)