### PR TITLE
Auto-select scenario after sweep, lock YAML editing during runs

### DIFF
--- a/frontend/src/components/modals/ScenarioYamlEditorModal.tsx
+++ b/frontend/src/components/modals/ScenarioYamlEditorModal.tsx
@@ -2,6 +2,8 @@ import { useState, useEffect, lazy, Suspense } from "react";
 import { fetchScenarioSource, updateScenario } from "@/api/scenarios";
 import { Button } from "@/components/ui/Button";
 import { toast } from "sonner";
+import { useSimulationStore } from "@/stores/simulationStore";
+import { useSweepRunStore } from "@/stores/sweepStore";
 
 const MonacoEditor = lazy(() => import("@monaco-editor/react"));
 
@@ -30,6 +32,9 @@ export function ScenarioYamlEditorModal({
   const [loading, setLoading] = useState(false);
   const [saving, setSaving] = useState(false);
   const [loadError, setLoadError] = useState<string | null>(null);
+  const isSimulating = useSimulationStore((s) => s.isRunning);
+  const isSweeping = useSweepRunStore((s) => s.sweeping);
+  const isCalculating = isSimulating || isSweeping;
 
   useEffect(() => {
     if (!scenarioId) return;
@@ -46,6 +51,10 @@ export function ScenarioYamlEditorModal({
   if (!scenarioId) return null;
 
   const handleSave = async () => {
+    if (isCalculating) {
+      toast.error("Wait for the current calculation to finish before saving YAML changes.");
+      return;
+    }
     setSaving(true);
     try {
       await updateScenario(scenarioId, value);
@@ -92,6 +101,12 @@ export function ScenarioYamlEditorModal({
           </Button>
         </div>
 
+        {isCalculating && (
+          <div className="px-4 py-2 text-xs bg-blue-50 dark:bg-blue-900/20 border-b border-blue-200 dark:border-blue-800 text-blue-800 dark:text-blue-300 shrink-0">
+            A calculation is running — this scenario is locked until it finishes.
+          </div>
+        )}
+
         <div className="flex-1 overflow-hidden">
           {loading ? (
             <div className="flex items-center justify-center h-full text-muted-foreground">
@@ -108,6 +123,7 @@ export function ScenarioYamlEditorModal({
                   id="scenario-yaml-editor"
                   value={value}
                   onChange={(e) => setValue(e.target.value)}
+                  readOnly={isCalculating}
                   className="w-full h-full p-4 font-mono text-sm bg-background text-foreground resize-none"
                 />
               }
@@ -122,6 +138,7 @@ export function ScenarioYamlEditorModal({
                   minimap: { enabled: false },
                   wordWrap: "on",
                   fontSize: 13,
+                  readOnly: isCalculating,
                 }}
               />
             </Suspense>
@@ -135,9 +152,10 @@ export function ScenarioYamlEditorModal({
           <Button
             id="save-scenario-yaml-btn"
             onClick={() => void handleSave()}
-            disabled={saving || loading || !!loadError}
+            disabled={saving || loading || !!loadError || isCalculating}
             variant="primary"
             size="sm"
+            title={isCalculating ? "Wait for the current calculation to finish" : undefined}
           >
             {saving ? "Saving…" : "Save"}
           </Button>

--- a/frontend/src/components/panels/YamlPane.test.tsx
+++ b/frontend/src/components/panels/YamlPane.test.tsx
@@ -62,6 +62,17 @@ vi.mock("@/stores/themeStore", () => ({
   useThemeStore: (selector: (s: unknown) => unknown) => selector({ theme: "light" }),
 }));
 
+let mockIsRunning = false;
+vi.mock("@/stores/simulationStore", () => ({
+  useSimulationStore: (selector: (s: unknown) => unknown) =>
+    selector({ isRunning: mockIsRunning }),
+}));
+
+let mockSweeping = false;
+vi.mock("@/stores/sweepStore", () => ({
+  useSweepRunStore: (selector: (s: unknown) => unknown) => selector({ sweeping: mockSweeping }),
+}));
+
 const mockSyncConfig = vi.fn();
 const mockParseYaml = vi.fn();
 vi.mock("@/api/configs", () => ({
@@ -91,6 +102,8 @@ describe("YamlPane", () => {
     mockOriginalYaml = "original: yaml\n";
     mockFileName = "test.yaml";
     mockSyncConfig.mockResolvedValue({ yaml: "merged: yaml\n", warnings: [] });
+    mockIsRunning = false;
+    mockSweeping = false;
   });
 
   it("syncs the merged YAML on mount", async () => {
@@ -186,6 +199,40 @@ describe("YamlPane", () => {
     render(<YamlPane />);
     const editor = await editorValue();
     await waitFor(() => expect(editor).toHaveValue("merged: yaml\n"));
+
+    fireEvent.keyDown(window, { key: "s", ctrlKey: true });
+    expect(mockParseYaml).not.toHaveBeenCalled();
+  });
+
+  it("locks Save and shows a banner while a sweep is running", async () => {
+    mockSweeping = true;
+    render(<YamlPane />);
+    const editor = await editorValue();
+    await waitFor(() => expect(editor).toHaveValue("merged: yaml\n"));
+    fireEvent.change(editor, { target: { value: "merged: yaml\nextra: 1\n" } });
+
+    expect(saveButton()).toBeDisabled();
+    expect(
+      screen.getByText(/calculation is running.*locked until it finishes/i),
+    ).toBeInTheDocument();
+  });
+
+  it("locks Save while a single simulation is running", async () => {
+    mockIsRunning = true;
+    render(<YamlPane />);
+    const editor = await editorValue();
+    await waitFor(() => expect(editor).toHaveValue("merged: yaml\n"));
+    fireEvent.change(editor, { target: { value: "merged: yaml\nextra: 1\n" } });
+
+    expect(saveButton()).toBeDisabled();
+  });
+
+  it("Ctrl+S does not save while a calculation is running", async () => {
+    mockSweeping = true;
+    render(<YamlPane />);
+    const editor = await editorValue();
+    await waitFor(() => expect(editor).toHaveValue("merged: yaml\n"));
+    fireEvent.change(editor, { target: { value: "merged: yaml\nextra: 1\n" } });
 
     fireEvent.keyDown(window, { key: "s", ctrlKey: true });
     expect(mockParseYaml).not.toHaveBeenCalled();

--- a/frontend/src/components/panels/YamlPane.tsx
+++ b/frontend/src/components/panels/YamlPane.tsx
@@ -4,6 +4,8 @@ import { useConfigStore } from "@/stores/configStore";
 import { useScenarioStore } from "@/stores/scenarioStore";
 import { useLayoutStore } from "@/stores/layoutStore";
 import { useThemeStore } from "@/stores/themeStore";
+import { useSimulationStore } from "@/stores/simulationStore";
+import { useSweepRunStore } from "@/stores/sweepStore";
 import { parseYaml, syncConfig } from "@/api/configs";
 import { Button } from "@/components/ui/Button";
 import { toast } from "sonner";
@@ -26,6 +28,9 @@ export function YamlPane() {
   const setConfig = useConfigStore((s) => s.setConfig);
   const closeYamlPane = useLayoutStore((s) => s.closeYamlPane);
   const theme = useThemeStore((s) => s.theme);
+  const isSimulating = useSimulationStore((s) => s.isRunning);
+  const isSweeping = useSweepRunStore((s) => s.sweeping);
+  const isCalculating = isSimulating || isSweeping;
 
   const [value, setValue] = useState("");
   const [baseline, setBaseline] = useState("");
@@ -91,6 +96,10 @@ export function YamlPane() {
   }, [refresh]);
 
   const handleSave = useCallback(async () => {
+    if (isCalculating) {
+      toast.error("Wait for the current calculation to finish before saving YAML changes.");
+      return;
+    }
     setSaving(true);
     try {
       const resp = await parseYaml(value);
@@ -107,21 +116,21 @@ export function YamlPane() {
     } finally {
       setSaving(false);
     }
-  }, [value, setConfig]);
+  }, [value, setConfig, isCalculating]);
 
-  const canSave = isDirty && !saving && !syncing && !syncError;
+  const canSave = isDirty && !saving && !syncing && !syncError && !isCalculating;
 
   // Ctrl/Cmd+S saves instead of triggering the browser's "Save Page As".
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
       if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === "s") {
         e.preventDefault();
-        if (canSave) void handleSave();
+        if (canSave || (isDirty && isCalculating)) void handleSave();
       }
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [canSave, handleSave]);
+  }, [canSave, handleSave, isDirty, isCalculating]);
 
   const handleCancel = () => {
     setValue(baseline);
@@ -155,6 +164,15 @@ export function YamlPane() {
         </Button>
       </div>
 
+      {isCalculating && (
+        <div
+          id="yaml-locked-banner"
+          className="px-3 py-2 text-xs bg-blue-50 dark:bg-blue-900/20 border-b border-blue-200 dark:border-blue-800 text-blue-800 dark:text-blue-300 shrink-0"
+        >
+          A calculation is running — the YAML is locked until it finishes.
+        </div>
+      )}
+
       {syncWarnings.length > 0 && (
         <div
           id="sync-warnings-banner"
@@ -186,6 +204,7 @@ export function YamlPane() {
                 id="config-yaml-editor"
                 value={value}
                 onChange={(e) => setValue(e.target.value)}
+                readOnly={isCalculating}
                 className="w-full h-full p-4 font-mono text-sm bg-background text-foreground resize-none"
               />
             }
@@ -200,6 +219,7 @@ export function YamlPane() {
                 minimap: { enabled: false },
                 wordWrap: "on",
                 fontSize: 13,
+                readOnly: isCalculating,
               }}
             />
           </Suspense>
@@ -219,7 +239,7 @@ export function YamlPane() {
           disabled={!canSave}
           variant="primary"
           size="sm"
-          title="Save (Ctrl+S)"
+          title={isCalculating ? "Wait for the current calculation to finish" : "Save (Ctrl+S)"}
         >
           {saving ? "Saving…" : "Save"}
         </Button>

--- a/frontend/src/stores/sweepStore.test.ts
+++ b/frontend/src/stores/sweepStore.test.ts
@@ -185,4 +185,47 @@ describe("sweepStore", () => {
 
     expect(mockGetSweepStatus).not.toHaveBeenCalled();
   });
+
+  it("run()'s completion auto-selects the first scenario when nothing was active", async () => {
+    vi.useFakeTimers();
+    mockActiveId = null;
+    mockScenarios = [{ id: "BASELINE" }, { id: "C600_P300" }];
+    mockStartSweep.mockResolvedValue({ status: "running", total: 2 });
+    mockGetSweepStatus.mockResolvedValueOnce({ status: "done", current: 2, total: 2 });
+
+    useSweepRunStore.getState().run({ total: 2 });
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(mockSetActive).toHaveBeenCalledWith("BASELINE");
+  });
+
+  it("run()'s completion re-fetches the existing active scenario instead of switching", async () => {
+    vi.useFakeTimers();
+    mockActiveId = "C600_P300";
+    mockScenarios = [{ id: "BASELINE" }, { id: "C600_P300" }];
+    mockStartSweep.mockResolvedValue({ status: "running", total: 2 });
+    mockGetSweepStatus.mockResolvedValueOnce({ status: "done", current: 2, total: 2 });
+
+    useSweepRunStore.getState().run({ total: 2 });
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(mockSetActive).toHaveBeenCalledWith("C600_P300");
+    expect(mockSetActive).toHaveBeenCalledOnce();
+  });
+
+  it("run()'s completion does nothing when there is no active scenario and none finished", async () => {
+    vi.useFakeTimers();
+    mockActiveId = null;
+    mockScenarios = [];
+    mockStartSweep.mockResolvedValue({ status: "running", total: 1 });
+    mockGetSweepStatus.mockResolvedValueOnce({ status: "done", current: 1, total: 1 });
+
+    useSweepRunStore.getState().run({ total: 1 });
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(mockSetActive).not.toHaveBeenCalled();
+  });
 });

--- a/frontend/src/stores/sweepStore.ts
+++ b/frontend/src/stores/sweepStore.ts
@@ -67,6 +67,11 @@ export const useSweepRunStore = create<SweepRunState>((set, get) => {
         const { activeId, scenarios, setActive } = useScenarioStore.getState();
         if (activeId && scenarios.some((s) => s.id === activeId)) {
           void setActive(activeId);
+        } else if (scenarios.length > 0) {
+          // Nothing was selected before the sweep ran (e.g. the first sweep
+          // in a session) — auto-select a scenario so the results view
+          // populates instead of staying blank behind the Scenario Pane.
+          void setActive(scenarios[0].id);
         }
       })();
     } else if (st.status === "error") {

--- a/frontend/src/stores/sweepStore.ts
+++ b/frontend/src/stores/sweepStore.ts
@@ -64,7 +64,7 @@ export const useSweepRunStore = create<SweepRunState>((set, get) => {
         // The active scenario may have only just finished solving — re-fetch
         // it now that it's actually in the store, replacing whatever
         // "calculating" placeholder was showing.
-        const { activeId, scenarios, setActive } = useScenarioStore.getState();
+        const { activeId, scenarios = [], setActive } = useScenarioStore.getState();
         if (activeId && scenarios.some((s) => s.id === activeId)) {
           void setActive(activeId);
         } else if (scenarios.length > 0) {


### PR DESCRIPTION
## Summary
- Sweep completion previously only re-selected a scenario when one was already active before the sweep started, so a fresh session's first sweep left the main results view (Plots/Sankey/Thermo/Summary/Convergence) blank even though every scenario had solved — the only visible output was the Scenario Pane's row list. Now the first scenario is auto-selected when nothing was active, so results always populate after a sweep.
- The YAML pane and the per-scenario YAML modal are now locked (read-only editor, disabled Save with an explanatory tooltip, banner) while a simulation or sweep is running, since edits made mid-run could desync from what's actually being solved.

## Test plan
- [x] Added unit tests for the auto-select-on-completion behavior in `sweepStore.test.ts` (auto-selects first scenario when nothing active, keeps re-fetching the existing active scenario otherwise, no-ops when there's nothing to select).
- [x] Added unit tests for the calculation lock in `YamlPane.test.tsx` (Save disabled + banner shown while sweeping/simulating, Ctrl+S is a no-op while calculating).
- [x] Verified live end-to-end in the browser against `bloc`'s `SPRING_A4_C1X_20260721.yaml`: ran a full 4-scenario sweep with nothing pre-selected — main pane auto-populated with results on completion (previously blank). Confirmed via the Monaco API that the editor is `readOnly: true` during the run and reverts to `false` after, Save button disables with the correct tooltip, and typing during the run is rejected.
- [ ] Could not run `npm run type-check` / `npm run lint` in this environment (no Node toolchain available where the diff was authored) — please run CI to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)