### PR TITLE
feat: per-node conservation status on the reactor graph, live stage progress

### DIFF
--- a/boulder/api/routes/simulations.py
+++ b/boulder/api/routes/simulations.py
@@ -305,6 +305,7 @@ async def get_simulation_results(sim_id: str, cleanup: bool = False) -> Dict[str
                 "times": progress.times,
                 "reactors_series": progress.reactors_series,
                 "total_time": progress.total_time,
+                "completed_stage_ids": progress.completed_stage_ids,
             }
         )
 

--- a/boulder/api/sse.py
+++ b/boulder/api/sse.py
@@ -41,6 +41,7 @@ async def simulation_event_stream(
             "error_message": progress.error_message,
             "stages_done": progress.stages_done,
             "n_stages": progress.n_stages,
+            "completed_stage_ids": progress.completed_stage_ids,
             "times": progress.times,
             "reactors_series": progress.reactors_series,
             "reactor_reports": _serialise_reports(progress.reactor_reports),

--- a/boulder/simulation_worker.py
+++ b/boulder/simulation_worker.py
@@ -72,6 +72,14 @@ class SimulationProgress:
     stages_done: int = 0
     n_stages: int = 0
 
+    # Stage ids that have finished solving, in completion order (append-only,
+    # reset per run via a fresh SimulationProgress()). Lets the client map a
+    # node's ``group`` (== stage id) to a live per-node status on the graph
+    # (calculating / resolved) without needing a separate "stage started"
+    # event -- stages solve strictly sequentially, so the first stage id not
+    # yet in this list is the one currently running.
+    completed_stage_ids: List[str] = field(default_factory=list)
+
     # Status flags
     is_running: bool = False
     is_complete: bool = False
@@ -169,6 +177,7 @@ class SimulationWorker:
                 ),
                 stages_done=self.progress.stages_done,
                 n_stages=self.progress.n_stages,
+                completed_stage_ids=list(self.progress.completed_stage_ids),
                 is_running=self.progress.is_running,
                 is_complete=self.progress.is_complete,
                 error_message=self.progress.error_message,
@@ -220,6 +229,7 @@ class SimulationWorker:
                 with self._lock:
                     self.progress.stages_done = n_done
                     self.progress.n_stages = n_total
+                    self.progress.completed_stage_ids.append(stage_id)
 
             # Build the network first
             network = converter.build_network(

--- a/frontend/src/components/graph/ReactorGraph.tsx
+++ b/frontend/src/components/graph/ReactorGraph.tsx
@@ -5,8 +5,53 @@ import dagre from "cytoscape-dagre";
 import { useConfigStore } from "@/stores/configStore";
 import { useSelectionStore } from "@/stores/selectionStore";
 import { useResultsTabStore } from "@/stores/resultsTabStore";
+import { useSimulationStore } from "@/stores/simulationStore";
 import { useThemeStore } from "@/stores/themeStore";
 import { useAddEntityModalStore } from "@/stores/addEntityModalStore";
+
+/**
+ * Per-node calc/conservation status badges (top-right corner), drawn as
+ * self-contained SVG data URIs (no new asset files / dependencies). Applied
+ * via node.data("calc_status", ...) — see the results-sync effect below —
+ * and matching "[calc_status = ...]" Cytoscape stylesheet rules.
+ */
+const CALC_STATUS_BADGES = {
+  // Rotating ring: this node's stage is the one currently solving. Pure SVG
+  // <animateTransform> spin, no JS-driven animation loop needed.
+  calculating:
+    "data:image/svg+xml;utf8," +
+    encodeURIComponent(
+      '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">' +
+        '<circle cx="12" cy="12" r="9" fill="none" stroke="#3b82f6" stroke-width="3" ' +
+        'stroke-dasharray="38 18" stroke-linecap="round">' +
+        '<animateTransform attributeName="transform" type="rotate" ' +
+        'from="0 12 12" to="360 12 12" dur="0.9s" repeatCount="indefinite"/>' +
+        "</circle>" +
+        "</svg>",
+    ),
+  // Green checkmark: this node's stage solved and (once the full solve
+  // completes) its conservation check passed.
+  resolved_ok:
+    "data:image/svg+xml;utf8," +
+    encodeURIComponent(
+      '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">' +
+        '<circle cx="12" cy="12" r="11" fill="#22c55e"/>' +
+        '<path d="M7 12.5 L10.5 16 L17 8.5" fill="none" stroke="white" ' +
+        'stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/>' +
+        "</svg>",
+    ),
+  // Amber warning triangle: solve completed but this node's mass/energy
+  // conservation check failed.
+  resolved_warning:
+    "data:image/svg+xml;utf8," +
+    encodeURIComponent(
+      '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">' +
+        '<path d="M12 2 L23 21 L1 21 Z" fill="#f59e0b" stroke="#7c2d12" stroke-width="1"/>' +
+        '<text x="12" y="18" font-size="13" font-weight="bold" text-anchor="middle" ' +
+        'fill="#1a1a1a">!</text>' +
+        "</svg>",
+    ),
+} as const;
 
 // Register dagre layout
 cytoscape.use(dagre);
@@ -91,6 +136,9 @@ export function ReactorGraph() {
   const setSelectedElement = useSelectionStore((s) => s.setSelectedElement);
   const clearSelection = useSelectionStore((s) => s.clearSelection);
   const setActiveTab = useResultsTabStore((s) => s.setActiveTab);
+  const results = useSimulationStore((s) => s.results);
+  const progress = useSimulationStore((s) => s.progress);
+  const isRunning = useSimulationStore((s) => s.isRunning);
   const theme = useThemeStore((s) => s.theme);
   const [graphHeight, setGraphHeight] = useState(loadStoredGraphHeight);
 
@@ -460,6 +508,25 @@ export function ReactorGraph() {
         // Must follow [type = 'Reservoir'] to override its octagon shape.
         selector: "[?stream_point]",
         style: { shape: "diamond", width: "60px", height: "60px" },
+      },
+      {
+        // Live calc/conservation status badge, top-right corner, via
+        // Cytoscape's multi-background-image support. Set live by the
+        // progress/results-sync effect below (not part of buildElements(),
+        // since it reflects solve state, not authored topology) — see
+        // CALC_STATUS_BADGES for what each value means.
+        selector:
+          "[calc_status = 'calculating'], [calc_status = 'resolved_ok'], "
+          + "[calc_status = 'resolved_warning']",
+        style: {
+          "background-image": "data(calc_status_icon)",
+          "background-fit": "none",
+          "background-clip": "none",
+          "background-width": "22px",
+          "background-height": "22px",
+          "background-position-x": "88%",
+          "background-position-y": "8%",
+        },
       },
       {
         selector: "edge",
@@ -1540,6 +1607,58 @@ export function ReactorGraph() {
     if (!cy) return;
     cy.style(buildStylesheet() as any);
   }, [buildStylesheet]);
+
+  // Mirror each node's live calc/conservation status onto its Cytoscape data
+  // (see the calc_status stylesheet rule above and CALC_STATUS_BADGES).
+  // A targeted .data() update, not a topology rebuild: this reflects solve
+  // state, so it must not disturb node positions or trigger a dagre pass.
+  //
+  // While running: a node's stage is either already solved (progress.
+  // completed_stage_ids), currently solving (the first stage, in
+  // config.groups declaration order, not yet in that list — stages solve
+  // strictly sequentially, so there is no separate "stage started" event),
+  // or not yet reached (no badge). Once complete: every node is resolved,
+  // overridden to a warning if its conservation check failed.
+  useEffect(() => {
+    const cy = cyRef.current;
+    if (!cy) return;
+
+    const setStatus = (n: cytoscape.NodeSingular, status: keyof typeof CALC_STATUS_BADGES | null) => {
+      n.data("calc_status", status);
+      n.data("calc_status_icon", status ? CALC_STATUS_BADGES[status] : undefined);
+    };
+
+    if (results) {
+      cy.nodes().forEach((n) => {
+        const conservation = results.reactors_series?.[n.id()]?.conservation;
+        const failed = conservation
+          ? !conservation.mass_closes || !conservation.energy_closes
+          : false;
+        setStatus(n, failed ? "resolved_warning" : "resolved_ok");
+      });
+      return;
+    }
+
+    if (isRunning && progress) {
+      const completed = new Set(progress.completed_stage_ids ?? []);
+      const stageOrder = Object.keys(config.groups ?? {});
+      const currentStageId = stageOrder.find((id) => !completed.has(id));
+      cy.nodes().forEach((n) => {
+        const group = n.data("parent") as string | undefined;
+        const stageId = group?.startsWith("group:") ? group.slice("group:".length) : undefined;
+        if (stageId && completed.has(stageId)) {
+          setStatus(n, "resolved_ok");
+        } else if (stageId && stageId === currentStageId) {
+          setStatus(n, "calculating");
+        } else {
+          setStatus(n, null);
+        }
+      });
+      return;
+    }
+
+    cy.nodes().forEach((n) => setStatus(n, null));
+  }, [results, progress, isRunning, config.groups]);
 
   // Keep Cytoscape canvas in sync when the pane is resized
   useEffect(() => {

--- a/frontend/src/components/results/ConvergenceTab.tsx
+++ b/frontend/src/components/results/ConvergenceTab.tsx
@@ -3,10 +3,57 @@ import Plot from "react-plotly.js";
 import { coerceNumericSeries, pressureYAxis } from "@/lib/plotAxis";
 import { useSelectionStore } from "@/stores/selectionStore";
 import { useThemeStore } from "@/stores/themeStore";
-import type { SimulationProgress } from "@/types/simulation";
+import type { NodeConservation, SimulationProgress } from "@/types/simulation";
 
 interface Props {
   data: SimulationProgress;
+}
+
+/** Compact mass/energy conservation summary, shown above the per-kind convergence view. */
+function ConservationSummary({ conservation }: { conservation: NodeConservation }) {
+  const massOk = conservation.mass_closes;
+  const energyOk = conservation.energy_closes;
+  const allOk = massOk && energyOk;
+  return (
+    <div
+      className={`rounded border p-3 text-sm ${
+        allOk
+          ? "border-emerald-600/30 bg-emerald-600/5"
+          : "border-amber-600/40 bg-amber-600/10"
+      }`}
+    >
+      <p className="font-medium mb-1">
+        {allOk ? "✓ Mass & energy conservation OK" : "⚠ Conservation check failed"}
+      </p>
+      <table className="w-full max-w-sm text-sm">
+        <tbody>
+          <tr>
+            <td className="pr-4 text-muted-foreground">Mass</td>
+            <td className="pr-2">{conservation.mass_in_kg_s.toPrecision(4)} kg/s in</td>
+            <td className="pr-2">{conservation.mass_out_kg_s.toPrecision(4)} kg/s out</td>
+            <td className={massOk ? "text-emerald-600" : "text-amber-600 font-medium"}>
+              {massOk ? "OK" : "FAILED"}
+            </td>
+          </tr>
+          <tr>
+            <td className="pr-4 text-muted-foreground">Energy</td>
+            <td className="pr-2">{conservation.energy_in_kw.toFixed(2)} kW in</td>
+            <td className="pr-2">{conservation.energy_out_kw.toFixed(2)} kW out</td>
+            <td className={energyOk ? "text-emerald-600" : "text-amber-600 font-medium"}>
+              {energyOk ? "OK" : "FAILED"}
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      {!allOk && (
+        <p className="text-xs text-muted-foreground mt-1">
+          A residence-time-sized reactor stage that hasn't reached steady
+          state often shows an energy imbalance here — try a longer stage
+          advance time.
+        </p>
+      )}
+    </div>
+  );
 }
 
 export function ConvergenceTab({ data }: Props) {
@@ -81,12 +128,18 @@ export function ConvergenceTab({ data }: Props) {
   }
 
   const gridcolor = theme === "dark" ? "#333" : "#e0e0e0";
+  const conservationBanner = series?.conservation ? (
+    <ConservationSummary conservation={series.conservation} />
+  ) : null;
 
   if (series?.is_residence) {
     return (
-      <p className="text-sm text-muted-foreground">
-        Physical residence-time profile is in the <strong>Plots</strong> tab.
-      </p>
+      <>
+        {conservationBanner}
+        <p className="text-sm text-muted-foreground">
+          Physical residence-time profile is in the <strong>Plots</strong> tab.
+        </p>
+      </>
     );
   }
 
@@ -97,6 +150,7 @@ export function ConvergenceTab({ data }: Props) {
 
     return (
       <div className="space-y-4">
+        {conservationBanner}
         <p className="text-sm text-muted-foreground">
           Forward-Backward Sweep convergence — heat loss at each iteration.
         </p>
@@ -163,6 +217,7 @@ export function ConvergenceTab({ data }: Props) {
 
     return (
       <div className="space-y-4">
+        {conservationBanner}
         <p className="text-sm text-muted-foreground">
           Transient approach to steady state (PSR time integration).
         </p>
@@ -280,6 +335,7 @@ export function ConvergenceTab({ data }: Props) {
     }));
     return (
       <div className="space-y-4">
+        {conservationBanner}
         <p className="text-sm text-muted-foreground">
           Staged solve: the stage solver switched between internal models at
           the times below (dotted lines on the trend).
@@ -343,9 +399,12 @@ export function ConvergenceTab({ data }: Props) {
 
   // --- All other reactor types ---
   return (
-    <p className="text-sm text-muted-foreground">
-      No convergence data available for this reactor type.
-    </p>
+    <>
+      {conservationBanner}
+      <p className="text-sm text-muted-foreground">
+        No convergence data available for this reactor type.
+      </p>
+    </>
   );
 }
 

--- a/frontend/src/hooks/useSimulationSSE.ts
+++ b/frontend/src/hooks/useSimulationSSE.ts
@@ -1,8 +1,19 @@
 import { useEffect, useRef } from "react";
+import { toast } from "sonner";
 import { useSimulationStore } from "@/stores/simulationStore";
 import { useConfigStore } from "@/stores/configStore";
 import type { SimulationProgress, SimulationResults } from "@/types/simulation";
 // useConfigStore is accessed via .getState() inside callbacks to avoid stale closures.
+
+/** Node ids where the post-solve mass/energy conservation check failed. */
+function conservationFailingNodes(data: SimulationResults): string[] {
+  return Object.entries(data.reactors_series ?? {})
+    .filter(([, series]) => {
+      const c = series.conservation;
+      return c && (!c.mass_closes || !c.energy_closes);
+    })
+    .map(([id]) => id);
+}
 
 /**
  * Hook that connects to the simulation SSE stream and updates the store.
@@ -37,6 +48,15 @@ export function useSimulationSSE() {
       try {
         const data = JSON.parse(e.data) as SimulationResults;
         setResults(data);
+
+        const failingNodes = conservationFailingNodes(data);
+        if (failingNodes.length > 0) {
+          toast.warning(
+            `Mass/energy conservation check failed at ${failingNodes.length} ` +
+              `node(s): ${failingNodes.join(", ")}. See the Convergence tab for ` +
+              "each node. Calculation Note export is blocked until this is resolved.",
+          );
+        }
 
         // Single source of truth: atomically replace nodes + connections with the
         // authoritative post-build lists from the backend.  Both lists are always

--- a/frontend/src/types/simulation.ts
+++ b/frontend/src/types/simulation.ts
@@ -32,6 +32,22 @@ export interface ReactorSeries {
    */
   model_sequence?: string[];
   switch_times_s?: number[];
+  /**
+   * Post-solve mass/energy conservation check for this node, if the backend
+   * provides one. Absent for boundary nodes (pure source/sink) and for
+   * reactor kinds the check couldn't run for.
+   */
+  conservation?: NodeConservation;
+}
+
+/** Per-node mass/energy balance: sum(in) vs sum(out) at the solved state. */
+export interface NodeConservation {
+  mass_in_kg_s: number;
+  mass_out_kg_s: number;
+  energy_in_kw: number;
+  energy_out_kw: number;
+  mass_closes: boolean;
+  energy_closes: boolean;
 }
 
 /** Connection (e.g. MFC) report from backend: mass and volumetric flow rates. */
@@ -51,6 +67,13 @@ export interface SimulationProgress {
   /** Staged-solver build counters — updated after each stage completes. */
   stages_done?: number;
   n_stages?: number;
+  /**
+   * Stage ids that have finished solving, in completion order. Stages solve
+   * strictly sequentially, so the first stage id (in config.groups
+   * declaration order) not yet in this list is the one currently running —
+   * drives the live per-node "calculating" indicator on the graph.
+   */
+  completed_stage_ids?: string[];
   times: number[];
   reactors_series: Record<string, ReactorSeries>;
   reactor_reports?: Record<string, unknown>;


### PR DESCRIPTION
## Summary

Surfaces a per-node post-solve mass/energy conservation check (an optional `conservation` field on each `reactors_series` entry, if the backend provides one) directly on the live GUI, plus live per-node status while a staged solve is still running.

- **ConvergenceTab**: compact mass/energy in/out summary banner, shown above whichever convergence view already applies for the selected node.
- **ReactorGraph**: a small corner badge per node via Cytoscape's native multi-background-image support, driven by a single `calc_status` node-data field:
  - spinning blue ring — this node's stage is the one currently solving
  - green check — stage resolved (or, once the full solve completes, conservation check passed)
  - amber warning — solve completed but this node's mass/energy conservation check failed
- **useSimulationSSE**: a bottom-right toast (`sonner`, already configured) when a solve completes with one or more nodes failing conservation.
- **simulation_worker / sse / routes/simulations**: new `completed_stage_ids` field (stage completion order) propagated through every progress-snapshot assembly point, so the client can derive "which stage is currently running" from `config.groups` order without a separate "stage started" event — stages solve strictly sequentially.

<img width="226" height="357" alt="image" src="https://github.com/user-attachments/assets/d96223ef-0816-4297-b342-c2c142229202" />

## Test plan

- [x] `tsc --noEmit` clean
- [x] `eslint` on all touched frontend files — no new errors (pre-existing issues in `ReactorGraph.tsx` confirmed unchanged by line-diffing)
- [x] Python imports clean (`boulder.simulation_worker`, `boulder.api.sse`, `boulder.api.routes.simulations`)
- [x] `tests/test_sse.py` (5), `tests/test_api.py` + `tests/test_gui_actions_api.py` (41) — all pass
- [x] Direct multi-stage verification against a real staged reactor-network model: `completed_stage_ids` populates in the correct order as each stage's callback fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)