### PR TITLE
feat(scenarios): preview scenario overrides in the Inputs pane

### DIFF
--- a/boulder/api/routes/scenarios.py
+++ b/boulder/api/routes/scenarios.py
@@ -225,6 +225,74 @@ async def get_scenario_source(scenario_id: str, request: Request) -> Dict[str, A
     return {"scenario_id": scenario_id, "yaml": yaml_text}
 
 
+def _raw_base_config(request: Request) -> Optional[Dict[str, Any]]:
+    """Return the inheritance-resolved base config dict (keeps `scenarios:`/`sweep:`).
+
+    Prefers the in-memory snapshot (kept fresh by `_reload_preloaded_state` after
+    every scenario write); falls back to a fresh disk load so the preview route
+    also works against a config path set directly (e.g. in tests) without going
+    through a scenario CRUD call first.
+    """
+    raw = getattr(request.app.state, "preloaded_raw", None)
+    if raw:
+        return raw
+    cfg_path = _config_path(request)
+    if cfg_path is None or not cfg_path.is_file():
+        return None
+    from ...runner import BoulderRunner
+
+    runner_cls = getattr(request.app.state, "runner_class", None) or BoulderRunner
+    return runner_cls.load(str(cfg_path))
+
+
+@router.get("/{scenario_id}/preview")
+async def get_scenario_preview(scenario_id: str, request: Request) -> Dict[str, Any]:
+    """Return the effective node/connection properties for one authored scenario.
+
+    Lets the Inputs pane show a scenario's parameter overrides (e.g. a reactor's
+    ``length``) the moment it's selected — even before Run Sweep has produced a
+    trajectory for it. Mirrors :func:`boulder.runset.expand_scenarios`'s base ⊕
+    overlay merge for a single scenario id, using the overlay's own values as-is:
+    an inner ``sweep:`` block's axis values are not expanded here (this is a
+    static preview of the authored overlay, not a resolved run-set point).
+    """
+    raw = _raw_base_config(request)
+    if not raw:
+        raise HTTPException(status_code=404, detail="No configuration loaded")
+
+    from ...runner import BoulderRunner
+    from ...runset import BASELINE_SCENARIO_ID, deep_merge
+
+    scenario_map = raw.get("scenarios") or {}
+    if scenario_id != BASELINE_SCENARIO_ID and scenario_id not in scenario_map:
+        raise HTTPException(status_code=404, detail=f"Unknown scenario {scenario_id!r}")
+
+    base_clean = {
+        k: v for k, v in raw.items() if k not in ("scenarios", "sweep", "sweeps")
+    }
+    overlay = (
+        dict(scenario_map[scenario_id]) if scenario_id != BASELINE_SCENARIO_ID else {}
+    )
+    overlay.pop("sweep", None)
+    overlay.pop("sweeps", None)
+    merged = deep_merge(base_clean, overlay)
+
+    runner_cls = getattr(request.app.state, "runner_class", None) or BoulderRunner
+    try:
+        normalized = runner_cls.normalize(merged)
+    except Exception as exc:  # noqa: BLE001 — surfaced as a 422 to the preview caller
+        raise HTTPException(
+            status_code=422,
+            detail=f"Could not preview scenario {scenario_id!r}: {exc}",
+        ) from exc
+
+    return {
+        "scenario_id": scenario_id,
+        "nodes": normalized.get("nodes", []),
+        "connections": normalized.get("connections", []),
+    }
+
+
 @router.post("")
 async def create_scenario(
     body: CreateScenarioRequest, request: Request

--- a/frontend/src/api/scenarios.ts
+++ b/frontend/src/api/scenarios.ts
@@ -1,5 +1,6 @@
 import { apiFetch } from "./client";
 import type { SimulationResults } from "@/types/simulation";
+import type { ConfigConnection, ConfigNode } from "@/types/config";
 
 /** One precomputed scenario (trajectory) in the active store. */
 export interface ScenarioMeta {
@@ -73,6 +74,23 @@ export interface ScenarioSourceResponse {
 export function fetchScenarioSource(id: string) {
   return apiFetch<ScenarioSourceResponse>(
     `/scenarios/${encodeURIComponent(id)}/source`,
+  );
+}
+
+export interface ScenarioPreviewResponse {
+  scenario_id: string;
+  nodes: ConfigNode[];
+  connections: ConfigConnection[];
+}
+
+/**
+ * Fetch one scenario's effective node/connection properties (base config
+ * deep-merged with its overlay) — works before Run Sweep has ever solved it,
+ * unlike `fetchScenario` (which 404s until a trajectory is cached).
+ */
+export function fetchScenarioPreview(id: string) {
+  return apiFetch<ScenarioPreviewResponse>(
+    `/scenarios/${encodeURIComponent(id)}/preview`,
   );
 }
 

--- a/frontend/src/components/panels/PropertiesPanel.test.tsx
+++ b/frontend/src/components/panels/PropertiesPanel.test.tsx
@@ -70,6 +70,22 @@ vi.mock("@/stores/configStore", () => ({
   },
 }));
 
+let mockPreviewId: string | null = null;
+let mockPreviewNodes: Array<{ id: string; properties: Record<string, unknown> }> | null = null;
+let mockPreviewConnections: Array<{ id: string; properties: Record<string, unknown> }> | null =
+  null;
+
+vi.mock("@/stores/scenarioStore", () => ({
+  useScenarioStore: (selector: (s: unknown) => unknown) => {
+    const store = {
+      previewId: mockPreviewId,
+      previewNodes: mockPreviewNodes,
+      previewConnections: mockPreviewConnections,
+    };
+    return selector(store);
+  },
+}));
+
 describe("PropertiesPanel delete confirmation", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -359,5 +375,91 @@ describe("PropertiesPanel object-valued properties", () => {
     expect(plotIndex).toBeGreaterThan(-1);
     expect(plotIndex).toBeGreaterThan(temperatureIndex);
     expect(plotIndex).toBeGreaterThan(pressureIndex);
+  });
+});
+
+describe("PropertiesPanel scenario preview", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockInitialConditionsEditNonce = 0;
+    mockSelectedElement = {
+      type: "node",
+      data: { id: "reactor_1", type: "IdealGasReactor" },
+    };
+    mockConfig = {
+      nodes: [
+        {
+          id: "reactor_1",
+          type: "IdealGasReactor",
+          properties: { temperature: 1273.15, length: 0.3 },
+        },
+      ],
+      connections: [],
+    };
+    mockPreviewId = null;
+    mockPreviewNodes = null;
+    mockPreviewConnections = null;
+  });
+
+  it("shows no preview badge and no override styling when nothing is previewed", () => {
+    render(<PropertiesPanel />);
+
+    expect(screen.queryByText(/Previewing scenario/)).not.toBeInTheDocument();
+    expect(screen.getByText("0.30")).toBeInTheDocument();
+  });
+
+  it("shows a scenario's overridden value and a preview badge once it's selected", () => {
+    mockPreviewId = "C600_P300";
+    mockPreviewNodes = [
+      { id: "reactor_1", properties: { temperature: 1273.15, length: 0.6 } },
+    ];
+    mockPreviewConnections = [];
+
+    render(<PropertiesPanel />);
+
+    expect(screen.getByText(/Previewing scenario/)).toBeInTheDocument();
+    expect(screen.getByText("C600_P300")).toBeInTheDocument();
+    expect(screen.getByText("0.60")).toBeInTheDocument();
+    expect(screen.queryByText("0.30")).not.toBeInTheDocument();
+  });
+
+  it("does not highlight a field the scenario leaves unchanged", () => {
+    mockPreviewId = "C600_P300";
+    // Same length as the base — only temperature differs.
+    mockPreviewNodes = [
+      { id: "reactor_1", properties: { temperature: 900, length: 0.3 } },
+    ];
+    mockPreviewConnections = [];
+
+    render(<PropertiesPanel />);
+
+    const lengthValue = screen.getByText("0.30");
+    expect(lengthValue.className).not.toMatch(/amber/);
+  });
+
+  it("highlights an overridden field distinctly from an unchanged one", () => {
+    mockPreviewId = "C600_P300";
+    mockPreviewNodes = [
+      { id: "reactor_1", properties: { temperature: 1273.15, length: 0.6 } },
+    ];
+    mockPreviewConnections = [];
+
+    render(<PropertiesPanel />);
+
+    expect(screen.getByText("0.60").className).toMatch(/amber/);
+  });
+
+  it("editing still shows/edits the base value, not the previewed scenario's override", () => {
+    mockPreviewId = "C600_P300";
+    mockPreviewNodes = [
+      { id: "reactor_1", properties: { temperature: 1273.15, length: 0.6 } },
+    ];
+    mockPreviewConnections = [];
+
+    render(<PropertiesPanel />);
+    fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+
+    expect(screen.getByDisplayValue("0.3")).toBeInTheDocument();
+    expect(screen.queryByText(/Previewing scenario/)).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/panels/PropertiesPanel.tsx
+++ b/frontend/src/components/panels/PropertiesPanel.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from "react";
 import { useSelectionStore } from "@/stores/selectionStore";
 import { useConfigStore } from "@/stores/configStore";
+import { useScenarioStore } from "@/stores/scenarioStore";
 import type { NormalizedConfig } from "@/types/config";
 import { kelvinToCelsius, celsiusToKelvin, formatNumber, labelWithUnit } from "@/lib/units";
 import { useKindSchema } from "@/hooks/useKindSchema";
@@ -57,6 +58,16 @@ function unfoldInitialConditions(
   return flat;
 }
 
+/** Render a property value the same way for the display span and override tooltips. */
+function formatDisplayValue(key: string, value: unknown): string {
+  if (key === "temperature" && typeof value === "number") {
+    return `${kelvinToCelsius(value).toFixed(2)} °C`;
+  }
+  if (typeof value === "number") return formatNumber(value);
+  if (typeof value === "object" && value !== null) return JSON.stringify(value);
+  return String(value ?? "");
+}
+
 function buildEditValuesFromProperties(
   displayProperties: Record<string, unknown>,
 ): Record<string, string> {
@@ -85,6 +96,9 @@ export function PropertiesPanel() {
   const removeNode = useConfigStore((s) => s.removeNode);
   const removeConnection = useConfigStore((s) => s.removeConnection);
   const clearSelection = useSelectionStore((s) => s.clearSelection);
+  const previewId = useScenarioStore((s) => s.previewId);
+  const previewNodes = useScenarioStore((s) => s.previewNodes);
+  const previewConnections = useScenarioStore((s) => s.previewConnections);
   const [isEditing, setIsEditing] = useState(false);
   const [editValues, setEditValues] = useState<Record<string, string>>({});
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
@@ -183,6 +197,22 @@ export function PropertiesPanel() {
   const properties = entity ? (entity.properties as Record<string, unknown>) : {};
   const displayProperties = unfoldInitialConditions(properties);
 
+  // A selected scenario's effective (base + overlay) properties for this same
+  // element — lets the Inputs pane preview a scenario's overrides (e.g. a
+  // reactor's length) the moment it's selected, even before Run Sweep has
+  // solved it. Falls back to the base properties when nothing is previewed,
+  // or when this element has no counterpart in the preview (shouldn't happen
+  // in practice — the preview mirrors the whole network — but is not fatal).
+  const previewList = isNode ? previewNodes : previewConnections;
+  const previewEntity = previewId ? previewList?.find((e) => e.id === id) : undefined;
+  const previewDisplayProperties = previewEntity
+    ? unfoldInitialConditions(previewEntity.properties as Record<string, unknown>)
+    : displayProperties;
+  // While editing, always show/edit the base config's own values — a scenario
+  // overlay is a separate, scoped edit (via "Edit scenario YAML"), not
+  // something a Save here should fold into the base network.
+  const renderProperties = isEditing ? displayProperties : previewDisplayProperties;
+
   // Stream-point nodes (inter-stage diamonds) and legacy terminal OutletSink nodes
   // are computed from upstream reactors.  OutletSink + terminal_sink is deprecated;
   // remove isTerminalSink when OutletSink is dropped from STONE.
@@ -198,7 +228,7 @@ export function PropertiesPanel() {
     const cond = schemaMeta?.[key]?.visibleWhen;
     if (!cond) return true;
     return Object.entries(cond).every(([dep, expected]) => {
-      const current = isEditing ? editValues[dep] : properties[dep];
+      const current = isEditing ? editValues[dep] : renderProperties[dep];
       return String(current ?? "") === String(expected);
     });
   };
@@ -272,6 +302,14 @@ export function PropertiesPanel() {
         <div>
           <h3 className="font-semibold text-sm text-foreground">{id}</h3>
           <span className="text-xs text-muted-foreground">{entityType}</span>
+          {previewId && !isEditing && (
+            <div
+              className="text-[10px] text-amber-600 dark:text-amber-400"
+              title="Values below are this scenario's effective overrides — Edit still edits the base network."
+            >
+              Previewing scenario <span className="font-mono">{previewId}</span>
+            </div>
+          )}
         </div>
         {!isComputedStream && (
           <div className="flex gap-1">
@@ -301,9 +339,16 @@ export function PropertiesPanel() {
         <div className="border-t border-border pt-2 mt-1">
           <p className="text-xs text-muted-foreground mb-1.5">Initial conditions</p>
           <div className="divide-y divide-border">
-            {Object.entries(displayProperties)
+            {Object.entries(renderProperties)
               .filter(([key]) => isFieldVisible(key))
-              .map(([key, value]) => (
+              .map(([key, value]) => {
+            // Only meaningful outside edit mode — editing always shows the
+            // base config's own value (renderProperties === displayProperties then).
+            const isOverridden =
+              !isEditing &&
+              Boolean(previewEntity) &&
+              JSON.stringify(value) !== JSON.stringify(displayProperties[key]);
+            return (
             <div key={key} className="py-1.5 flex items-center justify-between gap-2">
               <span
                 className={`text-xs text-muted-foreground truncate ${
@@ -338,19 +383,25 @@ export function PropertiesPanel() {
                   />
                 )
               ) : (
-                <span className="text-xs font-mono text-foreground">
-                  {key === "temperature" && typeof value === "number"
-                    ? `${kelvinToCelsius(value).toFixed(2)} °C`
-                    : typeof value === "number"
-                      ? formatNumber(value)
-                      : typeof value === "object" && value !== null
-                        ? JSON.stringify(value)
-                        : String(value ?? "")}
+                <span
+                  className={`text-xs font-mono ${
+                    isOverridden
+                      ? "text-amber-600 dark:text-amber-400 font-semibold"
+                      : "text-foreground"
+                  }`}
+                  title={
+                    isOverridden
+                      ? `Base value: ${formatDisplayValue(key, displayProperties[key])}`
+                      : undefined
+                  }
+                >
+                  {formatDisplayValue(key, value)}
                 </span>
               )}
             </div>
-          ))}
-          {Object.keys(displayProperties).length === 0 && (
+            );
+          })}
+          {Object.keys(renderProperties).length === 0 && (
             <p className="text-xs text-muted-foreground py-1 italic">No properties</p>
           )}
           </div>

--- a/frontend/src/stores/scenarioStore.test.ts
+++ b/frontend/src/stores/scenarioStore.test.ts
@@ -18,6 +18,7 @@ const mockRenameScenario = vi.fn();
 const mockDeleteScenario = vi.fn();
 const mockFetchScenario = vi.fn();
 const mockClearScenarioCache = vi.fn();
+const mockFetchScenarioPreview = vi.fn();
 
 vi.mock("@/api/scenarios", () => ({
   listScenarios: (...args: unknown[]) => mockListScenarios(...args),
@@ -26,6 +27,7 @@ vi.mock("@/api/scenarios", () => ({
   deleteScenario: (...args: unknown[]) => mockDeleteScenario(...args),
   fetchScenario: (...args: unknown[]) => mockFetchScenario(...args),
   clearScenarioCache: (...args: unknown[]) => mockClearScenarioCache(...args),
+  fetchScenarioPreview: (...args: unknown[]) => mockFetchScenarioPreview(...args),
   updateScenario: vi.fn(),
 }));
 
@@ -43,6 +45,11 @@ describe("scenarioStore", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockFetchPreloadedConfig.mockResolvedValue({ preloaded: false });
+    mockFetchScenarioPreview.mockResolvedValue({
+      scenario_id: "unset",
+      nodes: [],
+      connections: [],
+    });
     useScenarioStore.setState({
       available: false,
       scenarios: [],
@@ -52,6 +59,12 @@ describe("scenarioStore", () => {
       error: null,
       revision: 0,
       createdAt: undefined,
+      previewId: null,
+      previewNodes: null,
+      previewConnections: null,
+      previewLoading: false,
+      previewError: null,
+      previewSeq: 0,
     });
   });
 
@@ -147,6 +160,91 @@ describe("scenarioStore", () => {
     expect(useScenarioStore.getState().activeId).toBe("pending_id");
     expect(useScenarioStore.getState().error).toBeNull();
     expect(mockFetchScenario).not.toHaveBeenCalled();
+  });
+
+  it("deleteScenario clears the preview when the deleted scenario was being previewed", async () => {
+    useScenarioStore.setState({
+      previewId: "A",
+      previewNodes: [{ id: "r1", type: "x", properties: {} }],
+      previewConnections: [],
+    });
+    mockDeleteScenario.mockResolvedValue({ ok: true, scenario_id: "A" });
+    mockListScenarios.mockResolvedValue({ available: false, scenarios: [], authored_ids: [] });
+
+    await useScenarioStore.getState().deleteScenario("A");
+
+    const state = useScenarioStore.getState();
+    expect(state.previewId).toBeNull();
+    expect(state.previewNodes).toBeNull();
+  });
+
+  it("setActive on an authored-but-uncomputed scenario loads its preview without fetching a trajectory", async () => {
+    mockFetchScenarioPreview.mockResolvedValue({
+      scenario_id: "C600_P300",
+      nodes: [{ id: "reactor1", type: "IdealGasReactor", properties: { length: 0.6 } }],
+      connections: [],
+    });
+
+    await useScenarioStore.getState().setActive("C600_P300");
+
+    expect(mockFetchScenario).not.toHaveBeenCalled();
+    const state = useScenarioStore.getState();
+    expect(state.activeId).toBe("C600_P300");
+    expect(state.previewId).toBe("C600_P300");
+    expect(state.previewNodes).toEqual([
+      { id: "reactor1", type: "IdealGasReactor", properties: { length: 0.6 } },
+    ]);
+  });
+
+  it("setActive on a computed scenario loads its preview alongside the trajectory", async () => {
+    useScenarioStore.setState({ scenarios: [{ id: "A", t0_K: 300, label: "A" }] });
+    mockFetchScenario.mockResolvedValue({ reactors_series: {} });
+    mockFetchScenarioPreview.mockResolvedValue({
+      scenario_id: "A",
+      nodes: [{ id: "r1", type: "IdealGasReactor", properties: { length: 1.2 } }],
+      connections: [],
+    });
+
+    await useScenarioStore.getState().setActive("A");
+
+    expect(mockFetchScenario).toHaveBeenCalledWith("A");
+    expect(useScenarioStore.getState().previewNodes).toEqual([
+      { id: "r1", type: "IdealGasReactor", properties: { length: 1.2 } },
+    ]);
+  });
+
+  it("loadPreview surfaces a fetch failure in previewError without throwing", async () => {
+    mockFetchScenarioPreview.mockRejectedValue(new Error("boom"));
+
+    await useScenarioStore.getState().setActive("nope");
+
+    expect(useScenarioStore.getState().previewError).toBe("boom");
+  });
+
+  it("loadPreview ignores a stale response superseded by a newer selection", async () => {
+    let resolveFirst: (v: unknown) => void = () => {};
+    const firstPromise = new Promise((resolve) => {
+      resolveFirst = resolve;
+    });
+    mockFetchScenarioPreview.mockImplementationOnce(() => firstPromise);
+    mockFetchScenarioPreview.mockImplementationOnce(() =>
+      Promise.resolve({
+        scenario_id: "B",
+        nodes: [{ id: "r1", type: "x", properties: { length: 2 } }],
+        connections: [],
+      }),
+    );
+
+    const p1 = useScenarioStore.getState().setActive("A");
+    const p2 = useScenarioStore.getState().setActive("B");
+    resolveFirst({
+      scenario_id: "A",
+      nodes: [{ id: "r1", type: "x", properties: { length: 1 } }],
+      connections: [],
+    });
+    await Promise.all([p1, p2]);
+
+    expect(useScenarioStore.getState().previewId).toBe("B");
   });
 
   it("createScenario pushes the freshly-written config YAML into configStore", async () => {

--- a/frontend/src/stores/scenarioStore.ts
+++ b/frontend/src/stores/scenarioStore.ts
@@ -4,12 +4,14 @@ import {
   createScenario as apiCreateScenario,
   deleteScenario as apiDeleteScenario,
   fetchScenario,
+  fetchScenarioPreview,
   listScenarios,
   renameScenario as apiRenameScenario,
   updateScenario as apiUpdateScenario,
   type ScenarioMeta,
 } from "@/api/scenarios";
 import { fetchPreloadedConfig } from "@/api/configs";
+import type { ConfigConnection, ConfigNode } from "@/types/config";
 import { useConfigStore } from "./configStore";
 import { useSimulationStore } from "./simulationStore";
 import { useSelectionStore } from "./selectionStore";
@@ -52,10 +54,30 @@ interface ScenarioState {
    */
   revision: number;
 
+  /**
+   * Effective (base + overlay) node/connection properties for `previewId` —
+   * lets the Inputs pane show a scenario's parameter overrides immediately,
+   * even for an authored scenario Run Sweep hasn't solved yet. Populated by
+   * every `setActive()` call, computed or not (see `loadPreview`).
+   */
+  previewId: string | null;
+  previewNodes: ConfigNode[] | null;
+  previewConnections: ConfigConnection[] | null;
+  previewLoading: boolean;
+  previewError: string | null;
+  /** Internal: guards against a stale response landing after a newer selection. */
+  previewSeq: number;
+
   /** Fetch the scenario list for the active store (no-op-safe if none). */
   refresh: () => Promise<void>;
   /** Load a scenario's trajectory and push it into the simulation results. */
   setActive: (id: string) => Promise<void>;
+  /**
+   * Fetch `id`'s effective node/connection properties (base ⊕ overlay) into
+   * `previewNodes`/`previewConnections`. Called by `setActive` for every
+   * selection, so callers normally don't need to call this directly.
+   */
+  loadPreview: (id: string) => Promise<void>;
   /**
    * Create a new scenario overlay (blank, or cloned from `baseId`) and mark
    * it active for editing. Throws on failure (id collision, no config file,
@@ -80,6 +102,12 @@ export const useScenarioStore = create<ScenarioState>((set, get) => ({
   loading: false,
   error: null,
   revision: 0,
+  previewId: null,
+  previewNodes: null,
+  previewConnections: null,
+  previewLoading: false,
+  previewError: null,
+  previewSeq: 0,
 
   refresh: async () => {
     try {
@@ -129,6 +157,9 @@ export const useScenarioStore = create<ScenarioState>((set, get) => ({
   deleteScenario: async (id) => {
     const resp = await apiDeleteScenario(id);
     if (get().activeId === id) set({ activeId: null });
+    if (get().previewId === id) {
+      set({ previewId: null, previewNodes: null, previewConnections: null, previewError: null });
+    }
     await get().refresh();
     await resyncConfigYaml();
     return { cachePurged: resp.cache_purged };
@@ -142,15 +173,20 @@ export const useScenarioStore = create<ScenarioState>((set, get) => ({
   },
 
   setActive: async (id) => {
+    set({ activeId: id, error: null });
+    // Always preview the scenario's effective properties, computed or not —
+    // this is what lets the Inputs pane show an authored-but-unswept
+    // scenario's overrides without ever needing a trajectory.
+    void get().loadPreview(id);
+
     // Not computed yet (authored but unswept, or mid-sweep and not reached/
     // finished yet) — just record the selection, no fetch. `GET /api/scenarios/
     // {id}` would 404 for it; the Scenario Pane / results area read `activeId`
     // directly to show a "calculating"/"pending" state for this case instead.
     if (!get().scenarios.some((s) => s.id === id)) {
-      set({ activeId: id, error: null });
       return;
     }
-    set({ loading: true, error: null, activeId: id });
+    set({ loading: true });
     try {
       const result = await fetchScenario(id);
       // Same sink the cached-result path uses → swaps result data only, no
@@ -174,6 +210,27 @@ export const useScenarioStore = create<ScenarioState>((set, get) => ({
       set({ error: e instanceof Error ? e.message : String(e) });
     } finally {
       set({ loading: false });
+    }
+  },
+
+  loadPreview: async (id) => {
+    const seq = get().previewSeq + 1;
+    set({ previewSeq: seq, previewLoading: true, previewError: null });
+    try {
+      const preview = await fetchScenarioPreview(id);
+      if (get().previewSeq !== seq) return; // superseded by a newer selection
+      set({
+        previewId: id,
+        previewNodes: preview.nodes,
+        previewConnections: preview.connections,
+        previewLoading: false,
+      });
+    } catch (e) {
+      if (get().previewSeq !== seq) return;
+      set({
+        previewError: e instanceof Error ? e.message : String(e),
+        previewLoading: false,
+      });
     }
   },
 }));

--- a/tests/test_scenario_preview.py
+++ b/tests/test_scenario_preview.py
@@ -1,0 +1,143 @@
+"""Tests for GET /api/scenarios/{id}/preview.
+
+Unlike `/scenarios/{id}` (a precomputed HDF5 trajectory — 404s until a sweep has
+solved it), `/preview` deep-merges an authored scenario's overlay onto the base
+config and returns the effective node/connection properties, so the GUI's Inputs
+pane can show a scenario's parameter overrides before it has ever been solved.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("fastapi")
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from boulder.api.main import create_app  # noqa: E402
+
+_BASE_YAML = """\
+metadata:
+  description: "test config"
+phases:
+  gas:
+    mechanism: gri30.yaml
+network:
+  - id: feed
+    Reservoir:
+      temperature: 298.15
+      pressure: 101325
+      composition: "CH4:1"
+scenarios:
+  base_case:
+    network:
+      - id: feed
+        Reservoir:
+          temperature: 320.0
+"""
+
+
+def _write_config(tmp_path: Path) -> Path:
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(_BASE_YAML, encoding="utf-8")
+    return cfg
+
+
+def _client_with_config(cfg_path: Path):
+    app = create_app()
+    client = TestClient(app)
+    client.__enter__()
+    app.state.preloaded_config_path = str(cfg_path)
+    return client, app
+
+
+def _client_fully_preloaded(cfg_path: Path):
+    """Preload as the real app startup path would (populates `preloaded_raw`)."""
+    import os
+
+    os.environ["BOULDER_CONFIG_PATH"] = str(cfg_path)
+    try:
+        app = create_app()
+        client = TestClient(app)
+        client.__enter__()
+    finally:
+        del os.environ["BOULDER_CONFIG_PATH"]
+    return client, app
+
+
+def _node(body: dict, node_id: str) -> dict:
+    return next(n for n in body["nodes"] if n["id"] == node_id)
+
+
+def test_preview_authored_scenario_overrides_property(tmp_path: Path) -> None:
+    """An authored (never-swept) scenario's overlay shows up in the preview."""
+    cfg = _write_config(tmp_path)
+    client, _app = _client_with_config(cfg)
+    try:
+        resp = client.get("/api/scenarios/base_case/preview")
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["scenario_id"] == "base_case"
+        assert _node(body, "feed")["properties"]["temperature"] == 320.0
+    finally:
+        client.__exit__(None, None, None)
+
+
+def test_preview_baseline_returns_unmodified_base_values(tmp_path: Path) -> None:
+    cfg = _write_config(tmp_path)
+    client, _app = _client_with_config(cfg)
+    try:
+        resp = client.get("/api/scenarios/BASELINE/preview")
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert _node(body, "feed")["properties"]["temperature"] == 298.15
+    finally:
+        client.__exit__(None, None, None)
+
+
+def test_preview_unknown_scenario_404(tmp_path: Path) -> None:
+    cfg = _write_config(tmp_path)
+    client, _app = _client_with_config(cfg)
+    try:
+        resp = client.get("/api/scenarios/nope/preview")
+        assert resp.status_code == 404
+    finally:
+        client.__exit__(None, None, None)
+
+
+def test_preview_without_a_config_404() -> None:
+    app = create_app()
+    with TestClient(app) as client:
+        app.state.preloaded_config_path = None
+        resp = client.get("/api/scenarios/base_case/preview")
+        assert resp.status_code == 404
+
+
+def test_preview_falls_back_to_disk_when_preloaded_raw_is_unset(tmp_path: Path) -> None:
+    """The `preloaded_config_path`-only setup (as in scenario-editing tests) still works.
+
+    `preloaded_raw` isn't populated until a scenario CRUD call reloads it, but
+    the preview route must not depend on that having happened yet.
+    """
+    cfg = _write_config(tmp_path)
+    client, app = _client_with_config(cfg)
+    try:
+        assert app.state.preloaded_raw is None
+        resp = client.get("/api/scenarios/base_case/preview")
+        assert resp.status_code == 200, resp.text
+        assert _node(resp.json(), "feed")["properties"]["temperature"] == 320.0
+    finally:
+        client.__exit__(None, None, None)
+
+
+def test_preview_reflects_fully_preloaded_app_state(tmp_path: Path) -> None:
+    cfg = _write_config(tmp_path)
+    client, _app = _client_fully_preloaded(cfg)
+    try:
+        resp = client.get("/api/scenarios/base_case/preview")
+        assert resp.status_code == 200, resp.text
+        assert _node(resp.json(), "feed")["properties"]["temperature"] == 320.0
+    finally:
+        client.__exit__(None, None, None)


### PR DESCRIPTION
## Summary
- Adds `GET /api/scenarios/{id}/preview`, which deep-merges an authored scenario's overlay onto the base config (reusing `runset.deep_merge`) and returns the effective node/connection properties — works whether or not the scenario has been solved by Run Sweep yet.
- `scenarioStore.setActive()` now always loads this preview (guarded against out-of-order responses via a sequence counter), in addition to fetching a trajectory when the scenario is actually computed.
- `PropertiesPanel` shows a "Previewing scenario X" badge and highlights any field the active scenario overrides (with a "Base value: …" tooltip) — `Edit`/`Save` still always operate on the base network, never the overlay.

This lets a user select any scenario in the Scenario Pane — even one Run Sweep hasn't solved yet — and immediately see how it changes a given node's inputs (e.g. a reactor's length), navigable with the arrow keys.

Note: scenario-row selection/keyboard-navigation itself is already handled by the unified scenario list shipped in a recent `main` refactor (live per-scenario sweep progress); this PR only adds the input-preview piece, which nothing else provides yet.

## Test plan
- [x] Backend: `pytest tests/test_scenario_preview.py tests/test_scenario_editing.py tests/test_scenario_focus.py` — all pass
- [x] Backend: full suite (`pytest tests/`) — 769 passed, 2 skipped, 7 xfailed
- [x] Backend: `mypy boulder`, `ruff check`/`ruff format --check` — clean
- [x] Frontend: `npm run test:unit` — 186 passed
- [x] Frontend: `npm run type-check`, `npm run build` — clean
- [x] Manual: verified live against a running server — selecting an uncomputed scenario updates the reactor's `volume` field, arrow-key nav works, and Edit mode correctly shows the base value rather than the scenario's override

Extensive AI use — code & PR fully written by Claude Sonnet 5.