### PR TITLE
Fix editing an empty YAML and Run Sweep not seeing browser-authored scenarios

### DIFF
--- a/boulder/api/live_config.py
+++ b/boulder/api/live_config.py
@@ -1,0 +1,92 @@
+"""Adopt a browser-authored config as the server's preloaded config.
+
+Several Boulder features -- the Run Sweep button (:mod:`.routes.sweep`),
+Scenario Pane authoring (:mod:`.routes.scenarios`), and result caching
+(:mod:`...result_cache`) -- are keyed off ``app.state.preloaded_config_path``:
+a real on-disk file, normally set once at CLI startup from a YAML path
+argument (see the ``lifespan`` handler in :mod:`.main`). When Boulder is
+instead started with no file -- a browser-only deployment where users paste
+or upload their own config -- that path stays ``None`` for the whole session,
+so those features never see whatever the user is editing, even a config that
+already declares ``scenarios:``.
+
+:func:`adopt_live_config` closes that gap: the first time a live config is
+parsed or uploaded with no preloaded path set, it is written to a private
+temp file and adopted as the preloaded config, exactly as if Boulder had been
+started with that file. Subsequent edits overwrite the same temp file in
+place instead of leaving a trail of one-off files. A config that *was*
+already preloaded from a real file is left untouched -- this only ever fires
+for the "no file yet" case.
+"""
+
+from __future__ import annotations
+
+import logging
+import tempfile
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from fastapi import Request
+
+logger = logging.getLogger(__name__)
+
+#: Attribute name on ``app.state`` for the private directory backing
+#: adopted live configs (created lazily, reused across calls).
+_LIVE_CONFIG_DIR_ATTR = "_live_config_dir"
+
+
+def adopt_live_config(
+    request: Request,
+    raw: Dict[str, Any],
+    validated: Dict[str, Any],
+    yaml_str: str,
+    filename: Optional[str] = None,
+) -> None:
+    """Persist *yaml_str* to disk and adopt it as the preloaded config.
+
+    No-op when a real preloaded config path is already set (a config Boulder
+    was started with from the CLI) -- this only ever materializes the
+    "started with no file" case, and never overwrites or shadows a
+    user-provided file.
+
+    Parameters
+    ----------
+    request
+        The current request, used to reach and mutate ``app.state``.
+    raw
+        The inheritance-resolved config dict (pre-normalize -- keeps
+        ``scenarios:``/``sweep:``/``sweeps:`` blocks intact), stored as
+        ``app.state.preloaded_raw`` for the Run Sweep / Scenario Pane checks.
+    validated
+        The normalized + validated config dict, stored as
+        ``app.state.preloaded_config``.
+    yaml_str
+        The raw YAML text as authored in the browser, written verbatim to
+        the adopted file and stored as ``app.state.preloaded_yaml``.
+    filename
+        Display filename to adopt (e.g. an uploaded file's original name).
+        Defaults to ``"config.yaml"``.
+    """
+    state = request.app.state
+    live_dir = getattr(state, _LIVE_CONFIG_DIR_ATTR, None)
+    if live_dir is None:
+        # First adoption this session: bail if a *real* CLI-provided config
+        # path is already set. Once we've adopted once, `_LIVE_CONFIG_DIR_ATTR`
+        # is set and every later call is known to be updating our own
+        # ephemeral file, so this check is skipped on subsequent calls --
+        # otherwise the very first adoption would set preloaded_config_path
+        # and permanently block all later edits from ever being adopted.
+        if getattr(state, "preloaded_config_path", None):
+            return
+        live_dir = tempfile.mkdtemp(prefix="boulder-live-config-")
+        setattr(state, _LIVE_CONFIG_DIR_ATTR, live_dir)
+
+    path = Path(live_dir) / (filename or getattr(state, "preloaded_filename", None) or "config.yaml")
+    path.write_text(yaml_str, encoding="utf-8")
+
+    state.preloaded_config = validated
+    state.preloaded_raw = raw
+    state.preloaded_yaml = yaml_str
+    state.preloaded_filename = path.name
+    state.preloaded_config_path = str(path)
+    logger.info("Adopted browser-authored config as preloaded config: %s", path)

--- a/boulder/api/live_config.py
+++ b/boulder/api/live_config.py
@@ -81,7 +81,9 @@ def adopt_live_config(
         live_dir = tempfile.mkdtemp(prefix="boulder-live-config-")
         setattr(state, _LIVE_CONFIG_DIR_ATTR, live_dir)
 
-    path = Path(live_dir) / (filename or getattr(state, "preloaded_filename", None) or "config.yaml")
+    path = Path(live_dir) / (
+        filename or getattr(state, "preloaded_filename", None) or "config.yaml"
+    )
     path.write_text(yaml_str, encoding="utf-8")
 
     state.preloaded_config = validated

--- a/boulder/api/routes/configs.py
+++ b/boulder/api/routes/configs.py
@@ -23,6 +23,7 @@ from ...config import (
     validate_config,
     yaml_to_string_with_comments,
 )
+from ..live_config import adopt_live_config
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
@@ -117,6 +118,11 @@ async def parse_yaml(request: Request, body: YAMLParseRequest) -> Dict[str, Any]
         else:
             normalized = normalize_config(plain)
             validated = validate_config(normalized)
+
+        # See the Run Sweep button / Scenario Pane -- both need a real
+        # on-disk config path to work at all, which a browser-only session
+        # (no CLI-preloaded file) never has otherwise.
+        adopt_live_config(request, raw=plain, validated=validated, yaml_str=body.yaml)
 
         return {"config": validated, "yaml": body.yaml}
     except Exception as exc:
@@ -236,6 +242,14 @@ async def upload_config(
         else:
             normalized = normalize_config(plain)
             validated = validate_config(normalized)
+
+        adopt_live_config(
+            request,
+            raw=plain,
+            validated=validated,
+            yaml_str=yaml_str,
+            filename=file.filename,
+        )
 
         return {
             "config": validated,

--- a/configs/__init__.py
+++ b/configs/__init__.py
@@ -1,0 +1,10 @@
+"""Marks ``configs/`` as a real package purely so setuptools ships it.
+
+``boulder.config.get_initial_config()``/``get_initial_config_with_comments()``
+look for the built-in default config at a fixed path *sibling* to the
+installed ``boulder`` package (``dirname(dirname(__file__)) / "configs" /
+"default.yaml"``). Without this file, setuptools has no way to know this
+top-level directory should be copied into site-packages alongside ``boulder``
+when building the wheel — ``[tool.setuptools] packages`` only ships packages
+it recognises, and a plain data directory with no ``__init__.py`` isn't one.
+"""

--- a/frontend/src/components/panels/NetworkCard.test.tsx
+++ b/frontend/src/components/panels/NetworkCard.test.tsx
@@ -5,19 +5,26 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { NetworkCard } from "./NetworkCard";
 
 let mockFileName: string | null = "SPRING_A4_C1X_20260326.yaml";
 
+const mockSetConfig = vi.fn();
 vi.mock("@/stores/configStore", () => ({
   useConfigStore: (selector: (s: unknown) => unknown) =>
-    selector({ setConfig: vi.fn(), fileName: mockFileName }),
+    selector({ setConfig: mockSetConfig, fileName: mockFileName }),
 }));
 
+const mockScenarioRefresh = vi.fn();
+vi.mock("@/stores/scenarioStore", () => ({
+  useScenarioStore: { getState: () => ({ refresh: mockScenarioRefresh }) },
+}));
+
+const mockUploadConfigFile = vi.fn();
 vi.mock("@/api/configs", () => ({
-  uploadConfigFile: vi.fn(),
+  uploadConfigFile: (...args: unknown[]) => mockUploadConfigFile(...args),
 }));
 
 vi.mock("sonner", () => ({
@@ -46,5 +53,21 @@ describe("NetworkCard", () => {
     render(<NetworkCard onEditYaml={onEditYaml} />);
     fireEvent.click(screen.getByRole("button", { name: "Edit YAML" }));
     expect(onEditYaml).toHaveBeenCalledOnce();
+  });
+
+  it("nudges RunControl to re-check Run Sweep availability after an upload", async () => {
+    mockUploadConfigFile.mockResolvedValue({
+      config: { nodes: [], connections: [] },
+      filename: "uploaded.yaml",
+      yaml: "nodes: []\n",
+    });
+    render(<NetworkCard onEditYaml={vi.fn()} />);
+
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+    const file = new File(["nodes: []\n"], "uploaded.yaml", { type: "application/x-yaml" });
+    fireEvent.change(input, { target: { files: [file] } });
+
+    await waitFor(() => expect(mockSetConfig).toHaveBeenCalledOnce());
+    expect(mockScenarioRefresh).toHaveBeenCalledOnce();
   });
 });

--- a/frontend/src/components/panels/NetworkCard.tsx
+++ b/frontend/src/components/panels/NetworkCard.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useRef } from "react";
 import { useConfigStore } from "@/stores/configStore";
+import { useScenarioStore } from "@/stores/scenarioStore";
 import { uploadConfigFile } from "@/api/configs";
 import { Button } from "@/components/ui/Button";
 import { toast } from "sonner";
@@ -26,6 +27,10 @@ export function NetworkCard({ onEditYaml }: Props) {
       try {
         const resp = await uploadConfigFile(file);
         setConfig(resp.config, resp.filename, resp.yaml);
+        // The backend may have just adopted this upload as its preloaded
+        // config (if none was set yet) — bump scenarioRevision so RunControl
+        // re-checks Run Sweep availability instead of showing stale info.
+        void useScenarioStore.getState().refresh();
         toast.success(`Config uploaded: ${resp.filename}`);
       } catch (err) {
         toast.error(`Upload failed: ${err instanceof Error ? err.message : String(err)}`);

--- a/frontend/src/components/panels/YamlPane.test.tsx
+++ b/frontend/src/components/panels/YamlPane.test.tsx
@@ -53,6 +53,11 @@ vi.mock("@/stores/layoutStore", () => ({
     selector({ closeYamlPane: mockCloseYamlPane }),
 }));
 
+const mockScenarioRefresh = vi.fn();
+vi.mock("@/stores/scenarioStore", () => ({
+  useScenarioStore: { getState: () => ({ refresh: mockScenarioRefresh }) },
+}));
+
 vi.mock("@/stores/themeStore", () => ({
   useThemeStore: (selector: (s: unknown) => unknown) => selector({ theme: "light" }),
 }));
@@ -131,6 +136,9 @@ describe("YamlPane", () => {
     expect(mockParseYaml).toHaveBeenCalledWith("merged: yaml\nextra: 1\n");
     // A save that round-trips exactly what's on screen needs no re-sync.
     expect(saveButton()).toBeDisabled();
+    // Nudges RunControl to re-check Run Sweep availability: the backend may
+    // have just adopted this Save as its preloaded config.
+    expect(mockScenarioRefresh).toHaveBeenCalledOnce();
   });
 
   it("Cancel reverts unsaved edits back to the last synced value", async () => {
@@ -181,6 +189,32 @@ describe("YamlPane", () => {
 
     fireEvent.keyDown(window, { key: "s", ctrlKey: true });
     expect(mockParseYaml).not.toHaveBeenCalled();
+  });
+
+  it("mounts an empty, editable pane instead of an error when nothing is loaded yet", async () => {
+    mockConfig = { nodes: [], connections: [] };
+    mockOriginalYaml = "";
+    render(<YamlPane />);
+
+    const editor = await editorValue();
+    await waitFor(() => expect(editor).toHaveValue(""));
+    expect(screen.queryByText("No configuration available to edit.")).not.toBeInTheDocument();
+
+    fireEvent.change(editor, { target: { value: "nodes: []\n" } });
+    expect(editor).toHaveValue("nodes: []\n");
+    expect(saveButton()).not.toBeDisabled();
+  });
+
+  it("still shows the error when there's a live graph but no YAML to merge it into", async () => {
+    mockConfig = {
+      nodes: [{ id: "r1", type: "IdealGasReactor", properties: {} }],
+      connections: [],
+    };
+    mockOriginalYaml = "";
+    render(<YamlPane />);
+
+    expect(await screen.findByText("No configuration available to edit.")).toBeInTheDocument();
+    expect(mockSyncConfig).not.toHaveBeenCalled();
   });
 
   it("closes immediately when there are no unsaved edits", async () => {

--- a/frontend/src/components/panels/YamlPane.tsx
+++ b/frontend/src/components/panels/YamlPane.tsx
@@ -1,6 +1,7 @@
 import { lazy, Suspense, useCallback, useEffect, useRef, useState } from "react";
 import { FileCode, X } from "lucide-react";
 import { useConfigStore } from "@/stores/configStore";
+import { useScenarioStore } from "@/stores/scenarioStore";
 import { useLayoutStore } from "@/stores/layoutStore";
 import { useThemeStore } from "@/stores/themeStore";
 import { parseYaml, syncConfig } from "@/api/configs";
@@ -42,14 +43,19 @@ export function YamlPane() {
 
   const refresh = useCallback(() => {
     setSyncError(null);
-    if (!originalYaml) {
-      setSyncError("No configuration available to edit.");
-      return;
-    }
+    // No graph to sync (e.g. Boulder started with no preloaded config): show
+    // whatever original YAML there is — possibly "", which mounts an empty
+    // but editable pane rather than blocking on a "nothing to edit" error.
     if (config.nodes.length === 0) {
       setValue(originalYaml);
       setBaseline(originalYaml);
       setSyncWarnings([]);
+      return;
+    }
+    // A live graph exists but there's no original YAML to merge it into —
+    // this is the only case syncConfig genuinely can't handle.
+    if (!originalYaml) {
+      setSyncError("No configuration available to edit.");
       return;
     }
     setSyncing(true);
@@ -91,6 +97,10 @@ export function YamlPane() {
       setConfig(resp.config, undefined, value);
       justSavedRef.current = true;
       setBaseline(value);
+      // The backend may have just adopted this Save as its preloaded config
+      // (if none was set yet) — bump scenarioRevision so RunControl re-checks
+      // Run Sweep availability instead of showing stale info.
+      void useScenarioStore.getState().refresh();
       toast.success("YAML config updated");
     } catch (err) {
       toast.error(`Invalid YAML: ${err instanceof Error ? err.message : String(err)}`);

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,13 +93,19 @@ max-line-length = 110
 convention = "numpy"
 
 [tool.setuptools]
-packages = ["boulder"]
+packages = ["boulder", "configs"]
 
 [tool.setuptools.package-data]
 # Ship the prebuilt React frontend (emitted by `npm run build` into
 # boulder/_frontend) inside the wheel so the GUI works on a plain
 # `pip install` without Node/npm. The frontend is built in CI on release.
 boulder = ["_frontend/**/*"]
+# get_initial_config()/get_initial_config_with_comments() load default.yaml as
+# a sibling of the installed `boulder` package (see configs/__init__.py) — it
+# must ship in the wheel or the GUI's "no config preloaded" fallback 404s. The
+# rest of configs/ ships alongside it as a byproduct of setuptools_scm's
+# git-tracked-file inclusion; harmless (a few KB of example YAMLs).
+configs = ["*.yaml", "*.md"]
 
 [tool.setuptools_scm]
 write_to = "boulder/version.py"

--- a/tests/test_live_config_adoption.py
+++ b/tests/test_live_config_adoption.py
@@ -1,0 +1,213 @@
+"""Tests for :func:`boulder.api.live_config.adopt_live_config`.
+
+Covers the "Boulder started with no preloaded file" gap: the Run Sweep
+button and Scenario Pane are keyed off ``app.state.preloaded_config_path``,
+which stays ``None`` for a browser-only session unless something adopts the
+config the user pastes/uploads. These tests exercise both the helper
+directly and its wiring into ``POST /api/configs/parse`` and
+``POST /api/configs/upload``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("fastapi")
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from boulder.api.live_config import adopt_live_config  # noqa: E402
+from boulder.api.main import create_app  # noqa: E402
+
+_SCENARIO_YAML = """\
+metadata:
+  description: "test config"
+phases:
+  gas:
+    mechanism: gri30.yaml
+network:
+  - id: feed
+    Reservoir:
+      temperature: 298.15
+      pressure: 101325
+      composition: "CH4:1"
+scenarios:
+  a:
+    metadata:
+      scenario_name: "A"
+"""
+
+_PLAIN_YAML = """\
+metadata:
+  description: "no scenarios here"
+phases:
+  gas:
+    mechanism: gri30.yaml
+network:
+  - id: feed
+    Reservoir:
+      temperature: 298.15
+      pressure: 101325
+      composition: "CH4:1"
+"""
+
+
+def _client():
+    app = create_app()
+    client = TestClient(app)
+    client.__enter__()
+    return client, app
+
+
+class TestAdoptLiveConfigUnit:
+    def test_first_call_creates_file_and_populates_state(self, tmp_path):
+        app = create_app()
+        app.state.preloaded_config_path = None
+
+        class _Req:
+            pass
+
+        req = _Req()
+        req.app = app
+
+        adopt_live_config(
+            req,
+            raw={"scenarios": {"a": {}}},
+            validated={"nodes": [], "connections": []},
+            yaml_str=_SCENARIO_YAML,
+            filename="pasted.yaml",
+        )
+
+        assert app.state.preloaded_config_path is not None
+        path = app.state.preloaded_config_path
+        assert path.endswith("pasted.yaml")
+        assert app.state.preloaded_raw == {"scenarios": {"a": {}}}
+        assert app.state.preloaded_yaml == _SCENARIO_YAML
+        assert app.state.preloaded_filename == "pasted.yaml"
+
+        with open(path, encoding="utf-8") as f:
+            assert f.read() == _SCENARIO_YAML
+
+    def test_second_call_overwrites_same_file(self):
+        app = create_app()
+        app.state.preloaded_config_path = None
+
+        class _Req:
+            pass
+
+        req = _Req()
+        req.app = app
+
+        adopt_live_config(
+            req, raw={}, validated={}, yaml_str=_PLAIN_YAML, filename="live.yaml"
+        )
+        first_path = app.state.preloaded_config_path
+
+        adopt_live_config(
+            req,
+            raw={"scenarios": {"a": {}}},
+            validated={},
+            yaml_str=_SCENARIO_YAML,
+            filename="live.yaml",
+        )
+        second_path = app.state.preloaded_config_path
+
+        assert first_path == second_path
+        with open(second_path, encoding="utf-8") as f:
+            assert f.read() == _SCENARIO_YAML
+
+    def test_noop_when_real_config_path_already_set(self, tmp_path):
+        app = create_app()
+        real_cfg = tmp_path / "real.yaml"
+        real_cfg.write_text(_PLAIN_YAML, encoding="utf-8")
+        app.state.preloaded_config_path = str(real_cfg)
+        app.state.preloaded_raw = {"marker": "untouched"}
+
+        class _Req:
+            pass
+
+        req = _Req()
+        req.app = app
+
+        adopt_live_config(
+            req,
+            raw={"scenarios": {"a": {}}},
+            validated={},
+            yaml_str=_SCENARIO_YAML,
+            filename="pasted.yaml",
+        )
+
+        assert app.state.preloaded_config_path == str(real_cfg)
+        assert app.state.preloaded_raw == {"marker": "untouched"}
+
+
+class TestParseYamlAdoptsLiveConfig:
+    def test_parse_with_no_preloaded_config_adopts_it(self):
+        client, app = _client()
+        try:
+            assert app.state.preloaded_config_path is None
+
+            resp = client.post("/api/configs/parse", json={"yaml": _SCENARIO_YAML})
+            assert resp.status_code == 200, resp.text
+
+            assert app.state.preloaded_config_path is not None
+            assert app.state.preloaded_raw.get("scenarios") == {"a": {"metadata": {"scenario_name": "A"}}}
+        finally:
+            client.__exit__(None, None, None)
+
+    def test_sweep_info_reflects_scenarios_after_parse(self):
+        """GET /api/sweep sees a browser-pasted `scenarios:` block after Save.
+
+        `can_run` still correctly requires an actual runner (none registered
+        here) -- but `available`/`n_scenarios` must reflect the live config
+        instead of staying stuck at the pre-adoption "no file" defaults.
+        """
+        client, app = _client()
+        try:
+            client.post("/api/configs/parse", json={"yaml": _SCENARIO_YAML})
+
+            resp = client.get("/api/sweep")
+            assert resp.status_code == 200, resp.text
+            info = resp.json()
+            assert info["available"] is True
+            # Union run-set size: the baseline config + the one named scenario.
+            assert info["n_scenarios"] == 2
+            assert info["can_run"] is False  # no sweep_runner plugin registered
+            assert info["reason"] == "No scenario runner available"
+        finally:
+            client.__exit__(None, None, None)
+
+    def test_parse_is_noop_for_a_real_preloaded_config(self, tmp_path):
+        real_cfg = tmp_path / "real.yaml"
+        real_cfg.write_text(_PLAIN_YAML, encoding="utf-8")
+        client, app = _client()
+        try:
+            app.state.preloaded_config_path = str(real_cfg)
+            app.state.preloaded_raw = {"marker": "untouched"}
+
+            resp = client.post("/api/configs/parse", json={"yaml": _SCENARIO_YAML})
+            assert resp.status_code == 200, resp.text
+
+            assert app.state.preloaded_config_path == str(real_cfg)
+            assert app.state.preloaded_raw == {"marker": "untouched"}
+        finally:
+            client.__exit__(None, None, None)
+
+
+class TestUploadConfigAdoptsLiveConfig:
+    def test_upload_with_no_preloaded_config_adopts_it(self):
+        client, app = _client()
+        try:
+            assert app.state.preloaded_config_path is None
+
+            resp = client.post(
+                "/api/configs/upload",
+                files={"file": ("uploaded.yaml", _SCENARIO_YAML, "application/x-yaml")},
+            )
+            assert resp.status_code == 200, resp.text
+
+            assert app.state.preloaded_config_path is not None
+            assert app.state.preloaded_filename == "uploaded.yaml"
+            assert app.state.preloaded_raw.get("scenarios")
+        finally:
+            client.__exit__(None, None, None)

--- a/tests/test_live_config_adoption.py
+++ b/tests/test_live_config_adoption.py
@@ -151,7 +151,9 @@ class TestParseYamlAdoptsLiveConfig:
             assert resp.status_code == 200, resp.text
 
             assert app.state.preloaded_config_path is not None
-            assert app.state.preloaded_raw.get("scenarios") == {"a": {"metadata": {"scenario_name": "A"}}}
+            assert app.state.preloaded_raw.get("scenarios") == {
+                "a": {"metadata": {"scenario_name": "A"}}
+            }
         finally:
             client.__exit__(None, None, None)
 


### PR DESCRIPTION
## Summary

Two related "no preloaded file" bugs, both surfacing in host apps (e.g. bloc's Docker/Cloud deployment) that launch Boulder with no CLI config path so users load everything through the browser:

### 1. Editing an empty YAML was impossible

- `get_initial_config()`/`get_initial_config_with_comments()` load `configs/default.yaml` as a sibling of the installed `boulder` package, but `[tool.setuptools] packages = ["boulder"]` never shipped that top-level directory in the wheel — `GET /api/configs/default` 404s for anyone who `pip install`ed Boulder instead of running from a source checkout.
- When that preload silently fails, the frontend falls back to a blank config — but `YamlPane`'s `refresh()` treated an empty `originalYaml` as a blocking `"No configuration available to edit."` error *before* checking whether there was a live graph to sync, so the Monaco/textarea editor never mounted.

**Fix:** ship `configs/` in the wheel (mark it a real package + package-data), and reorder `YamlPane`'s checks so a blank slate (no graph, no YAML) renders an empty, editable pane. The error is now reserved for the one case `syncConfig` genuinely can't handle: a live graph with no YAML to merge it into.

### 2. Run Sweep never saw scenarios pasted/uploaded through the browser

`GET /api/sweep`'s `can_run` is computed solely from `app.state.preloaded_raw`/`preloaded_config_path` — populated once at CLI startup from a real file path, and otherwise never touched. A user who pastes a `scenarios:`/`sweep:` block directly into the main YAML editor (or starts from an uploaded config) has scenarios visible in the browser that the server can never see, so the button stays stuck reporting "no scenarios."

**Fix:** `boulder/api/live_config.py::adopt_live_config()` — the first time a config is parsed or uploaded with no preloaded path set, write it to a private temp file and adopt it as the preloaded config, exactly as if Boulder had been started with that file. This closes the gap for Run Sweep, Scenario Pane authoring, and result caching uniformly, rather than teaching each feature to separately accept a live in-memory config. A config that *was* preloaded from a real file is left untouched. Also nudge `RunControl` to re-check sweep availability right after a Save/Upload adopts a config (it previously only re-polled on Scenario Pane CRUD).

## Test plan

- [x] Backend: `pytest` — 752 passed, 2 skipped (pre-existing/unrelated), 5 xfailed (pre-existing), 0 failed
- [x] Frontend: `vitest run` — 158 passed (25 files), including new coverage in `YamlPane.test.tsx`, `NetworkCard.test.tsx`
- [x] Manually built the wheel (`pip wheel --no-deps .`) and confirmed `configs/default.yaml` is now present; installed it into an isolated `--target` dir and confirmed `get_initial_config_with_comments()` succeeds from outside the source checkout (the exact previously-broken scenario)
- [x] New `tests/test_live_config_adoption.py` covers `adopt_live_config` directly and its wiring into `/api/configs/parse` and `/api/configs/upload`, including the no-op-when-a-real-file-is-already-preloaded case

🤖 Generated with [Claude Code](https://claude.com/claude-code)