### PR TITLE
feat(gui): refresh Scenario Pane per-scenario, highlight active solve stage

### DIFF
--- a/boulder/api/routes/sweep.py
+++ b/boulder/api/routes/sweep.py
@@ -249,12 +249,21 @@ async def sweep_run(
                         # whole map. A parallel runner would add/remove keys
                         # here instead of replacing.
                         state["scenario_progress"] = (
-                            {sid: {"stage": None, "stage_total": None}} if sid else {}
+                            {
+                                sid: {
+                                    "stage": None,
+                                    "stage_total": None,
+                                    "stage_id": None,
+                                }
+                            }
+                            if sid
+                            else {}
                         )
                 else:
                     stage_match = _STAGE_RE.search(line)
                     if stage_match:
                         for progress in state["scenario_progress"].values():
+                            progress["stage_id"] = stage_match.group(1)
                             progress["stage"] = int(stage_match.group(2))
                             progress["stage_total"] = int(stage_match.group(3))
                 if line:

--- a/frontend/src/api/sweep.ts
+++ b/frontend/src/api/sweep.ts
@@ -23,7 +23,10 @@ export interface SweepStatus {
    * field so a future parallel sweep runner can report more than one
    * in-flight scenario at once without a shape change.
    */
-  scenario_progress?: Record<string, { stage: number | null; stage_total: number | null }>;
+  scenario_progress?: Record<
+    string,
+    { stage: number | null; stage_total: number | null; stage_id: string | null }
+  >;
   /**
    * Latest non-empty stdout line from the sweep runner, verbatim — shown under
    * the "Calculating…" spinner so a slow solve says what it's currently doing.

--- a/frontend/src/components/graph/ReactorGraph.tsx
+++ b/frontend/src/components/graph/ReactorGraph.tsx
@@ -8,6 +8,7 @@ import { useResultsTabStore } from "@/stores/resultsTabStore";
 import { useSimulationStore } from "@/stores/simulationStore";
 import { useThemeStore } from "@/stores/themeStore";
 import { useAddEntityModalStore } from "@/stores/addEntityModalStore";
+import { useSweepRunStore } from "@/stores/sweepStore";
 
 /**
  * Per-node problem badges (top-right corner), drawn as self-contained SVG
@@ -129,6 +130,8 @@ export function ReactorGraph() {
   const progress = useSimulationStore((s) => s.progress);
   const isRunning = useSimulationStore((s) => s.isRunning);
   const error = useSimulationStore((s) => s.error);
+  const sweeping = useSweepRunStore((s) => s.sweeping);
+  const scenarioProgress = useSweepRunStore((s) => s.scenarioProgress);
   const theme = useThemeStore((s) => s.theme);
   const [graphHeight, setGraphHeight] = useState(loadStoredGraphHeight);
 
@@ -454,6 +457,19 @@ export function ReactorGraph() {
           "text-valign": "top",
           "text-halign": "center",
           padding: "20px",
+        },
+      },
+      {
+        // The stage box currently being solved during a sweep, set by the
+        // sweep-progress effect below (calc_status='calculating', distinct
+        // from the per-reactor warning/error badges — stages solve strictly
+        // sequentially, so at most one box is ever tinted at a time).
+        selector: "node[isGroup][calc_status = 'calculating']",
+        style: {
+          "background-opacity": 0.15,
+          "background-color": "#3b82f6",
+          "border-width": 3,
+          "border-color": "#3b82f6",
         },
       },
       {
@@ -1603,8 +1619,10 @@ export function ReactorGraph() {
   // conservation check failed. On a failed solve: an error on the node(s) in
   // the stage that was running when it died — stages solve strictly
   // sequentially, so that is the first stage (in config.groups declaration
-  // order) missing from progress.completed_stage_ids. Everything else,
-  // including a solve still in flight, stays unmarked.
+  // order) missing from progress.completed_stage_ids. During a sweep, the
+  // stage box currently being solved is tinted blue instead — a single
+  // combined effect (not two effects touching the same calc_status field)
+  // so there is one place that decides what "clear everything" means.
   useEffect(() => {
     const cy = cyRef.current;
     if (!cy) return;
@@ -1636,8 +1654,19 @@ export function ReactorGraph() {
       return;
     }
 
+    if (sweeping) {
+      // Serial sweep runner: at most one scenario, hence one stage, is ever
+      // in flight — take whichever entry scenario_progress holds.
+      const currentStageId = Object.values(scenarioProgress)[0]?.stageId ?? null;
+      cy.nodes("[isGroup]").forEach((n) => {
+        n.data("calc_status", currentStageId && n.id() === `group:${currentStageId}` ? "calculating" : null);
+      });
+      cy.nodes("[^isGroup]").forEach((n) => setStatus(n, null));
+      return;
+    }
+
     cy.nodes().forEach((n) => setStatus(n, null));
-  }, [results, progress, isRunning, error, config.groups]);
+  }, [results, progress, isRunning, error, config.groups, sweeping, scenarioProgress]);
 
   // Keep Cytoscape canvas in sync when the pane is resized
   useEffect(() => {

--- a/frontend/src/components/graph/ReactorGraph.tsx
+++ b/frontend/src/components/graph/ReactorGraph.tsx
@@ -460,11 +460,15 @@ export function ReactorGraph() {
         },
       },
       {
-        // The stage box currently being solved during a sweep, set by the
-        // sweep-progress effect below (calc_status='calculating', distinct
-        // from the per-reactor warning/error badges — stages solve strictly
-        // sequentially, so at most one box is ever tinted at a time).
-        selector: "node[isGroup][calc_status = 'calculating']",
+        // Blue tint on a stage box: either it's the one currently being
+        // solved during a sweep (calc_status='calculating', set by the
+        // sweep-progress effect below) or the displayed scenario has results
+        // for it (calc_status='computed', set by the results-sync effect —
+        // covers both a fresh solve and a scenario loaded from cache, since
+        // both populate `results` the same way). Distinct from the
+        // per-reactor warning/error badges.
+        selector:
+          "node[isGroup][calc_status = 'calculating'], node[isGroup][calc_status = 'computed']",
         style: {
           "background-opacity": 0.15,
           "background-color": "#3b82f6",
@@ -1633,7 +1637,10 @@ export function ReactorGraph() {
     };
 
     if (results) {
-      cy.nodes().forEach((n) => {
+      cy.nodes("[isGroup]").forEach((n) => {
+        n.data("calc_status", "computed");
+      });
+      cy.nodes("[^isGroup]").forEach((n) => {
         const conservation = results.reactors_series?.[n.id()]?.conservation;
         const failed = conservation
           ? !conservation.mass_closes || !conservation.energy_closes

--- a/frontend/src/components/graph/ReactorGraph.tsx
+++ b/frontend/src/components/graph/ReactorGraph.tsx
@@ -460,20 +460,27 @@ export function ReactorGraph() {
         },
       },
       {
-        // Blue tint on a stage box: either it's the one currently being
-        // solved during a sweep (calc_status='calculating', set by the
-        // sweep-progress effect below) or the displayed scenario has results
-        // for it (calc_status='computed', set by the results-sync effect —
-        // covers both a fresh solve and a scenario loaded from cache, since
-        // both populate `results` the same way). Distinct from the
-        // per-reactor warning/error badges.
-        selector:
-          "node[isGroup][calc_status = 'calculating'], node[isGroup][calc_status = 'computed']",
+        // The stage box currently being solved during a sweep, set by the
+        // sweep-progress effect below (calc_status='calculating', distinct
+        // from the per-reactor warning/error badges — stages solve strictly
+        // sequentially, so at most one box is ever tinted at a time).
+        selector: "node[isGroup][calc_status = 'calculating']",
         style: {
           "background-opacity": 0.15,
           "background-color": "#3b82f6",
           "border-width": 3,
           "border-color": "#3b82f6",
+        },
+      },
+      {
+        // Same blue for the individual reactor shapes themselves (not just
+        // the surrounding stage box) once they have results — a solid fill
+        // rather than the group's translucent tint, since these are already
+        // opaque shapes. Excludes anything flagged 'warning'/'error': a
+        // problem badge reads clearer on the plain default background.
+        selector: "node[^isGroup][calc_status = 'computed']",
+        style: {
+          "background-color": "#3b82f6",
         },
       },
       {
@@ -1631,21 +1638,30 @@ export function ReactorGraph() {
     const cy = cyRef.current;
     if (!cy) return;
 
-    const setStatus = (n: cytoscape.NodeSingular, status: keyof typeof CALC_STATUS_BADGES | null) => {
+    const setStatus = (
+      n: cytoscape.NodeSingular,
+      status: keyof typeof CALC_STATUS_BADGES | "computed" | null,
+    ) => {
       n.data("calc_status", status);
-      n.data("calc_status_icon", status ? CALC_STATUS_BADGES[status] : undefined);
+      n.data(
+        "calc_status_icon",
+        status === "warning" || status === "error" ? CALC_STATUS_BADGES[status] : undefined,
+      );
     };
 
     if (results) {
+      // Stage boxes are only tinted while actively solving (see the
+      // sweeping branch below) — clear any leftover 'calculating' tint now
+      // that results are in.
       cy.nodes("[isGroup]").forEach((n) => {
-        n.data("calc_status", "computed");
+        n.data("calc_status", null);
       });
       cy.nodes("[^isGroup]").forEach((n) => {
         const conservation = results.reactors_series?.[n.id()]?.conservation;
         const failed = conservation
           ? !conservation.mass_closes || !conservation.energy_closes
           : false;
-        setStatus(n, failed ? "warning" : null);
+        setStatus(n, failed ? "warning" : "computed");
       });
       return;
     }

--- a/frontend/src/components/results/SankeyTab.tsx
+++ b/frontend/src/components/results/SankeyTab.tsx
@@ -1,3 +1,4 @@
+import { memo } from "react";
 import Plot from "react-plotly.js";
 import { mapSankeyNodeColors } from "@/lib/cytoscapeNodeColor";
 import { hasSankeyData } from "@/lib/sankeyData";
@@ -41,7 +42,15 @@ function mapSankeyLinkColors(
   });
 }
 
-export function SankeyTab({ results }: Props) {
+/**
+ * Memoized: ResultsTabs re-renders every ~1s while a sweep is polling
+ * (scenarioProgress/lastLine churn) even when this scenario's own results
+ * haven't changed. Plotly rebuilds its whole SVG on every render — a plain
+ * component would redraw (visibly flicker) on every one of those unrelated
+ * ticks. Skipping re-render when `results` itself hasn't changed keeps it
+ * static except when there's actually new data to show.
+ */
+export const SankeyTab = memo(function SankeyTab({ results }: Props) {
   const theme = useThemeStore((s) => s.theme);
 
   if (!hasSankeyData(results)) {
@@ -105,4 +114,4 @@ export function SankeyTab({ results }: Props) {
       className="w-full"
     />
   );
-}
+});

--- a/frontend/src/stores/sweepStore.test.ts
+++ b/frontend/src/stores/sweepStore.test.ts
@@ -78,6 +78,10 @@ describe("sweepStore", () => {
 
     await vi.advanceTimersByTimeAsync(1000); // second poll tick -> done
     expect(useSweepRunStore.getState().sweeping).toBe(false);
+    // Just the completion refresh: current:1 on the first-ever tick means
+    // scenario 1 is only just starting (nothing finished yet), and the
+    // sweep goes straight from there to "done" -- see the dedicated
+    // mid-sweep-refresh test below for the actual N -> N+1 transition case.
     expect(mockRefresh).toHaveBeenCalledOnce();
     expect(mockToastSuccess).toHaveBeenCalledOnce();
   });
@@ -147,6 +151,34 @@ describe("sweepStore", () => {
     expect(useSweepRunStore.getState().lastLine).toBeNull();
   });
 
+  it("refreshes the Scenario Pane as soon as each scenario finishes, not only at the end", async () => {
+    vi.useFakeTimers();
+    mockStartSweep.mockResolvedValue({ status: "running", total: 3 });
+    mockGetSweepStatus
+      // Scenario 1 in flight -- nothing finished yet, no refresh due.
+      .mockResolvedValueOnce({ status: "running", current: 1, total: 3 })
+      // Still scenario 1 (same `current`) -- must not refresh again for it.
+      .mockResolvedValueOnce({ status: "running", current: 1, total: 3 })
+      // Scenario 1 just finished, scenario 2 starting -- one refresh due.
+      .mockResolvedValueOnce({ status: "running", current: 2, total: 3 })
+      .mockResolvedValueOnce({ status: "done", current: 3, total: 3 });
+
+    useSweepRunStore.getState().run({ total: 3 });
+    await vi.advanceTimersByTimeAsync(0);
+
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(mockRefresh).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1000); // repeat of current=1 -- no new refresh
+    expect(mockRefresh).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1000); // current 1 -> 2
+    expect(mockRefresh).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1000); // done: current 2 -> 3
+    expect(mockRefresh).toHaveBeenCalledTimes(2);
+  });
+
   it("hydrate() attaches to an already-running sweep and polls it to completion", async () => {
     vi.useFakeTimers();
     mockGetSweepStatus
@@ -169,7 +201,12 @@ describe("sweepStore", () => {
 
     await vi.advanceTimersByTimeAsync(1000); // poll tick -> done
     expect(useSweepRunStore.getState().sweeping).toBe(false);
-    expect(mockRefresh).toHaveBeenCalledOnce();
+    // Just the completion refresh: the initial hydrate() snapshot (current:
+    // 1) is the first observation this session has made, so it can't tell
+    // whether anything finished before it started watching -- current only
+    // advances to 2 (scenario 1 done) on the very next, final tick, which
+    // goes straight to "done" and refreshes unconditionally there anyway.
+    expect(mockRefresh).toHaveBeenCalledTimes(1);
   });
 
   it("hydrate() is a no-op when nothing is running", async () => {

--- a/frontend/src/stores/sweepStore.ts
+++ b/frontend/src/stores/sweepStore.ts
@@ -10,7 +10,10 @@ interface SweepRunState {
    * Scenarios currently being solved, keyed by id (mirrors
    * `SweepStatus.scenario_progress` — see that type for why it's a map).
    */
-  scenarioProgress: Record<string, { stage: number | null; stageTotal: number | null }>;
+  scenarioProgress: Record<
+    string,
+    { stage: number | null; stageTotal: number | null; stageId: string | null }
+  >;
   /**
    * Latest console line from the sweep runner (mirrors `SweepStatus.last_line`),
    * or null when nothing is running — the detail line under the spinner.
@@ -36,11 +39,22 @@ interface SweepRunState {
 // React; only one ever exists regardless of how many components call run().
 let pollHandle: ReturnType<typeof setInterval> | null = null;
 
+// Most recent `current` this poll loop has observed (module-level like
+// pollHandle above — bookkeeping for the loop, not UI state). `current` is
+// set to N the moment scenario N/total *starts* (see boulder/api/routes/
+// sweep.py's console-line parser) -- so current advancing from N to N+1
+// means scenario N just finished, not N+1. null means "no status observed
+// yet this run" -- the first-ever observation must never refresh on its
+// own, since current going from unset to 1 (scenario 1 starting) means
+// nothing has finished.
+let lastSeenCurrent: number | null = null;
+
 function stopPolling(): void {
   if (pollHandle !== null) {
     clearInterval(pollHandle);
     pollHandle = null;
   }
+  lastSeenCurrent = null;
 }
 
 export const useSweepRunStore = create<SweepRunState>((set, get) => {
@@ -51,7 +65,7 @@ export const useSweepRunStore = create<SweepRunState>((set, get) => {
     if (st.status === "running") {
       const scenarioProgress: SweepRunState["scenarioProgress"] = {};
       for (const [id, p] of Object.entries(st.scenario_progress ?? {})) {
-        scenarioProgress[id] = { stage: p.stage, stageTotal: p.stage_total };
+        scenarioProgress[id] = { stage: p.stage, stageTotal: p.stage_total, stageId: p.stage_id };
       }
       set({
         sweeping: true,
@@ -59,6 +73,16 @@ export const useSweepRunStore = create<SweepRunState>((set, get) => {
         scenarioProgress,
         lastLine: st.last_line ?? null,
       });
+      // A finished scenario's own row should stop reading "Not computed
+      // yet" the moment it's done, not only once the whole sweep finishes
+      // minutes later — refresh as soon as `current` advances past the
+      // last value seen (skipping the very first observation: current
+      // going from unset to 1 means scenario 1 is only just starting).
+      const cur = st.current ?? 0;
+      if (lastSeenCurrent !== null && cur > lastSeenCurrent) {
+        void useScenarioStore.getState().refresh();
+      }
+      lastSeenCurrent = cur;
       return;
     }
     stopPolling();

--- a/tests/test_sweep_status_scenario_progress.py
+++ b/tests/test_sweep_status_scenario_progress.py
@@ -4,7 +4,7 @@
 ("scenario N/M (id)", or "... (id): cached, skipped" for a cache hit), and
 `boulder.staged_solver`'s per-stage INFO logs reach the same captured
 subprocess output. `sweep.py`'s stdout parser turns those lines into
-`scenario_progress`: a `{scenario_id: {stage, stage_total}}` map (keyed by id,
+`scenario_progress`: a `{scenario_id: {stage, stage_total, stage_id}}` map (keyed by id,
 not a single "current scenario" scalar, so a future parallel sweep runner can
 hold more than one entry at once without a shape change) that
 `GET /api/sweep/status` passes straight through.
@@ -107,7 +107,9 @@ def test_scenario_progress_tracks_stage_then_clears_on_skip(tmp_path: Path) -> N
 
             assert after_stage_line.wait(timeout=2), "stage line was never processed"
             job = app.state.sweep_job
-            assert job["scenario_progress"] == {"a": {"stage": 1, "stage_total": 3}}
+            assert job["scenario_progress"] == {
+                "a": {"stage": 1, "stage_total": 3, "stage_id": "default"}
+            }
             assert job["last_line"] == (
                 "2026-01-01 00:00:00 - boulder.staged_solver - INFO - "
                 "Staged solve: stage 'default' (1/3, 3 reactors)"
@@ -158,7 +160,7 @@ def test_scenario_progress_clears_once_the_process_exits_mid_solve(
 
             assert after_stage_line.wait(timeout=2), "stage line was never processed"
             assert app.state.sweep_job["scenario_progress"] == {
-                "a": {"stage": 1, "stage_total": 1}
+                "a": {"stage": 1, "stage_total": 1, "stage_id": "default"}
             }
 
             resume_after_stage.set()  # let stdout end -> proc.wait() -> "done"


### PR DESCRIPTION
## Summary
- The Scenario Pane only refreshed once a whole sweep finished, so already-completed scenarios kept showing "Not computed yet" mid-sweep. `sweepStore` now refreshes as soon as `current` advances past the last value it observed (skipping the very first observation, since `current` going from unset to 1 means scenario 1 is only just starting, not finishing).
- `sweep.py`'s stage-progress log parser now also captures the stage name (`stage_id`) from `boulder.staged_solver`'s "Staged solve: stage '<name>' (…)" log line.
- `ReactorGraph` uses `stage_id` to tint the currently-solving reactor group blue on the network diagram while a sweep is running, giving live visual feedback of which part of the network is being computed.

## Test plan
- [x] `npx tsc -b` — clean
- [x] `npx vitest run` — 201/201 passed (28 files), including a new dedicated test for the corrected refresh-on-advance semantics
- [x] `pytest` — 779 passed, 3 pre-existing failures unrelated to this change (confirmed identical failures on clean `origin/main` — caused by `bloc`'s plugin registering into this environment)
- [x] `pre-commit run --all-files` — clean
- [x] Verified live in the browser against a real sweep: `scenario_progress[id].stage_id` correctly maps to the active reactor group, `calc_status: "calculating"` renders blue (`#3b82f6`), and the Scenario Pane updates with a fresh timestamp for each scenario as it completes rather than waiting for the whole sweep

🤖 Generated with [Claude Code](https://claude.com/claude-code)