### PR TITLE
Live per-scenario progress in the Scenario Pane during Run Sweep

### DIFF
--- a/boulder/api/routes/sweep.py
+++ b/boulder/api/routes/sweep.py
@@ -42,6 +42,17 @@ class SweepRunRequest(BaseModel):
 
 
 _SCENARIO_RE = re.compile(r"scenario\s+(\d+)\s*/\s*(\d+)", re.IGNORECASE)
+#: Captures the scenario id `sweep_runner.run()` already prints in parens,
+#: e.g. "scenario 3/8 (cold_feed)" or "scenario 3/8 (cold_feed): cached, skipped".
+_SCENARIO_ID_RE = re.compile(r"scenario\s+\d+\s*/\s*\d+\s*\(([^)]+)\)", re.IGNORECASE)
+_SCENARIO_SKIP_RE = re.compile(
+    r"scenario\s+\d+\s*/\s*\d+\s*\([^)]+\)\s*:\s*cached,\s*skipped", re.IGNORECASE
+)
+#: `boulder.staged_solver`'s per-stage progress log line, e.g.
+#: "Staged solve: stage 'default' (1/3, 3 reactors)".
+_STAGE_RE = re.compile(
+    r"Staged solve:\s*stage\s+'([^']*)'\s*\((\d+)\s*/\s*(\d+)", re.IGNORECASE
+)
 _RUNNER_NAME = "run_sweep.py"
 
 
@@ -186,6 +197,12 @@ async def sweep_run(
         "total": total,
         "message": "starting…",
         "returncode": None,
+        # Keyed by scenario id, e.g. {"cold_feed": {"stage": 1, "stage_total": 3}}.
+        # A scenario id's presence here *is* "currently being solved" — a
+        # deliberate map rather than a single "current scenario" scalar so a
+        # future parallel sweep runner can hold more than one entry at once
+        # without changing this shape.
+        "scenario_progress": {},
     }
     request.app.state.sweep_job = state
     # Surface on the server console by default — at least that the run started.
@@ -218,6 +235,24 @@ async def sweep_run(
                     state["current"] = int(match.group(1))
                     state["total"] = int(match.group(2))
                     state["message"] = line.strip()
+                    if _SCENARIO_SKIP_RE.search(line):
+                        # Cache hit: instantaneous, never "calculating".
+                        state["scenario_progress"] = {}
+                    else:
+                        id_match = _SCENARIO_ID_RE.search(line)
+                        sid = id_match.group(1).strip() if id_match else None
+                        # Serial today: one scenario in flight, so replace the
+                        # whole map. A parallel runner would add/remove keys
+                        # here instead of replacing.
+                        state["scenario_progress"] = (
+                            {sid: {"stage": None, "stage_total": None}} if sid else {}
+                        )
+                else:
+                    stage_match = _STAGE_RE.search(line)
+                    if stage_match:
+                        for progress in state["scenario_progress"].values():
+                            progress["stage"] = int(stage_match.group(2))
+                            progress["stage_total"] = int(stage_match.group(3))
                 if line:
                     tail.append(line)
                     del tail[:-30]
@@ -225,6 +260,10 @@ async def sweep_run(
                     print(f"[sweep] {line}", flush=True)
             proc.wait()
             state["returncode"] = proc.returncode
+            # The last scenario processed may not have ended with a "cached,
+            # skipped" line clearing it — nothing is "calculating" once the
+            # subprocess itself has exited, one way or another.
+            state["scenario_progress"] = {}
             if proc.returncode == 0:
                 state["status"] = "done"
                 state["message"] = "Sweep complete"

--- a/frontend/src/api/sweep.ts
+++ b/frontend/src/api/sweep.ts
@@ -17,6 +17,13 @@ export interface SweepStatus {
   current?: number;
   total?: number;
   message?: string;
+  /**
+   * Scenarios currently being solved, keyed by id — a scenario id's presence
+   * here *is* "calculating". A map rather than a single "current scenario"
+   * field so a future parallel sweep runner can report more than one
+   * in-flight scenario at once without a shape change.
+   */
+  scenario_progress?: Record<string, { stage: number | null; stage_total: number | null }>;
 }
 
 /** Whether the preloaded config has a runnable sweep, and how many scenarios. */

--- a/frontend/src/components/layout/AppShell.test.tsx
+++ b/frontend/src/components/layout/AppShell.test.tsx
@@ -80,6 +80,11 @@ vi.mock("@/stores/scenarioStore", () => ({
     }),
 }));
 
+const mockHydrate = vi.fn();
+vi.mock("@/stores/sweepStore", () => ({
+  useSweepRunStore: { getState: () => ({ hydrate: mockHydrate }) },
+}));
+
 let mockYamlPaneOpen = false;
 const mockOpenYamlPane = vi.fn();
 
@@ -224,5 +229,10 @@ describe("AppShell", () => {
     mockAuthoredScenarioIds = ["draft_a"];
     render(<AppShell />);
     expect(screen.getByTestId("scenario-pane")).toBeInTheDocument();
+  });
+
+  it("hydrates the sweep store once on mount, to resume an in-flight sweep after a refresh", () => {
+    render(<AppShell />);
+    expect(mockHydrate).toHaveBeenCalledOnce();
   });
 });

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -16,6 +16,7 @@ import { YamlPane } from "@/components/panels/YamlPane";
 import { PaneToggle, PaneResizer } from "@/components/layout/paneControls";
 import { useLayoutStore } from "@/stores/layoutStore";
 import { useScenarioStore } from "@/stores/scenarioStore";
+import { useSweepRunStore } from "@/stores/sweepStore";
 import { ReactorGraph } from "@/components/graph/ReactorGraph";
 import { ResultsTabs } from "@/components/results/ResultsTabs";
 import { SimulationOverlay } from "@/components/simulation/SimulationOverlay";
@@ -53,6 +54,13 @@ export function AppShell() {
   useEffect(() => {
     void refreshScenarios();
   }, [refreshScenarios]);
+
+  // Reconstruct an in-flight Run Sweep after a page refresh — the backend
+  // (a separate process/thread) may still be running one even though this
+  // fresh page load has no memory of it.
+  useEffect(() => {
+    useSweepRunStore.getState().hydrate();
+  }, []);
 
   // Connect SSE stream
   useSimulationSSE();

--- a/frontend/src/components/panels/ScenarioPane.test.tsx
+++ b/frontend/src/components/panels/ScenarioPane.test.tsx
@@ -48,6 +48,12 @@ vi.mock("@/stores/scenarioStore", () => ({
   }),
 }));
 
+let mockScenarioProgress: Record<string, { stage: number | null; stageTotal: number | null }> = {};
+vi.mock("@/stores/sweepStore", () => ({
+  useSweepRunStore: (selector: (s: unknown) => unknown) =>
+    selector({ scenarioProgress: mockScenarioProgress }),
+}));
+
 vi.mock("sonner", () => ({
   toast: { success: vi.fn(), error: vi.fn() },
 }));
@@ -76,6 +82,7 @@ describe("ScenarioPane", () => {
     mockAvailable = true;
     mockScenarios = [{ id: "A", label: "Scenario A", t0_K: 300 }];
     mockAuthoredIds = [];
+    mockScenarioProgress = {};
   });
 
   it("deleting a scenario confirms first, then calls deleteScenario", () => {
@@ -163,5 +170,36 @@ describe("ScenarioPane", () => {
 
     expect(mockDeleteScenario).toHaveBeenCalledWith("draft_a");
     confirmSpy.mockRestore();
+  });
+
+  it("shows a mixed list: computed scenarios alongside authored-but-pending ones", () => {
+    mockScenarios = [{ id: "A", label: "Scenario A", t0_K: 300 }];
+    mockAuthoredIds = ["A", "pending_b"];
+    render(<ScenarioPane />);
+
+    expect(screen.getByText("Scenario A")).toBeInTheDocument();
+    expect(screen.getByText("pending_b")).toBeInTheDocument();
+    expect(screen.getByText("Not computed yet")).toBeInTheDocument();
+  });
+
+  it('shows "Calculating…" for the scenario currently mid-sweep, in place of its status', () => {
+    mockScenarios = [{ id: "A", label: "Scenario A", t0_K: 300 }];
+    mockAuthoredIds = ["A", "cold_feed"];
+    mockScenarioProgress = { cold_feed: { stage: 1, stageTotal: 3 } };
+    render(<ScenarioPane />);
+
+    expect(screen.getByText("Calculating…")).toBeInTheDocument();
+    // The computed, not-currently-solving row keeps its own status.
+    expect(screen.queryByText("Not computed yet")).not.toBeInTheDocument();
+  });
+
+  it("clicking a pending (not-yet-computed) row still calls setActive", () => {
+    mockScenarios = [];
+    mockAuthoredIds = ["pending_a"];
+    render(<ScenarioPane />);
+
+    fireEvent.click(screen.getByText("pending_a"));
+
+    expect(mockSetActive).toHaveBeenCalledWith("pending_a");
   });
 });

--- a/frontend/src/components/panels/ScenarioPane.tsx
+++ b/frontend/src/components/panels/ScenarioPane.tsx
@@ -2,9 +2,32 @@ import { type KeyboardEvent, useEffect, useRef, useState } from "react";
 import { Eraser, Pencil, Plus, Trash2 } from "lucide-react";
 import { toast } from "sonner";
 import { useScenarioStore } from "@/stores/scenarioStore";
+import { useSweepRunStore } from "@/stores/sweepStore";
 import { AddScenarioModal } from "@/components/modals/AddScenarioModal";
 import { ScenarioYamlEditorModal } from "@/components/modals/ScenarioYamlEditorModal";
 import { SweepResultsPlot } from "./SweepResultsPlot";
+import type { ScenarioMeta } from "@/api/scenarios";
+
+/** One row in the pane: every authored id, paired with its computed data if any. */
+interface ScenarioRow {
+  id: string;
+  computed: ScenarioMeta | null;
+}
+
+/** `authoredIds` first (the sweep's solve order), then any computed scenario
+ * a host's `run_sweep.py` produced without declaring it in `scenarios:`. */
+function buildRows(authoredIds: string[], scenarios: ScenarioMeta[]): ScenarioRow[] {
+  const byId = new Map(scenarios.map((s) => [s.id, s]));
+  const seen = new Set<string>();
+  const rows: ScenarioRow[] = authoredIds.map((id) => {
+    seen.add(id);
+    return { id, computed: byId.get(id) ?? null };
+  });
+  for (const s of scenarios) {
+    if (!seen.has(s.id)) rows.push({ id: s.id, computed: s });
+  }
+  return rows;
+}
 
 /** Compact relative-time label, e.g. "just now", "2 min ago", "3 h ago". */
 function timeAgo(tsSeconds: number | undefined, nowMs: number): string {
@@ -26,7 +49,6 @@ function timeAgo(tsSeconds: number | undefined, nowMs: number): string {
  */
 export function ScenarioPane() {
   const {
-    available,
     scenarios,
     authoredIds,
     createdAt,
@@ -38,6 +60,7 @@ export function ScenarioPane() {
     deleteScenario,
     clearCache,
   } = useScenarioStore();
+  const scenarioProgress = useSweepRunStore((s) => s.scenarioProgress);
   const [addModalOpen, setAddModalOpen] = useState(false);
   const [editingId, setEditingId] = useState<string | null>(null);
 
@@ -67,18 +90,13 @@ export function ScenarioPane() {
     prevCreated.current = createdAt;
   }, [createdAt]);
 
-  const handleDelete = async (id: string) => {
-    // Every row here already has a cached trajectory (that's why it's in
-    // `scenarios`, the store-derived list), so this message is always
-    // accurate — deleting drops both the definition and its cached result.
-    if (
-      !window.confirm(
-        `Delete scenario "${id}"? This also removes its cached trajectory ` +
-          "immediately. This cannot be undone.",
-      )
-    ) {
-      return;
-    }
+  const handleDelete = async (id: string, isComputed: boolean) => {
+    // Only a computed row actually has a cached trajectory to lose.
+    const confirmMsg = isComputed
+      ? `Delete scenario "${id}"? This also removes its cached trajectory ` +
+        "immediately. This cannot be undone."
+      : `Delete scenario "${id}"? This cannot be undone.`;
+    if (!window.confirm(confirmMsg)) return;
     try {
       const { cachePurged } = await deleteScenario(id);
       toast.success(
@@ -113,10 +131,10 @@ export function ScenarioPane() {
     }
   };
 
-  if (!available || scenarios.length === 0) {
-    // No precomputed store yet (nothing has been swept), but scenario
-    // authoring doesn't need one — surface just the "+ Add Scenario" entry
-    // point so the pane isn't the only way in (Run Sweep's menu has it too).
+  if (authoredIds.length === 0 && scenarios.length === 0) {
+    // Nothing authored, nothing computed — scenario authoring doesn't need a
+    // store, so surface just the "+ Add Scenario" entry point (Run Sweep's
+    // menu has it too).
     return (
       <div className="rounded-lg border border-border bg-card p-4 space-y-2">
         <div className="flex items-center justify-between">
@@ -129,43 +147,9 @@ export function ScenarioPane() {
             <Plus size={12} /> Add Scenario
           </button>
         </div>
-        {authoredIds.length === 0 ? (
-          <p className="text-xs text-muted-foreground">
-            No computed scenarios yet — add one, then Run Sweep.
-          </p>
-        ) : (
-          <>
-            <p className="text-xs text-muted-foreground">
-              Not computed yet — Run Sweep to solve{" "}
-              {authoredIds.length === 1 ? "it" : "them"}.
-            </p>
-            <ul className="space-y-1 max-h-[70vh] overflow-y-auto pr-1">
-              {authoredIds.map((id) => (
-                <li key={id} className="group flex items-center gap-1">
-                  <span className="flex-1 min-w-0 truncate rounded-md px-2 py-1.5 text-xs text-foreground">
-                    {id}
-                  </span>
-                  <button
-                    type="button"
-                    onClick={() => setEditingId(id)}
-                    title="Edit scenario YAML"
-                    className="shrink-0 p-1 rounded text-muted-foreground opacity-0 group-hover:opacity-100 hover:text-foreground hover:bg-muted"
-                  >
-                    <Pencil size={12} />
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => void handleDelete(id)}
-                    title="Delete scenario"
-                    className="shrink-0 p-1 rounded text-muted-foreground opacity-0 group-hover:opacity-100 hover:text-destructive hover:bg-muted"
-                  >
-                    <Trash2 size={12} />
-                  </button>
-                </li>
-              ))}
-            </ul>
-          </>
-        )}
+        <p className="text-xs text-muted-foreground">
+          No computed scenarios yet — add one, then Run Sweep.
+        </p>
         <AddScenarioModal
           open={addModalOpen}
           onClose={() => setAddModalOpen(false)}
@@ -180,20 +164,26 @@ export function ScenarioPane() {
     );
   }
 
+  // Every authored id (Run Sweep's solve order), paired with its computed
+  // data if any — kept as one list so a scenario mid-sweep (or never yet
+  // swept) stays visible and clickable instead of disappearing once
+  // something else has been computed.
+  const rows = buildRows(authoredIds, scenarios);
+
   const onKeyDown = (e: KeyboardEvent<HTMLUListElement>) => {
     if (e.key !== "ArrowDown" && e.key !== "ArrowUp") return;
     e.preventDefault();
-    const idx = scenarios.findIndex((s) => s.id === activeId);
+    const idx = rows.findIndex((r) => r.id === activeId);
     let next =
       idx === -1
         ? e.key === "ArrowDown"
           ? 0
-          : scenarios.length - 1
+          : rows.length - 1
         : e.key === "ArrowDown"
           ? idx + 1
           : idx - 1;
-    next = Math.max(0, Math.min(scenarios.length - 1, next));
-    const target = scenarios[next];
+    next = Math.max(0, Math.min(rows.length - 1, next));
+    const target = rows[next];
     if (!target) return;
     void setActive(target.id);
     // Focus synchronously on the already-rendered node — a requestAnimationFrame
@@ -210,15 +200,17 @@ export function ScenarioPane() {
         <div className="flex items-center justify-between">
           <h3 className="font-semibold text-sm text-foreground">Scenarios</h3>
           <div className="flex items-center gap-2">
-            <span className="text-xs text-muted-foreground">{scenarios.length}</span>
-            <button
-              type="button"
-              onClick={() => void handleClearCache()}
-              title="Clear cache (delete every scenario's cached result, without re-solving)"
-              className="text-muted-foreground hover:text-foreground"
-            >
-              <Eraser size={14} />
-            </button>
+            <span className="text-xs text-muted-foreground">{rows.length}</span>
+            {scenarios.length > 0 && (
+              <button
+                type="button"
+                onClick={() => void handleClearCache()}
+                title="Clear cache (delete every scenario's cached result, without re-solving)"
+                className="text-muted-foreground hover:text-foreground"
+              >
+                <Eraser size={14} />
+              </button>
+            )}
             <button
               type="button"
               onClick={() => setAddModalOpen(true)}
@@ -230,24 +222,32 @@ export function ScenarioPane() {
           </div>
         </div>
         {error && <p className="text-xs text-red-500">{error}</p>}
+        {scenarios.length === 0 && (
+          <p className="text-xs text-muted-foreground">
+            Not computed yet — Run Sweep to solve{" "}
+            {rows.length === 1 ? "it" : "them"}.
+          </p>
+        )}
         <ul
           onKeyDown={onKeyDown}
           className={`space-y-1 max-h-[70vh] overflow-y-auto pr-1${
             bump ? " animate-[scenarioBump_0.6s_ease-out]" : ""
           }`}
         >
-          {scenarios.map((s) => {
-            const isActive = s.id === activeId;
-            const ago = timeAgo(s.computed_at ?? createdAt, now);
+          {rows.map((row) => {
+            const isActive = row.id === activeId;
+            const isCalculating = row.id in scenarioProgress;
+            const s = row.computed;
+            const ago = s ? timeAgo(s.computed_at ?? createdAt, now) : "";
             return (
-              <li key={s.id} className="group flex items-center gap-1">
+              <li key={row.id} className="group flex items-center gap-1">
                 <button
-                  id={`scenario-${s.id}`}
+                  id={`scenario-${row.id}`}
                   type="button"
-                  onClick={() => void setActive(s.id)}
+                  onClick={() => void setActive(row.id)}
                   aria-busy={loading && isActive}
                   title={
-                    s.final_temperature_K != null
+                    s?.final_temperature_K != null
                       ? `T_final ≈ ${Math.round(s.final_temperature_K)} K` +
                         (s.solid_carbon_yield_pct != null
                           ? ` · C(s) ${s.solid_carbon_yield_pct.toFixed(1)}%`
@@ -263,14 +263,24 @@ export function ScenarioPane() {
                   ].join(" ")}
                 >
                   <div className="flex items-center justify-between gap-2">
-                    <span className="font-medium truncate">{s.label}</span>
-                    {ago && (
+                    <span className="font-medium truncate">{s?.label ?? row.id}</span>
+                    {isCalculating ? (
+                      <span className="shrink-0 text-[10px] text-primary animate-pulse">
+                        Calculating…
+                      </span>
+                    ) : s ? (
+                      ago && (
+                        <span className="shrink-0 text-[10px] text-muted-foreground">
+                          {ago}
+                        </span>
+                      )
+                    ) : (
                       <span className="shrink-0 text-[10px] text-muted-foreground">
-                        {ago}
+                        Not computed yet
                       </span>
                     )}
                   </div>
-                  {s.reactor_mode && (
+                  {s?.reactor_mode && (
                     <div className="text-[10px] text-muted-foreground">
                       {s.reactor_mode}
                     </div>
@@ -278,7 +288,7 @@ export function ScenarioPane() {
                 </button>
                 <button
                   type="button"
-                  onClick={() => setEditingId(s.id)}
+                  onClick={() => setEditingId(row.id)}
                   title="Edit scenario YAML"
                   className="shrink-0 p-1 rounded text-muted-foreground opacity-0 group-hover:opacity-100 hover:text-foreground hover:bg-muted"
                 >
@@ -286,7 +296,7 @@ export function ScenarioPane() {
                 </button>
                 <button
                   type="button"
-                  onClick={() => void handleDelete(s.id)}
+                  onClick={() => void handleDelete(row.id, s !== null)}
                   title="Delete scenario"
                   className="shrink-0 p-1 rounded text-muted-foreground opacity-0 group-hover:opacity-100 hover:text-destructive hover:bg-muted"
                 >

--- a/frontend/src/components/results/ResultsTabs.tsx
+++ b/frontend/src/components/results/ResultsTabs.tsx
@@ -4,6 +4,8 @@ import { useSelectionStore } from "@/stores/selectionStore";
 import { useConfigStore } from "@/stores/configStore";
 import { useThemeStore } from "@/stores/themeStore";
 import { useResultsTabStore } from "@/stores/resultsTabStore";
+import { useScenarioStore } from "@/stores/scenarioStore";
+import { useSweepRunStore } from "@/stores/sweepStore";
 import { fetchPlugins, renderPlugin } from "@/api/plugins";
 import { Button } from "@/components/ui/Button";
 import { PlotsTab } from "./PlotsTab";
@@ -11,6 +13,7 @@ import { ConvergenceTab } from "./ConvergenceTab";
 import { SummaryTab } from "./SummaryTab";
 import { ErrorTab } from "./ErrorTab";
 import { PluginTab } from "./PluginTab";
+import { SweepCalculatingCard } from "./SweepCalculatingCard";
 import type { PluginMeta, PluginRenderData } from "@/types/plugin";
 
 const SankeyTab = lazy(() => import("./SankeyTab").then((m) => ({ default: m.SankeyTab })));
@@ -31,6 +34,8 @@ export function ResultsTabs() {
   const theme = useThemeStore((s) => s.theme);
   const activeTab = useResultsTabStore((s) => s.activeTab);
   const setActiveTab = useResultsTabStore((s) => s.setActiveTab);
+  const activeScenarioId = useScenarioStore((s) => s.activeId);
+  const scenarioProgress = useSweepRunStore((s) => s.scenarioProgress);
   /** Resolved tab for UI: explicit choice, else Sankey when results exist, else Plots. */
   const displayTab = activeTab ?? (results ? "Sankey" : "Plots");
   const [plugins, setPlugins] = useState<PluginMeta[]>([]);
@@ -163,6 +168,19 @@ export function ResultsTabs() {
       });
   }); // no dependency array — runs every render, but the cache-key
       // guard above ensures we only actually fetch when needed.
+
+  // A scenario currently mid-sweep takes priority over whatever stale
+  // results/progress a previously-viewed scenario left behind — non-blocking
+  // (this just occupies the results card's own slot), so the Scenario Pane
+  // and the rest of the layout stay fully visible and usable.
+  if (activeScenarioId != null && activeScenarioId in scenarioProgress) {
+    return (
+      <SweepCalculatingCard
+        scenarioId={activeScenarioId}
+        stage={scenarioProgress[activeScenarioId]}
+      />
+    );
+  }
 
   const data = results ?? progress;
   if (!data && !error) return null;

--- a/frontend/src/components/results/SweepCalculatingCard.test.tsx
+++ b/frontend/src/components/results/SweepCalculatingCard.test.tsx
@@ -1,0 +1,44 @@
+/**
+ * Asserts SweepCalculatingCard: shows the scenario id and a stage label when
+ * there's more than one stage, and omits the stage label when there's only
+ * one (or stage data hasn't arrived yet) — a single-stage network shouldn't
+ * say "Stage 1/1".
+ */
+
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { SweepCalculatingCard } from "./SweepCalculatingCard";
+
+describe("SweepCalculatingCard", () => {
+  it("shows the scenario id and a stage label for a multi-stage network", () => {
+    render(
+      <SweepCalculatingCard
+        scenarioId="cold_feed"
+        stage={{ stage: 1, stageTotal: 3 }}
+      />,
+    );
+
+    expect(screen.getByText(/Calculating "cold_feed"…/)).toBeInTheDocument();
+    expect(screen.getByText(/Stage 1\/3/)).toBeInTheDocument();
+  });
+
+  it("omits the stage label for a single-stage network", () => {
+    render(
+      <SweepCalculatingCard
+        scenarioId="cold_feed"
+        stage={{ stage: 1, stageTotal: 1 }}
+      />,
+    );
+
+    expect(screen.getByText(/Calculating "cold_feed"…/)).toBeInTheDocument();
+    expect(screen.queryByText(/Stage/)).not.toBeInTheDocument();
+  });
+
+  it("omits the stage label when no stage data has arrived yet", () => {
+    render(<SweepCalculatingCard scenarioId="cold_feed" stage={undefined} />);
+
+    expect(screen.getByText(/Calculating "cold_feed"…/)).toBeInTheDocument();
+    expect(screen.queryByText(/Stage/)).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/results/SweepCalculatingCard.tsx
+++ b/frontend/src/components/results/SweepCalculatingCard.tsx
@@ -1,0 +1,29 @@
+/**
+ * Non-blocking "this scenario is mid-sweep" placeholder for the results area.
+ *
+ * Deliberately just an inline card (not a `fixed inset-0` overlay like
+ * `SimulationOverlay`) — it only occupies the results card's own slot in
+ * `<main>`, leaving the Scenario Pane and the rest of the layout fully
+ * visible and interactive while a sweep is running.
+ */
+export function SweepCalculatingCard({
+  scenarioId,
+  stage,
+}: {
+  scenarioId: string;
+  stage: { stage: number | null; stageTotal: number | null } | undefined;
+}) {
+  const stageLabel =
+    stage?.stage != null && stage.stageTotal != null && stage.stageTotal > 1
+      ? ` — Stage ${stage.stage}/${stage.stageTotal}`
+      : "";
+
+  return (
+    <div className="rounded-lg border border-border bg-card p-6 text-center space-y-3">
+      <div className="animate-spin rounded-full h-8 w-8 border-4 border-primary border-t-transparent mx-auto" />
+      <p className="text-foreground font-medium">
+        Calculating &quot;{scenarioId}&quot;…{stageLabel}
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/stores/scenarioStore.test.ts
+++ b/frontend/src/stores/scenarioStore.test.ts
@@ -139,6 +139,16 @@ describe("scenarioStore", () => {
     expect(useScenarioStore.getState().activeId).toBeNull();
   });
 
+  it("setActive on an id not yet computed just selects it, without fetching", async () => {
+    useScenarioStore.setState({ scenarios: [{ id: "A", t0_K: 300, label: "A" }] });
+
+    await useScenarioStore.getState().setActive("pending_id");
+
+    expect(useScenarioStore.getState().activeId).toBe("pending_id");
+    expect(useScenarioStore.getState().error).toBeNull();
+    expect(mockFetchScenario).not.toHaveBeenCalled();
+  });
+
   it("createScenario pushes the freshly-written config YAML into configStore", async () => {
     mockCreateScenario.mockResolvedValue({ scenario_id: "C", yaml: "" });
     mockListScenarios.mockResolvedValue({ available: false, scenarios: [], authored_ids: ["C"] });

--- a/frontend/src/stores/scenarioStore.ts
+++ b/frontend/src/stores/scenarioStore.ts
@@ -142,6 +142,14 @@ export const useScenarioStore = create<ScenarioState>((set, get) => ({
   },
 
   setActive: async (id) => {
+    // Not computed yet (authored but unswept, or mid-sweep and not reached/
+    // finished yet) — just record the selection, no fetch. `GET /api/scenarios/
+    // {id}` would 404 for it; the Scenario Pane / results area read `activeId`
+    // directly to show a "calculating"/"pending" state for this case instead.
+    if (!get().scenarios.some((s) => s.id === id)) {
+      set({ activeId: id, error: null });
+      return;
+    }
     set({ loading: true, error: null, activeId: id });
     try {
       const result = await fetchScenario(id);

--- a/frontend/src/stores/sweepStore.test.ts
+++ b/frontend/src/stores/sweepStore.test.ts
@@ -15,8 +15,22 @@ vi.mock("@/api/sweep", () => ({
 }));
 
 const mockRefresh = vi.fn();
+const mockSetActive = vi.fn();
+let mockActiveId: string | null = null;
+let mockScenarios: Array<{ id: string }> = [];
 vi.mock("./scenarioStore", () => ({
-  useScenarioStore: { getState: () => ({ refresh: mockRefresh }) },
+  useScenarioStore: {
+    getState: () => ({
+      refresh: mockRefresh,
+      setActive: mockSetActive,
+      get activeId() {
+        return mockActiveId;
+      },
+      get scenarios() {
+        return mockScenarios;
+      },
+    }),
+  },
 }));
 
 const mockToastSuccess = vi.fn();
@@ -33,7 +47,13 @@ import { useSweepRunStore } from "./sweepStore";
 describe("sweepStore", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    useSweepRunStore.setState({ sweeping: false, progress: { current: 0, total: 0 } });
+    mockActiveId = null;
+    mockScenarios = [];
+    useSweepRunStore.setState({
+      sweeping: false,
+      progress: { current: 0, total: 0 },
+      scenarioProgress: {},
+    });
   });
 
   afterEach(() => {
@@ -94,5 +114,75 @@ describe("sweepStore", () => {
 
     expect(mockStartSweep).not.toHaveBeenCalled();
     expect(mockToastError).toHaveBeenCalledWith("A sweep is already running");
+  });
+
+  it("run()'s poll tick populates scenarioProgress from the status payload", async () => {
+    vi.useFakeTimers();
+    mockStartSweep.mockResolvedValue({ status: "running", total: 1 });
+    mockGetSweepStatus
+      .mockResolvedValueOnce({
+        status: "running",
+        current: 1,
+        total: 2,
+        scenario_progress: { cold_feed: { stage: 1, stage_total: 3 } },
+      })
+      .mockResolvedValueOnce({ status: "done", current: 2, total: 2 });
+
+    useSweepRunStore.getState().run({ total: 2 });
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(useSweepRunStore.getState().scenarioProgress).toEqual({
+      cold_feed: { stage: 1, stageTotal: 3 },
+    });
+
+    await vi.advanceTimersByTimeAsync(1000);
+    // Cleared once the sweep finishes.
+    expect(useSweepRunStore.getState().scenarioProgress).toEqual({});
+  });
+
+  it("hydrate() attaches to an already-running sweep and polls it to completion", async () => {
+    vi.useFakeTimers();
+    mockGetSweepStatus
+      .mockResolvedValueOnce({
+        status: "running",
+        current: 1,
+        total: 2,
+        scenario_progress: { a: { stage: null, stage_total: null } },
+      })
+      .mockResolvedValueOnce({ status: "done", current: 2, total: 2 });
+
+    useSweepRunStore.getState().hydrate();
+    await vi.advanceTimersByTimeAsync(0); // flush the initial getSweepStatus()
+
+    expect(useSweepRunStore.getState().sweeping).toBe(true);
+    expect(useSweepRunStore.getState().scenarioProgress).toEqual({
+      a: { stage: null, stageTotal: null },
+    });
+    expect(mockStartSweep).not.toHaveBeenCalled(); // attaches, never re-POSTs
+
+    await vi.advanceTimersByTimeAsync(1000); // poll tick -> done
+    expect(useSweepRunStore.getState().sweeping).toBe(false);
+    expect(mockRefresh).toHaveBeenCalledOnce();
+  });
+
+  it("hydrate() is a no-op when nothing is running", async () => {
+    mockGetSweepStatus.mockResolvedValue({ status: "idle" });
+
+    useSweepRunStore.getState().hydrate();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(useSweepRunStore.getState().sweeping).toBe(false);
+    expect(mockToastSuccess).not.toHaveBeenCalled();
+    expect(mockToastError).not.toHaveBeenCalled();
+  });
+
+  it("hydrate() is a no-op when this session is already polling its own run()", async () => {
+    useSweepRunStore.setState({ sweeping: true, progress: { current: 0, total: 0 } });
+
+    useSweepRunStore.getState().hydrate();
+
+    expect(mockGetSweepStatus).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/stores/sweepStore.ts
+++ b/frontend/src/stores/sweepStore.ts
@@ -1,11 +1,16 @@
 import { create } from "zustand";
 import { toast } from "sonner";
-import { getSweepStatus, startSweep } from "@/api/sweep";
+import { getSweepStatus, startSweep, type SweepStatus } from "@/api/sweep";
 import { useScenarioStore } from "./scenarioStore";
 
 interface SweepRunState {
   sweeping: boolean;
   progress: { current: number; total: number };
+  /**
+   * Scenarios currently being solved, keyed by id (mirrors
+   * `SweepStatus.scenario_progress` — see that type for why it's a map).
+   */
+  scenarioProgress: Record<string, { stage: number | null; stageTotal: number | null }>;
   /**
    * Start a sweep job and poll it to completion, toasting the outcome and
    * refreshing the Scenario Pane. Backs RunControl's "Run Sweep" — a single
@@ -14,6 +19,12 @@ interface SweepRunState {
    * store's per-scenario fingerprint cache (see `startSweep`).
    */
   run: (options?: { total?: number; noCache?: boolean }) => void;
+  /**
+   * Attach to a sweep that's already running server-side (e.g. the page was
+   * refreshed mid-sweep) — a no-op if nothing is running, or if this session
+   * is already polling one via `run()`.
+   */
+  hydrate: () => void;
 }
 
 // Module-level (not store state) — a plain interval handle, not observed by
@@ -27,43 +38,87 @@ function stopPolling(): void {
   }
 }
 
-export const useSweepRunStore = create<SweepRunState>((set, get) => ({
-  sweeping: false,
-  progress: { current: 0, total: 0 },
-
-  run: (options) => {
-    if (get().sweeping) {
-      toast.error("A sweep is already running");
+export const useSweepRunStore = create<SweepRunState>((set, get) => {
+  // Single place that interprets a status payload — `run()`'s poll tick and
+  // `hydrate()`'s first snapshot both funnel through this, so there is only
+  // ever one poll loop and one completion path regardless of who started it.
+  function applyStatus(st: SweepStatus): void {
+    if (st.status === "running") {
+      const scenarioProgress: SweepRunState["scenarioProgress"] = {};
+      for (const [id, p] of Object.entries(st.scenario_progress ?? {})) {
+        scenarioProgress[id] = { stage: p.stage, stageTotal: p.stage_total };
+      }
+      set({
+        sweeping: true,
+        progress: { current: st.current ?? 0, total: st.total ?? 0 },
+        scenarioProgress,
+      });
       return;
     }
-    set({ sweeping: true, progress: { current: 0, total: options?.total ?? 0 } });
-    startSweep({ noCache: options?.noCache })
-      .then(() => {
-        pollHandle = setInterval(() => {
-          getSweepStatus()
-            .then((st) => {
-              if (st.status === "running") {
-                set({ progress: { current: st.current ?? 0, total: st.total ?? 0 } });
-                return;
-              }
-              stopPolling();
-              set({ sweeping: false });
-              if (st.status === "done") {
-                toast.success("Sweep complete — scenarios updated");
-                void useScenarioStore.getState().refresh();
-              } else {
-                toast.error(`Sweep failed: ${st.message ?? "unknown error"}`);
-              }
-            })
-            .catch(() => {
-              stopPolling();
-              set({ sweeping: false });
-            });
-        }, 1000);
-      })
-      .catch((e) => {
-        set({ sweeping: false });
-        toast.error(e instanceof Error ? e.message : String(e));
-      });
-  },
-}));
+    stopPolling();
+    set({ sweeping: false, scenarioProgress: {} });
+    if (st.status === "done") {
+      toast.success("Sweep complete — scenarios updated");
+      void (async () => {
+        await useScenarioStore.getState().refresh();
+        // The active scenario may have only just finished solving — re-fetch
+        // it now that it's actually in the store, replacing whatever
+        // "calculating" placeholder was showing.
+        const { activeId, scenarios, setActive } = useScenarioStore.getState();
+        if (activeId && scenarios.some((s) => s.id === activeId)) {
+          void setActive(activeId);
+        }
+      })();
+    } else if (st.status === "error") {
+      toast.error(`Sweep failed: ${st.message ?? "unknown error"}`);
+    }
+    // "idle" only ever reaches here from hydrate()'s no-op path below, never
+    // from an active poll tick — nothing to do, no toast.
+  }
+
+  function startPolling(): void {
+    if (pollHandle !== null) return; // a loop is already running
+    pollHandle = setInterval(() => {
+      getSweepStatus()
+        .then(applyStatus)
+        .catch(() => {
+          stopPolling();
+          set({ sweeping: false });
+        });
+    }, 1000);
+  }
+
+  return {
+    sweeping: false,
+    progress: { current: 0, total: 0 },
+    scenarioProgress: {},
+
+    run: (options) => {
+      if (get().sweeping) {
+        toast.error("A sweep is already running");
+        return;
+      }
+      set({ sweeping: true, progress: { current: 0, total: options?.total ?? 0 } });
+      startSweep({ noCache: options?.noCache })
+        .then(() => startPolling())
+        .catch((e) => {
+          set({ sweeping: false });
+          toast.error(e instanceof Error ? e.message : String(e));
+        });
+    },
+
+    hydrate: () => {
+      if (get().sweeping) return; // this session's own run() is already attached
+      getSweepStatus()
+        .then((st) => {
+          if (st.status !== "running") return; // nothing in flight
+          applyStatus(st);
+          startPolling();
+        })
+        .catch(() => {
+          // Best-effort — if the backend isn't reachable yet, a later
+          // manual Run Sweep click will surface the real error.
+        });
+    },
+  };
+});

--- a/tests/test_sweep_status_scenario_progress.py
+++ b/tests/test_sweep_status_scenario_progress.py
@@ -1,0 +1,164 @@
+"""Tests for `sweep_status`'s per-scenario `scenario_progress` map.
+
+`sweep_runner.run()` already prints the scenario id inline
+("scenario N/M (id)", or "... (id): cached, skipped" for a cache hit), and
+`boulder.staged_solver`'s per-stage INFO logs reach the same captured
+subprocess output. `sweep.py`'s stdout parser turns those lines into
+`scenario_progress`: a `{scenario_id: {stage, stage_total}}` map (keyed by id,
+not a single "current scenario" scalar, so a future parallel sweep runner can
+hold more than one entry at once without a shape change) that
+`GET /api/sweep/status` passes straight through.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from pathlib import Path
+from typing import Any, Dict
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytest.importorskip("fastapi")
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from boulder.api.main import create_app  # noqa: E402
+
+_CONFIG_YAML = """\
+metadata:
+  description: "test config"
+phases:
+  gas:
+    mechanism: gri30.yaml
+network:
+  - id: feed
+    Reservoir:
+      temperature: 298.15
+      pressure: 101325
+      composition: "CH4:1"
+scenarios:
+  a:
+    metadata:
+      scenario_name: "A"
+  b:
+    metadata:
+      scenario_name: "B"
+"""
+
+
+def _client_with_local_runner(tmp_path: Path):
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(_CONFIG_YAML, encoding="utf-8")
+    (tmp_path / "run_sweep.py").write_text("", encoding="utf-8")
+
+    app = create_app()
+    client = TestClient(app)
+    client.__enter__()
+    app.state.preloaded_config_path = str(cfg)
+    app.state.preloaded_raw = {"scenarios": {"a": {}, "b": {}}}
+    return client, app
+
+
+def test_scenario_progress_tracks_stage_then_clears_on_skip(tmp_path: Path) -> None:
+    """A solving scenario's stage updates land in scenario_progress[id].
+
+    A subsequent "cached, skipped" scenario line clears the map instead of
+    ever showing that scenario as "calculating" (a cache hit is instant).
+    """
+    client, app = _client_with_local_runner(tmp_path)
+    after_stage_line = threading.Event()
+    resume_after_stage = threading.Event()
+    after_skip_line = threading.Event()
+
+    def stdout_gen():
+        yield "scenario 1/2 (a)"
+        yield (
+            "2026-01-01 00:00:00 - boulder.staged_solver - INFO - "
+            "Staged solve: stage 'default' (1/3, 3 reactors)"
+        )
+        # Pause here (holding the for-loop mid-iteration) so the test can
+        # assert the in-flight state before the next line arrives.
+        after_stage_line.set()
+        resume_after_stage.wait(timeout=5)
+        yield "scenario 2/2 (b): cached, skipped"
+        after_skip_line.set()
+
+    proc = MagicMock()
+    proc.stdout = stdout_gen()
+    proc.wait.return_value = None
+    proc.returncode = 0
+    captured: Dict[str, Any] = {}
+
+    def _factory(*args: Any, **kwargs: Any) -> MagicMock:
+        captured["kwargs"] = kwargs
+        return proc
+
+    try:
+        with patch("boulder.api.routes.sweep.subprocess.Popen", side_effect=_factory):
+            resp = client.post("/api/sweep/run", json={})
+            assert resp.status_code == 200, resp.text
+
+            assert after_stage_line.wait(timeout=2), "stage line was never processed"
+            job = app.state.sweep_job
+            assert job["scenario_progress"] == {"a": {"stage": 1, "stage_total": 3}}
+
+            resume_after_stage.set()
+            assert after_skip_line.wait(timeout=2), "skip line was never processed"
+            assert app.state.sweep_job["scenario_progress"] == {}
+
+            status = client.get("/api/sweep/status").json()
+            assert status["scenario_progress"] == {}
+            assert status["current"] == 2
+            assert status["total"] == 2
+    finally:
+        client.__exit__(None, None, None)
+
+
+def test_scenario_progress_clears_once_the_process_exits_mid_solve(
+    tmp_path: Path,
+) -> None:
+    """The last scenario solved may not end with a "cached, skipped" line.
+
+    Nothing should linger as "calculating" once the subprocess has exited,
+    one way or another.
+    """
+    client, app = _client_with_local_runner(tmp_path)
+    after_stage_line = threading.Event()
+    resume_after_stage = threading.Event()
+
+    def stdout_gen():
+        yield "scenario 1/1 (a)"
+        yield (
+            "2026-01-01 00:00:00 - boulder.staged_solver - INFO - "
+            "Staged solve: stage 'default' (1/1, 3 reactors)"
+        )
+        after_stage_line.set()
+        resume_after_stage.wait(timeout=5)
+
+    proc = MagicMock()
+    proc.stdout = stdout_gen()
+    proc.wait.return_value = None
+    proc.returncode = 0
+
+    try:
+        with patch("boulder.api.routes.sweep.subprocess.Popen", return_value=proc):
+            resp = client.post("/api/sweep/run", json={})
+            assert resp.status_code == 200, resp.text
+
+            assert after_stage_line.wait(timeout=2), "stage line was never processed"
+            assert app.state.sweep_job["scenario_progress"] == {
+                "a": {"stage": 1, "stage_total": 1}
+            }
+
+            resume_after_stage.set()  # let stdout end -> proc.wait() -> "done"
+
+            for _ in range(50):
+                if app.state.sweep_job.get("status") == "done":
+                    break
+                time.sleep(0.05)
+            assert app.state.sweep_job["status"] == "done"
+            assert app.state.sweep_job["scenario_progress"] == {}
+    finally:
+        client.__exit__(None, None, None)


### PR DESCRIPTION
## What

- Each scenario row in the Scenario Pane shows **"Calculating…"** only while it's actually being solved, replacing its cache-age label. Every scenario — computed, pending, or mid-sweep — stays visible and clickable in one unified list instead of disappearing until a sweep finishes.
- Selecting a scenario that's mid-sweep shows a small inline "Calculating … — Stage X/Y" card in the results area — **not** a blocking overlay like `SimulationOverlay` — so the Scenario Pane and the rest of the layout stay fully visible and usable.
- A page refresh mid-sweep now reconstructs the in-flight job: `sweepStore` hydrates from `GET /api/sweep/status` once on `AppShell` mount instead of only tracking state from the moment `run()` was clicked in that tab.

## Why

The Scenario Pane had no visibility into an in-progress sweep, and a scenario not yet computed would vanish from the list entirely once anything else had been computed — making it impossible to tell what's happening or navigate to a scenario still being solved. A page refresh mid-sweep also silently lost track of it client-side, even though the backend kept running.

## Design note: forward-compatible with parallel sweeps

Progress is tracked as `scenario_progress: {scenario_id: {stage, stage_total}}` — a **map keyed by id**, not a single "current scenario" scalar — even though sweeps run serially today (one subprocess, one scenario at a time). A scenario id's presence in the map *is* "currently calculating." This means a future parallel sweep runner can report more than one in-flight scenario at once without any API/store shape change; only the "one scenario in flight" assumption in `sweep.py`'s stdout parser (called out in a comment) would need revisiting.

## How

- **`boulder/api/routes/sweep.py`**: the subprocess stdout parser now also captures the scenario id `sweep_runner.run()` already prints inline, and `boulder.staged_solver`'s per-stage log lines (which already reach the same captured output — verified empirically, no `sweep_runner.py` change needed). A cache-hit ("cached, skipped") line clears that id from the map instead of ever showing it as calculating.
- **`frontend/src/stores/sweepStore.ts`**: adds `scenarioProgress` and a `hydrate()` action; `run()` and `hydrate()` now share one status-handling function and one poll-starter instead of forked logic.
- **`frontend/src/stores/scenarioStore.ts`**: `setActive` on a not-yet-computed scenario id is now a no-op selection (no 404 fetch, no error) instead of the only supported path being an already-computed one.
- **`frontend/src/components/panels/ScenarioPane.tsx`**: unifies what were two mutually-exclusive render branches into one merged, always-current row list.
- **New `frontend/src/components/results/SweepCalculatingCard.tsx`**, wired into `ResultsTabs.tsx`.
- **`frontend/src/components/layout/AppShell.tsx`**: calls `hydrate()` once on mount.

## Test plan

- [x] Backend: `pytest tests/` — 755 passed, 2 skipped, 7 xfailed (including two new tests covering the stdout-parsing regexes and a regression test for a bug found during manual testing — see below).
- [x] Backend: `mypy boulder`, `ruff check`, `ruff format --check` all clean.
- [x] Frontend: `npm run test:unit` (167 passed), `npm run type-check`, `npm run build` all clean.
- [x] Manual end-to-end: ran `boulder --dev` against a scratch multi-stage config with a `scenarios:` block and a local `run_sweep.py` shim, and drove a real sweep subprocess through the browser. Confirmed live:
  - Rows correctly show "Calculating…" for exactly the scenario currently solving, "Not computed yet" for pending ones.
  - Clicking the calculating row renders the inline card (`Calculating "hot_feed"…`) in `<main>` while the Scenario Pane `<aside>` — listing all 5 scenarios with live per-row status — stayed fully visible and interactive alongside it.
  - A page reload triggered mid-sweep correctly re-attached via `hydrate()` and later surfaced the normal "Sweep complete" toast, with no `run()` ever having been called in that page load.
  - Along the way, found and fixed a real bug: `scenario_progress` wasn't cleared when the subprocess exited without a trailing "cached, skipped" line for the last scenario, leaving stale data in the backend's job state (harmless to the UI, which clears client-side on any terminal status regardless, but incorrect for the API contract itself) — added a regression test for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — Claude Sonnet 5. This PR's implementation was planned and reviewed with the user before being written.