### PR TITLE
Add link from Boulder GUI node/connector to the online docs

### DIFF
--- a/frontend/src/components/panels/PropertiesPanel.test.tsx
+++ b/frontend/src/components/panels/PropertiesPanel.test.tsx
@@ -86,10 +86,20 @@ vi.mock("@/stores/scenarioStore", () => ({
   },
 }));
 
+let mockKinds: {
+  reactors: { kind: string; doc_url: string | null; description: string | null }[];
+  connections: { kind: string; doc_url: string | null; description: string | null }[];
+} = { reactors: [], connections: [] };
+
+vi.mock("@/hooks/useKinds", () => ({
+  useKinds: () => mockKinds,
+}));
+
 describe("PropertiesPanel delete confirmation", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockInitialConditionsEditNonce = 0;
+    mockKinds = { reactors: [], connections: [] };
     mockSelectedElement = {
       type: "node",
       data: { id: "reactor_1", type: "IdealGasReactor" },
@@ -261,6 +271,7 @@ describe("PropertiesPanel edit-on-double-click", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockInitialConditionsEditNonce = 0;
+    mockKinds = { reactors: [], connections: [] };
     mockSelectedElement = {
       type: "node",
       data: { id: "reactor_1", type: "IdealGasReactor" },
@@ -304,6 +315,7 @@ describe("PropertiesPanel object-valued properties", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockInitialConditionsEditNonce = 0;
+    mockKinds = { reactors: [], connections: [] };
     mockSelectedElement = {
       type: "node",
       data: { id: "reactor_1", type: "ConstPressureReactor" },
@@ -378,10 +390,126 @@ describe("PropertiesPanel object-valued properties", () => {
   });
 });
 
+describe("PropertiesPanel Cantera doc-link tooltip", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockInitialConditionsEditNonce = 0;
+    mockKinds = { reactors: [], connections: [] };
+    mockPreviewId = null;
+    mockPreviewNodes = null;
+    mockPreviewConnections = null;
+  });
+
+  it("shows a Cantera doc link for a selected reactor kind on hover", () => {
+    mockKinds = {
+      reactors: [
+        {
+          kind: "IdealGasReactor",
+          doc_url: "https://cantera.org/stable/python/zerodim.html#cantera.IdealGasReactor",
+          description: "Ideal-gas, constant-volume reactor.",
+        },
+      ],
+      connections: [],
+    };
+    mockSelectedElement = {
+      type: "node",
+      data: { id: "reactor_1", type: "IdealGasReactor" },
+    };
+    mockConfig = {
+      nodes: [
+        {
+          id: "reactor_1",
+          type: "IdealGasReactor",
+          properties: { temperature: 1273.15, pressure: 101325 },
+        },
+      ],
+      connections: [],
+    };
+
+    render(<PropertiesPanel />);
+
+    const trigger = screen.getByLabelText("About IdealGasReactor");
+    fireEvent.mouseEnter(trigger.parentElement!);
+    const link = screen.getByRole("link", { name: "Cantera docs" });
+    expect(link).toHaveAttribute(
+      "href",
+      "https://cantera.org/stable/python/zerodim.html#cantera.IdealGasReactor",
+    );
+    expect(screen.getByText("Ideal-gas, constant-volume reactor.")).toBeInTheDocument();
+  });
+
+  it("shows a Cantera doc link for a selected connection kind on hover", () => {
+    mockKinds = {
+      reactors: [],
+      connections: [
+        {
+          kind: "MassFlowController",
+          doc_url: "https://cantera.org/stable/python/zerodim.html#cantera.MassFlowController",
+          description: "Imposes a fixed or time-varying mass flow rate between two reactors.",
+        },
+      ],
+    };
+    mockSelectedElement = {
+      type: "edge",
+      data: {
+        id: "mfc_1",
+        type: "MassFlowController",
+        source: "reactor_1",
+        target: "reactor_2",
+      },
+    };
+    mockConfig = {
+      nodes: [],
+      connections: [
+        {
+          id: "mfc_1",
+          type: "MassFlowController",
+          source: "reactor_1",
+          target: "reactor_2",
+          properties: { mdot: 0.001 },
+        },
+      ],
+    };
+
+    render(<PropertiesPanel />);
+
+    const trigger = screen.getByLabelText("About MassFlowController");
+    fireEvent.mouseEnter(trigger.parentElement!);
+    const link = screen.getByRole("link", { name: "Cantera docs" });
+    expect(link).toHaveAttribute(
+      "href",
+      "https://cantera.org/stable/python/zerodim.html#cantera.MassFlowController",
+    );
+  });
+
+  it("omits the doc-link icon when the kind has no doc_url (e.g. plugin types)", () => {
+    mockKinds = {
+      reactors: [
+        { kind: "_TestPluginReactor", doc_url: null, description: null },
+      ],
+      connections: [],
+    };
+    mockSelectedElement = {
+      type: "node",
+      data: { id: "plugin_r", type: "_TestPluginReactor" },
+    };
+    mockConfig = {
+      nodes: [{ id: "plugin_r", type: "_TestPluginReactor", properties: {} }],
+      connections: [],
+    };
+
+    render(<PropertiesPanel />);
+
+    expect(screen.queryByLabelText("About _TestPluginReactor")).not.toBeInTheDocument();
+    expect(screen.getByText("_TestPluginReactor")).toBeInTheDocument();
+  });
+});
+
 describe("PropertiesPanel scenario preview", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockInitialConditionsEditNonce = 0;
+    mockKinds = { reactors: [], connections: [] };
     mockSelectedElement = {
       type: "node",
       data: { id: "reactor_1", type: "IdealGasReactor" },

--- a/frontend/src/components/panels/PropertiesPanel.tsx
+++ b/frontend/src/components/panels/PropertiesPanel.tsx
@@ -5,7 +5,9 @@ import { useScenarioStore } from "@/stores/scenarioStore";
 import type { NormalizedConfig } from "@/types/config";
 import { kelvinToCelsius, celsiusToKelvin, formatNumber, labelWithUnit } from "@/lib/units";
 import { useKindSchema } from "@/hooks/useKindSchema";
+import { useKinds } from "@/hooks/useKinds";
 import { Button } from "@/components/ui/Button";
+import { Tooltip } from "@/components/ui/Tooltip";
 import { ConfirmDeleteNodeModal } from "@/components/modals/ConfirmDeleteNodeModal";
 import { StageCard } from "@/components/panels/StageCard";
 import { toast } from "sonner";
@@ -162,6 +164,7 @@ export function PropertiesPanel() {
       ? String(selectedElement.data.type ?? "")
       : "";
   const schemaMeta = useKindSchema(schemaKind);
+  const { reactors, connections } = useKinds();
 
   if (!selectedElement) {
     // A config with exactly one stage has no clickable stage box (see
@@ -183,6 +186,7 @@ export function PropertiesPanel() {
   const isNode = selectedElement.type === "node";
   const id = String(selectedElement.data.id);
   const entityType = String(selectedElement.data.type ?? "");
+  const kindDoc = (isNode ? reactors : connections).find((k) => k.kind === entityType);
 
   // Group compound box (a stage) selected — show the Stage panel instead.
   if (selectedElement.data.isGroup) {
@@ -301,7 +305,35 @@ export function PropertiesPanel() {
       <div className="flex items-center justify-between">
         <div>
           <h3 className="font-semibold text-sm text-foreground">{id}</h3>
-          <span className="text-xs text-muted-foreground">{entityType}</span>
+          <div className="flex items-center gap-1">
+            <span className="text-xs text-muted-foreground">{entityType}</span>
+            {kindDoc?.doc_url && (
+              <Tooltip
+                content={
+                  <span className="block space-y-1">
+                    {kindDoc.description && (
+                      <span className="block">{kindDoc.description}</span>
+                    )}
+                    <a
+                      href={kindDoc.doc_url}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="underline text-primary"
+                    >
+                      Cantera docs
+                    </a>
+                  </span>
+                }
+              >
+                <span
+                  className="flex h-4 w-4 shrink-0 items-center justify-center rounded-full text-[10px] text-muted-foreground cursor-help"
+                  aria-label={`About ${entityType}`}
+                >
+                  ⓘ
+                </span>
+              </Tooltip>
+            )}
+          </div>
           {previewId && !isEditing && (
             <div
               className="text-[10px] text-amber-600 dark:text-amber-400"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When a reactor or connection is selected in the graph, the **Properties** panel now shows a Cantera doc-link tooltip (ⓘ) next to the type name — the same pattern already used in the Add Reactor/Connection modals and Solver Details modal.

For example, selecting a `MassFlowController` edge links to:
https://cantera.org/stable/python/zerodim.html#cantera.MassFlowController

Doc URLs and descriptions are sourced from the existing `GET /api/ui/kinds` endpoint (`boulder/cantera_docs.py`). Plugin-registered kinds without a `doc_url` omit the icon.

## Changes

- `PropertiesPanel.tsx` — look up the selected element's kind via `useKinds()` and render a `Tooltip` with description + "Cantera docs" link when `doc_url` is present.
- `PropertiesPanel.test.tsx` — three new tests: reactor doc link, connection doc link, and no icon for plugin kinds.

## Test plan

- [x] `cd frontend && npm run test:unit -- src/components/panels/PropertiesPanel.test.tsx` — 22 passed
- [x] `npm run type-check` — clean
- [x] `npm run build` — clean

> *Extensive AI use — code & PR fully written by Composer*
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-db1866f6-5ddc-4dc0-beac-300cc0fcfb10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-db1866f6-5ddc-4dc0-beac-300cc0fcfb10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

