### PR TITLE
Remove Download Python button's hover tooltip

### DIFF
--- a/frontend/src/components/panels/SimulateCard.tsx
+++ b/frontend/src/components/panels/SimulateCard.tsx
@@ -197,20 +197,15 @@ export function SimulateCard() {
         runDisabled={runDisabled}
       />
 
-      <Tooltip
-        className="block"
-        content="Download the equivalent runnable Python/Cantera script for this network."
+      <Button
+        id="download-python"
+        onClick={handleDownloadPy}
+        disabled={!pythonCode}
+        variant="secondary"
+        className="w-full"
       >
-        <Button
-          id="download-python"
-          onClick={handleDownloadPy}
-          disabled={!pythonCode}
-          variant="secondary"
-          className="w-full"
-        >
-          Download Python
-        </Button>
-      </Tooltip>
+        Download Python
+      </Button>
 
       {guiActions.map((action) => {
         const button = (


### PR DESCRIPTION
## What

Removes the `Tooltip` wrapper around the "Download Python" button in the Simulate card — it popped up over the button and got in the way.

## Test plan

- [x] `npm run test:unit` (SimulateCard.test.tsx, 5 passed)
- [x] `npm run type-check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)