### PR TITLE
After calculation, open Plot if Sankey is empty

### DIFF
--- a/frontend/src/components/results/ResultsTabs.test.tsx
+++ b/frontend/src/components/results/ResultsTabs.test.tsx
@@ -1,0 +1,173 @@
+/**
+ * Vitest unit tests for ResultsTabs default tab selection.
+ *
+ * Asserts that when final results lack Sankey data the Plots tab is shown by
+ * default (not an empty Sankey pane), and that a reactor node is auto-selected
+ * so plot content can render without an extra click.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import type { SimulationResults } from "@/types/simulation";
+
+const mockSetSelectedElement = vi.fn();
+let mockResults: SimulationResults | null = null;
+let mockProgress: SimulationResults | null = null;
+let mockActiveTab: string | null = null;
+let mockSelectedElement: { type: string; data: Record<string, unknown> } | null = null;
+
+const baseResults: SimulationResults = {
+  is_running: false,
+  is_complete: true,
+  times: [0, 1],
+  reactors_series: {
+    reactor1: { T: [300, 400], P: [101325, 101325], X: { N2: [0.8, 0.7] } },
+  },
+  sankey_links: null,
+  sankey_nodes: null,
+};
+
+vi.mock("@/stores/simulationStore", () => ({
+  useSimulationStore: (selector: (s: unknown) => unknown) =>
+    selector({
+      results: mockResults,
+      progress: mockProgress,
+      error: null,
+    }),
+}));
+
+vi.mock("@/stores/selectionStore", () => ({
+  useSelectionStore: (selector: (s: unknown) => unknown) =>
+    selector({
+      selectedElement: mockSelectedElement,
+      setSelectedElement: mockSetSelectedElement,
+    }),
+}));
+
+vi.mock("@/stores/configStore", () => ({
+  useConfigStore: (selector: (s: unknown) => unknown) =>
+    selector({
+      config: {
+        nodes: [{ id: "reactor1", type: "IdealGasReactor", properties: {} }],
+        connections: [],
+      },
+    }),
+}));
+
+vi.mock("@/stores/themeStore", () => ({
+  useThemeStore: (selector: (s: unknown) => unknown) =>
+    selector({ theme: "light" }),
+}));
+
+vi.mock("@/stores/resultsTabStore", () => ({
+  useResultsTabStore: (selector: (s: unknown) => unknown) =>
+    selector({
+      activeTab: mockActiveTab,
+      setActiveTab: vi.fn(),
+    }),
+}));
+
+vi.mock("@/stores/scenarioStore", () => ({
+  useScenarioStore: (selector: (s: unknown) => unknown) =>
+    selector({ activeId: null }),
+}));
+
+vi.mock("@/stores/sweepStore", () => ({
+  useSweepRunStore: (selector: (s: unknown) => unknown) =>
+    selector({ scenarioProgress: {} }),
+}));
+
+vi.mock("@/api/plugins", () => ({
+  fetchPlugins: vi.fn().mockResolvedValue([]),
+  renderPlugin: vi.fn(),
+}));
+
+vi.mock("./PlotsTab", () => ({
+  PlotsTab: () => <div data-testid="plots-tab" />,
+}));
+
+vi.mock("./ConvergenceTab", () => ({
+  ConvergenceTab: () => null,
+}));
+
+vi.mock("./SummaryTab", () => ({
+  SummaryTab: () => null,
+}));
+
+vi.mock("./ErrorTab", () => ({
+  ErrorTab: () => null,
+}));
+
+vi.mock("./PluginTab", () => ({
+  PluginTab: () => null,
+}));
+
+vi.mock("./SweepCalculatingCard", () => ({
+  SweepCalculatingCard: () => null,
+}));
+
+vi.mock("./SankeyTab", () => ({
+  SankeyTab: () => <div data-testid="sankey-tab" />,
+}));
+
+vi.mock("./ThermoReportTab", () => ({
+  ThermoReportTab: () => null,
+}));
+
+import { ResultsTabs } from "./ResultsTabs";
+
+describe("ResultsTabs", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockResults = null;
+    mockProgress = null;
+    mockActiveTab = null;
+    mockSelectedElement = null;
+  });
+
+  it("defaults to Plots when results have no Sankey data", () => {
+    mockResults = { ...baseResults };
+
+    render(<ResultsTabs />);
+
+    expect(screen.getByRole("button", { name: "Plots" })).toHaveAttribute(
+      "data-active",
+      "true",
+    );
+    expect(screen.getByTestId("plots-tab")).toBeInTheDocument();
+    expect(screen.queryByTestId("sankey-tab")).not.toBeInTheDocument();
+  });
+
+  it("defaults to Sankey when Sankey data is present", async () => {
+    mockResults = {
+      ...baseResults,
+      sankey_links: { source: [0], target: [1], value: [1] },
+      sankey_nodes: ["in", "out"],
+    };
+
+    render(<ResultsTabs />);
+
+    expect(screen.getByRole("button", { name: "Sankey" })).toHaveAttribute(
+      "data-active",
+      "true",
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("sankey-tab")).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId("plots-tab")).not.toBeInTheDocument();
+  });
+
+  it("auto-selects a reactor when Sankey is missing and nothing is selected", async () => {
+    mockResults = { ...baseResults };
+
+    render(<ResultsTabs />);
+
+    await waitFor(() => {
+      expect(mockSetSelectedElement).toHaveBeenCalledWith({
+        type: "node",
+        data: { id: "reactor1", type: "IdealGasReactor" },
+      });
+    });
+  });
+});

--- a/frontend/src/components/results/ResultsTabs.tsx
+++ b/frontend/src/components/results/ResultsTabs.tsx
@@ -7,6 +7,7 @@ import { useResultsTabStore } from "@/stores/resultsTabStore";
 import { useScenarioStore } from "@/stores/scenarioStore";
 import { useSweepRunStore } from "@/stores/sweepStore";
 import { fetchPlugins, renderPlugin } from "@/api/plugins";
+import { hasSankeyData } from "@/lib/sankeyData";
 import { Button } from "@/components/ui/Button";
 import { PlotsTab } from "./PlotsTab";
 import { ConvergenceTab } from "./ConvergenceTab";
@@ -36,8 +37,9 @@ export function ResultsTabs() {
   const setActiveTab = useResultsTabStore((s) => s.setActiveTab);
   const activeScenarioId = useScenarioStore((s) => s.activeId);
   const scenarioProgress = useSweepRunStore((s) => s.scenarioProgress);
-  /** Resolved tab for UI: explicit choice, else Sankey when results exist, else Plots. */
-  const displayTab = activeTab ?? (results ? "Sankey" : "Plots");
+  const defaultResultsTab = results && hasSankeyData(results) ? "Sankey" : "Plots";
+  /** Resolved tab for UI: explicit choice, else Sankey/Plots per available data. */
+  const displayTab = activeTab ?? defaultResultsTab;
   const [plugins, setPlugins] = useState<PluginMeta[]>([]);
   const [pluginData, setPluginData] = useState<Record<string, PluginRenderData>>({});
   const [pluginLoading, setPluginLoading] = useState<Record<string, boolean>>({});
@@ -73,17 +75,31 @@ export function ResultsTabs() {
     if (!results || activeTab !== null || selectedElement) return;
     if (autoOpenedForRef.current === resultsVersionRef.current) return;
     const pref = plugins.find((p) => p.preferred);
-    if (!pref) return;
-    const kinds = pref.supported_node_types ?? null;
-    const node = config.nodes.find(
-      (n) => !kinds || kinds.includes(String(n.type)),
-    );
-    if (!node && pref.requires_selection) return;
-    autoOpenedForRef.current = resultsVersionRef.current;
-    if (node) {
-      setSelectedElement({ type: "node", data: { id: node.id, type: node.type } });
+    if (pref) {
+      const kinds = pref.supported_node_types ?? null;
+      const node = config.nodes.find(
+        (n) => !kinds || kinds.includes(String(n.type)),
+      );
+      if (!node && pref.requires_selection) return;
+      autoOpenedForRef.current = resultsVersionRef.current;
+      if (node) {
+        setSelectedElement({ type: "node", data: { id: node.id, type: node.type } });
+      }
+      setActiveTab(pref.label);
+      return;
     }
-    setActiveTab(pref.label);
+
+    if (!hasSankeyData(results)) {
+      const series = results.reactors_series ?? {};
+      const ids = Object.keys(series);
+      if (ids.length === 0) return;
+      autoOpenedForRef.current = resultsVersionRef.current;
+      const node = config.nodes.find((n) => n.id === ids[0]);
+      setSelectedElement({
+        type: "node",
+        data: { id: ids[0], type: node?.type },
+      });
+    }
   }, [
     results,
     plugins,
@@ -193,11 +209,7 @@ export function ResultsTabs() {
   ];
   // If the active tab just disappeared (its plugin's selection was cleared),
   // fall back to a safe base tab instead of rendering an empty pane.
-  const safeTab: Tab = tabs.includes(displayTab)
-    ? displayTab
-    : results
-      ? "Sankey"
-      : "Plots";
+  const safeTab: Tab = tabs.includes(displayTab) ? displayTab : defaultResultsTab;
 
   return (
     <div id="simulation-results-card" className="rounded-lg border border-border bg-card">

--- a/frontend/src/components/results/SankeyTab.tsx
+++ b/frontend/src/components/results/SankeyTab.tsx
@@ -1,5 +1,6 @@
 import Plot from "react-plotly.js";
 import { mapSankeyNodeColors } from "@/lib/cytoscapeNodeColor";
+import { hasSankeyData } from "@/lib/sankeyData";
 import { useThemeStore } from "@/stores/themeStore";
 import type { SimulationResults } from "@/types/simulation";
 
@@ -43,7 +44,7 @@ function mapSankeyLinkColors(
 export function SankeyTab({ results }: Props) {
   const theme = useThemeStore((s) => s.theme);
 
-  if (!results.sankey_links || !results.sankey_nodes) {
+  if (!hasSankeyData(results)) {
     return <p className="text-sm text-muted-foreground">No Sankey data available.</p>;
   }
 

--- a/frontend/src/lib/sankeyData.test.ts
+++ b/frontend/src/lib/sankeyData.test.ts
@@ -1,0 +1,26 @@
+/**
+ * Unit tests for Sankey availability helper.
+ *
+ * Asserts hasSankeyData is true only when both sankey_links and sankey_nodes
+ * are present (non-null), matching what SankeyTab needs to render a diagram.
+ */
+
+import { describe, it, expect } from "vitest";
+import { hasSankeyData } from "./sankeyData";
+
+describe("hasSankeyData", () => {
+  it("returns false when either links or nodes are missing", () => {
+    expect(hasSankeyData({ sankey_links: null, sankey_nodes: null })).toBe(false);
+    expect(hasSankeyData({ sankey_links: {}, sankey_nodes: null })).toBe(false);
+    expect(hasSankeyData({ sankey_links: null, sankey_nodes: ["a"] })).toBe(false);
+  });
+
+  it("returns true when both links and nodes are present", () => {
+    expect(
+      hasSankeyData({
+        sankey_links: { source: [0], target: [1], value: [1] },
+        sankey_nodes: ["a", "b"],
+      }),
+    ).toBe(true);
+  });
+});

--- a/frontend/src/lib/sankeyData.ts
+++ b/frontend/src/lib/sankeyData.ts
@@ -1,0 +1,13 @@
+import type { SimulationResults } from "@/types/simulation";
+
+type SankeyResults = SimulationResults & {
+  sankey_links: NonNullable<SimulationResults["sankey_links"]>;
+  sankey_nodes: NonNullable<SimulationResults["sankey_nodes"]>;
+};
+
+/** True when the backend produced Sankey link/node payload for rendering. */
+export function hasSankeyData(
+  results: Pick<SimulationResults, "sankey_links" | "sankey_nodes">,
+): results is SankeyResults {
+  return results.sankey_links != null && results.sankey_nodes != null;
+}

--- a/frontend/src/lib/sankeyData.ts
+++ b/frontend/src/lib/sankeyData.ts
@@ -1,8 +1,13 @@
 import type { SimulationResults } from "@/types/simulation";
 
+type SankeyResults = SimulationResults & {
+  sankey_links: NonNullable<SimulationResults["sankey_links"]>;
+  sankey_nodes: NonNullable<SimulationResults["sankey_nodes"]>;
+};
+
 /** True when the backend produced Sankey link/node payload for rendering. */
 export function hasSankeyData(
   results: Pick<SimulationResults, "sankey_links" | "sankey_nodes">,
-): boolean {
+): results is SankeyResults {
   return results.sankey_links != null && results.sankey_nodes != null;
 }

--- a/frontend/src/lib/sankeyData.ts
+++ b/frontend/src/lib/sankeyData.ts
@@ -1,13 +1,8 @@
 import type { SimulationResults } from "@/types/simulation";
 
-type SankeyResults = SimulationResults & {
-  sankey_links: NonNullable<SimulationResults["sankey_links"]>;
-  sankey_nodes: NonNullable<SimulationResults["sankey_nodes"]>;
-};
-
 /** True when the backend produced Sankey link/node payload for rendering. */
 export function hasSankeyData(
   results: Pick<SimulationResults, "sankey_links" | "sankey_nodes">,
-): results is SankeyResults {
+): boolean {
   return results.sankey_links != null && results.sankey_nodes != null;
 }

--- a/frontend/src/stores/resultsTabStore.ts
+++ b/frontend/src/stores/resultsTabStore.ts
@@ -1,7 +1,7 @@
 import { create } from "zustand";
 
 interface ResultsTabState {
-  /** null = no explicit choice: show Plots while streaming, Sankey once final results exist. */
+  /** null = no explicit choice: Plots while streaming; Sankey or Plots once results exist. */
   activeTab: string | null;
   setActiveTab: (tab: string) => void;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

After a successful calculation, Boulder defaults to the **Sankey** results tab when no pane is explicitly selected. For cases where the backend does not produce Sankey data (e.g. nanosecond discharge networks with no supported species bands), the user lands on an empty pane showing "No Sankey data available."

## Solution

- Default to **Plots** instead of Sankey when `sankey_links` / `sankey_nodes` are absent.
- When falling back to Plots, auto-select the first reactor that has `reactors_series` data so plots render without an extra click (same pattern as scenario result loading).
- Extract a shared `hasSankeyData()` helper used by `ResultsTabs` and `SankeyTab`.

## Testing

- `frontend/src/lib/sankeyData.test.ts` — helper truth table
- `frontend/src/components/results/ResultsTabs.test.tsx` — default tab + auto-selection behavior
- `npm run test:unit` (targeted) and `npm run build` pass

> AI-assisted — code & PR written by Composer
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9e0b078d-007a-417b-b90b-b0c8dc20836f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9e0b078d-007a-417b-b90b-b0c8dc20836f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

