### PR TITLE
Share species colors between composition plots and Sankey

### DIFF
--- a/boulder/api/routes/ui.py
+++ b/boulder/api/routes/ui.py
@@ -97,3 +97,21 @@ async def get_branding() -> Dict[str, Any]:
     except Exception:  # noqa: BLE001 - branding must never break the UI
         branding = None
     return {"branding": branding}
+
+
+@router.get("/species-colors")
+async def get_species_colors() -> Dict[str, Any]:
+    """Return the species -> hex color palette set by a plugin, if any.
+
+    Boulder has no built-in notion of which color belongs to which species;
+    a host plugin may register one (the same palette already used to color
+    the Sankey diagram's species bands, via ``plugins.sankey_link_colors``)
+    so other charts can render a given species consistently.
+    """
+    from ...cantera_converter import get_plugins
+
+    try:
+        species_colors = get_plugins().sankey_link_colors
+    except Exception:  # noqa: BLE001 - this must never break the UI
+        species_colors = None
+    return {"species_colors": species_colors or {}}

--- a/frontend/src/api/uiConfig.ts
+++ b/frontend/src/api/uiConfig.ts
@@ -1,0 +1,12 @@
+import { apiFetch } from "./client";
+
+interface SpeciesColorsResponse {
+  species_colors: Record<string, string>;
+}
+
+/** Species -> hex color palette a host plugin has registered, if any. */
+export function fetchSpeciesColors(): Promise<Record<string, string>> {
+  return apiFetch<SpeciesColorsResponse>("/ui/species-colors").then(
+    (r) => r.species_colors,
+  );
+}

--- a/frontend/src/components/results/PlotsTab.tsx
+++ b/frontend/src/components/results/PlotsTab.tsx
@@ -1,6 +1,8 @@
 import { useCallback, useMemo, useState } from "react";
 import Plot from "react-plotly.js";
+import { useSpeciesColors } from "@/hooks/useSpeciesColors";
 import { coerceNumericSeries, pressureYAxis } from "@/lib/plotAxis";
+import { getSpeciesColor } from "@/lib/speciesColor";
 import { useConfigStore } from "@/stores/configStore";
 import { useSelectionStore } from "@/stores/selectionStore";
 import { useThemeStore } from "@/stores/themeStore";
@@ -30,6 +32,7 @@ export function PlotsTab({ data }: Props) {
   const selectedElement = useSelectionStore((s) => s.selectedElement);
   const theme = useThemeStore((s) => s.theme);
   const configNodes = useConfigStore((s) => s.config.nodes);
+  const speciesColors = useSpeciesColors();
 
   // Shared x-range: zoom/pan on any plot synchronizes all of them
   // (double-click autoscale resets the whole set).
@@ -159,23 +162,23 @@ export function PlotsTab({ data }: Props) {
     const coordLabel = isResidence ? "Residence time" : "Position";
     const profileTraceMode = traceModeForSamples(xAxis.length);
 
-    const moleFractionTraces = mainSpeciesMole.map((species) => ({
+    const moleFractionTraces = mainSpeciesMole.map((species, i) => ({
       x: xAxis,
       y: reactorSeries.X?.[species] ?? [],
       type: "scatter" as const,
       mode: profileTraceMode,
       name: species,
-      line: { width: 2 },
+      line: { width: 2, color: getSpeciesColor(species, theme, i, speciesColors) },
       visible: traceVisibility(species, plotConfig.hideSpecies),
     }));
 
-    const massFractionTraces = mainSpeciesMass.map((species) => ({
+    const massFractionTraces = mainSpeciesMass.map((species, i) => ({
       x: xAxis,
       y: reactorSeries.Y?.[species] ?? [],
       type: "scatter" as const,
       mode: profileTraceMode,
       name: species,
-      line: { width: 2 },
+      line: { width: 2, color: getSpeciesColor(species, theme, i, speciesColors) },
       visible: traceVisibility(species, plotConfig.hideSpecies),
     }));
 
@@ -345,6 +348,13 @@ export function PlotsTab({ data }: Props) {
                 type: "pie",
                 textinfo: "label+percent",
                 hoverinfo: "label+value+percent",
+                marker: {
+                  colors: moleLabelsAll.map((label, i) =>
+                    label === "Other"
+                      ? "#cccccc"
+                      : getSpeciesColor(label, theme, i, speciesColors),
+                  ),
+                },
               },
             ]}
             layout={{
@@ -368,6 +378,13 @@ export function PlotsTab({ data }: Props) {
                 type: "pie",
                 textinfo: "label+percent",
                 hoverinfo: "label+value+percent",
+                marker: {
+                  colors: massLabelsAll.map((label, i) =>
+                    label === "Other"
+                      ? "#cccccc"
+                      : getSpeciesColor(label, theme, i, speciesColors),
+                  ),
+                },
               },
             ]}
             layout={{
@@ -390,23 +407,23 @@ export function PlotsTab({ data }: Props) {
   const times = data.times;
   const timeTraceMode = traceModeForSamples(times.length);
 
-  const moleFractionTraces = mainSpeciesMole.map((species) => ({
+  const moleFractionTraces = mainSpeciesMole.map((species, i) => ({
     x: times,
     y: reactorSeries?.X?.[species] ?? [],
     type: "scatter" as const,
     mode: timeTraceMode,
     name: species,
-    line: { width: 2 },
+    line: { width: 2, color: getSpeciesColor(species, theme, i, speciesColors) },
     visible: traceVisibility(species, plotConfig.hideSpecies),
   }));
 
-  const massFractionTraces = mainSpeciesMass.map((species) => ({
+  const massFractionTraces = mainSpeciesMass.map((species, i) => ({
     x: times,
     y: reactorSeries?.Y?.[species] ?? [],
     type: "scatter" as const,
     mode: timeTraceMode,
     name: species,
-    line: { width: 2 },
+    line: { width: 2, color: getSpeciesColor(species, theme, i, speciesColors) },
     visible: traceVisibility(species, plotConfig.hideSpecies),
   }));
 

--- a/frontend/src/hooks/useSpeciesColors.ts
+++ b/frontend/src/hooks/useSpeciesColors.ts
@@ -1,0 +1,34 @@
+import { useEffect, useState } from "react";
+import { fetchSpeciesColors } from "@/api/uiConfig";
+
+let cache: Record<string, string> | null = null;
+let inflight: Promise<Record<string, string>> | null = null;
+
+/**
+ * Species -> hex color palette a host plugin has registered (the same one
+ * the Sankey diagram uses for its species bands), so composition plots can
+ * render a given species with the same color. Empty when no plugin
+ * registers one. Fetched once per session and cached.
+ */
+export function useSpeciesColors(): Record<string, string> {
+  const [state, setState] = useState<Record<string, string>>(cache ?? {});
+
+  useEffect(() => {
+    if (cache) return;
+    if (!inflight) inflight = fetchSpeciesColors();
+    let cancelled = false;
+    inflight
+      .then((colors) => {
+        cache = colors;
+        if (!cancelled) setState(colors);
+      })
+      .catch(() => {
+        // Best-effort; callers fall back to their own default colorway.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return state;
+}

--- a/frontend/src/lib/speciesColor.ts
+++ b/frontend/src/lib/speciesColor.ts
@@ -1,0 +1,49 @@
+/**
+ * Species trace colors for the composition plots (PlotsTab).
+ *
+ * Boulder has no built-in notion of which color belongs to which species --
+ * a host plugin may register a palette (``plugins.sankey_link_colors``,
+ * fetched via ``useSpeciesColors``) which is also what colors the Sankey
+ * diagram's species bands, so the two views agree. Species outside that
+ * palette fall back to the theme colorway, cycled by legend order.
+ */
+
+type Theme = "light" | "dark";
+
+const LIGHT_COLORWAY = [
+  "#1f77b4",
+  "#ff7f0e",
+  "#2ca02c",
+  "#d62728",
+  "#9467bd",
+  "#8c564b",
+  "#e377c2",
+  "#7f7f7f",
+  "#bcbd22",
+  "#17becf",
+];
+
+const DARK_COLORWAY = [
+  "#4A90E2",
+  "#7ED321",
+  "#F5A623",
+  "#D0021B",
+  "#9013FE",
+  "#50E3C2",
+  "#BD10E0",
+  "#B8E986",
+  "#FF6B6B",
+  "#4ECDC4",
+];
+
+export function getSpeciesColor(
+  species: string,
+  theme: Theme,
+  fallbackIndex: number,
+  overrides: Record<string, string> = {},
+): string {
+  const override = overrides[species];
+  if (override) return override;
+  const colorway = theme === "dark" ? DARK_COLORWAY : LIGHT_COLORWAY;
+  return colorway[fallbackIndex % colorway.length];
+}


### PR DESCRIPTION
## Summary
- Composition plot traces (mole/mass fraction line charts, PSR pie charts) now take species colors from a plugin-registered `species -> hex` palette instead of default index-based cycling.
- New `GET /api/ui/species-colors` endpoint exposes `plugins.sankey_link_colors` (the same palette a host plugin already registers for the Sankey diagram's species bands) so both views agree on a given species' color.
- Boulder itself carries no species names/colors — species outside the registered palette keep falling back to the existing theme colorway.

## Test plan
- [ ] With a host plugin registering `sankey_link_colors`, confirm a species (e.g. H2) renders the same color in the Plots tab and the Sankey diagram.
- [ ] Without any plugin, confirm the Plots tab still colors species via the default colorway (no regression).
- [ ] `GET /api/ui/species-colors` returns `{}` when no plugin is installed.