### PR TITLE
feat(gui): let a plugin supply a doc-link for its own reactor kinds

### DIFF
--- a/boulder/api/routes/ui.py
+++ b/boulder/api/routes/ui.py
@@ -56,19 +56,28 @@ async def get_kinds() -> Dict[str, Any]:
 
     Combines Boulder's built-in kinds (with a Cantera doc link/description
     from :mod:`boulder.cantera_docs`) with any kind a loaded plugin has
-    registered via ``schema_registry.register_reactor_builder``/
+    registered via ``schema_registry.register_reactor_builder`` (doc link
+    only if the plugin passed ``doc_url``/``doc_description``) or
     ``register_connection_schema`` (no doc link — plugins document their own
-    kinds). Powers the Add Reactor/Add Connection modals so the type
-    dropdown always reflects what this build can actually construct.
+    connection kinds). Powers the Add Reactor/Add Connection modals so the
+    type dropdown always reflects what this build can actually construct.
     """
     from ...cantera_docs import CONNECTION_DOCS, REACTOR_DOCS
-    from ...schema_registry import registered_connection_kinds, registered_kinds
+    from ...schema_registry import (
+        get_schema_entry,
+        registered_connection_kinds,
+        registered_kinds,
+    )
 
     reactors = [
         {"kind": kind, "doc_url": doc["doc_url"], "description": doc["description"]}
         for kind, doc in REACTOR_DOCS.items()
     ] + [
-        {"kind": kind, "doc_url": None, "description": None}
+        {
+            "kind": kind,
+            "doc_url": (entry := get_schema_entry(kind)) and entry.doc_url,
+            "description": entry and entry.doc_description,
+        }
         for kind in registered_kinds()
         if kind not in REACTOR_DOCS
     ]

--- a/boulder/schema_registry.py
+++ b/boulder/schema_registry.py
@@ -69,6 +69,13 @@ class ReactorSchemaEntry:
         const-pressure base classes (both standard and ``Extensible*`` roots),
         so no explicit flag is needed for reactors that inherit from any
         Cantera const-pressure base.
+    doc_url:
+        Optional URL to the plugin's own documentation for this kind. Powers
+        the same doc-link tooltip Boulder's built-in kinds get from
+        :mod:`boulder.cantera_docs` (Properties panel, Add Reactor modal).
+    doc_description:
+        Optional one-line description shown above ``doc_url`` in that
+        tooltip.
     """
 
     kind: str
@@ -79,6 +86,8 @@ class ReactorSchemaEntry:
     default_constraints: List[Dict[str, Any]] = field(default_factory=list)
     variable_maps: Dict[str, Dict[str, Any]] = field(default_factory=dict)
     reactor_class: Optional[Type[Any]] = None
+    doc_url: Optional[str] = None
+    doc_description: Optional[str] = None
 
 
 _SCHEMA_REGISTRY: Dict[str, ReactorSchemaEntry] = {}
@@ -95,6 +104,8 @@ def register_reactor_builder(
     default_constraints: Optional[List[Dict[str, Any]]] = None,
     variable_maps: Optional[Dict[str, Dict[str, Any]]] = None,
     reactor_class: Optional[Type[Any]] = None,
+    doc_url: Optional[str] = None,
+    doc_description: Optional[str] = None,
 ) -> None:
     """Register a reactor builder together with its declarative metadata.
 
@@ -111,6 +122,10 @@ def register_reactor_builder(
         ``True`` automatically if any ancestor name contains
         ``"ConstPressure"``.  This avoids the need for an explicit flag
         and stays correct as the class hierarchy evolves.
+    doc_url, doc_description:
+        Optional link to the plugin's own documentation for *kind* (see
+        :class:`ReactorSchemaEntry`). Omit to leave the GUI's doc-link
+        tooltip hidden for this kind, as before.
     """
     plugins.reactor_builders[kind] = builder
     entry = ReactorSchemaEntry(
@@ -122,6 +137,8 @@ def register_reactor_builder(
         default_constraints=list(default_constraints or []),
         variable_maps=dict(variable_maps or {}),
         reactor_class=reactor_class,
+        doc_url=doc_url,
+        doc_description=doc_description,
     )
     _SCHEMA_REGISTRY[kind] = entry
 

--- a/frontend/src/components/modals/AddMFCModal.tsx
+++ b/frontend/src/components/modals/AddMFCModal.tsx
@@ -134,7 +134,7 @@ export function AddMFCModal({ open, onClose, defaultGroup, defaultSource }: Prop
                       rel="noreferrer"
                       className="underline text-primary"
                     >
-                      Cantera docs
+                      Docs
                     </a>
                   </span>
                 }

--- a/frontend/src/components/modals/AddReactorModal.tsx
+++ b/frontend/src/components/modals/AddReactorModal.tsx
@@ -132,7 +132,7 @@ export function AddReactorModal({ open, onClose, defaultGroup }: Props) {
                       rel="noreferrer"
                       className="underline text-primary"
                     >
-                      Cantera docs
+                      Docs
                     </a>
                   </span>
                 }

--- a/frontend/src/components/panels/PropertiesPanel.test.tsx
+++ b/frontend/src/components/panels/PropertiesPanel.test.tsx
@@ -430,7 +430,7 @@ describe("PropertiesPanel Cantera doc-link tooltip", () => {
 
     const trigger = screen.getByLabelText("About IdealGasReactor");
     fireEvent.mouseEnter(trigger.parentElement!);
-    const link = screen.getByRole("link", { name: "Cantera docs" });
+    const link = screen.getByRole("link", { name: "Docs" });
     expect(link).toHaveAttribute(
       "href",
       "https://cantera.org/stable/python/zerodim.html#cantera.IdealGasReactor",
@@ -475,7 +475,7 @@ describe("PropertiesPanel Cantera doc-link tooltip", () => {
 
     const trigger = screen.getByLabelText("About MassFlowController");
     fireEvent.mouseEnter(trigger.parentElement!);
-    const link = screen.getByRole("link", { name: "Cantera docs" });
+    const link = screen.getByRole("link", { name: "Docs" });
     expect(link).toHaveAttribute(
       "href",
       "https://cantera.org/stable/python/zerodim.html#cantera.MassFlowController",

--- a/frontend/src/components/panels/PropertiesPanel.tsx
+++ b/frontend/src/components/panels/PropertiesPanel.tsx
@@ -333,7 +333,7 @@ export function PropertiesPanel() {
                       rel="noreferrer"
                       className="underline text-primary"
                     >
-                      Cantera docs
+                      Docs
                     </a>
                   </span>
                 }

--- a/tests/test_ui_kinds_api.py
+++ b/tests/test_ui_kinds_api.py
@@ -37,6 +37,35 @@ def test_lists_builtin_reactor_and_connection_kinds() -> None:
     assert connection_kinds["Valve"]["doc_url"].startswith("https://cantera.org/")
 
 
+def test_plugin_registered_reactor_kind_with_doc_url_is_surfaced() -> None:
+    plugins = get_plugins()
+    register_reactor_builder(
+        plugins,
+        "_TestPluginReactorWithDocs",
+        builder=lambda converter, node: None,
+        doc_url="https://example.com/docs#_TestPluginReactorWithDocs",
+        doc_description="A plugin reactor with its own docs.",
+    )
+    try:
+        client = TestClient(create_app())
+        resp = client.get("/api/ui/kinds")
+        assert resp.status_code == 200
+        reactor_kinds = {r["kind"]: r for r in resp.json()["reactors"]}
+        assert (
+            reactor_kinds["_TestPluginReactorWithDocs"]["doc_url"]
+            == "https://example.com/docs#_TestPluginReactorWithDocs"
+        )
+        assert (
+            reactor_kinds["_TestPluginReactorWithDocs"]["description"]
+            == "A plugin reactor with its own docs."
+        )
+    finally:
+        del plugins.reactor_builders["_TestPluginReactorWithDocs"]
+        from boulder.schema_registry import _SCHEMA_REGISTRY
+
+        _SCHEMA_REGISTRY.pop("_TestPluginReactorWithDocs", None)
+
+
 def test_plugin_registered_reactor_kind_has_no_doc_url() -> None:
     plugins = get_plugins()
     register_reactor_builder(


### PR DESCRIPTION
## Summary
- [PR #124](https://github.com/parks4/boulder/pull/124) added a doc-link tooltip (i) next to a selected node/connection's type name, but it only ever resolves for Boulder's built-in Cantera kinds — `GET /api/ui/kinds` hardcoded `doc_url: null` for every plugin-registered kind, and `schema_registry.register_reactor_builder()` had no parameter for a plugin to supply one at all.
- `register_reactor_builder()` gained optional `doc_url`/`doc_description` keyword arguments, stored on `ReactorSchemaEntry`.
- `GET /api/ui/kinds` now surfaces a plugin's `doc_url`/`doc_description` when the plugin supplied one, instead of always returning `null` for plugin kinds.
- The tooltip's link label was hardcoded `"Cantera docs"` in three spots (Properties panel, Add Reactor modal, Add Connection modal) — generalized to `"Docs"` since the link may now point at a plugin's own documentation, not just Cantera's. `SolverDetailsModal.tsx`'s "Cantera docs" label was left alone — that one is always about Cantera's ODE solver, unrelated to reactor/connection kinds.

## Test plan
- [x] `python -m pytest tests/test_ui_kinds_api.py` — added a test confirming a plugin-supplied `doc_url`/`doc_description` round-trips through the API; existing no-doc_url test still passes unchanged
- [x] `npm run type-check` — clean
- [x] `npx eslint` on changed files — no new issues (one pre-existing, unrelated error already on `main`)
- [x] `npm run test:unit` — 201 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)