### PR TITLE
Scenario authoring moves in-memory; Run Sweep runs in-process

### DIFF
--- a/.cursor/skills/boulder-scenario-editing/SKILL.md
+++ b/.cursor/skills/boulder-scenario-editing/SKILL.md
@@ -1,6 +1,6 @@
 ______________________________________________________________________
 
-## name: boulder-scenario-editing description: >- Verify scenario-parameter editing in the Boulder GUI (Properties panel and the scenario overlay YAML pane) via interactive browser automation. Use when the user asks to test/verify editing a scenario's node or connection properties, check that GUI edits land in the right scenario overlay (not the base network), or exercise edge cases around BASELINE, cross-node validation conflicts, and GUI/YAML live sync. Requires boulder >= the commit introducing `PATCH /scenarios/{id}/entities/{entity_id}` (see `boulder/scenario_editor.py::update_scenario_entity`).
+## name: boulder-scenario-editing description: >- Verify scenario-parameter editing in the Boulder GUI (Properties panel and the scenario overlay YAML pane) via interactive browser automation. Use when the user asks to test/verify editing a scenario's node or connection properties, check that GUI edits land in the right scenario overlay (not the base network), or exercise edge cases around BASELINE, cross-node validation conflicts, and GUI/YAML live sync. Requires boulder >= the commit making scenario authoring in-memory-only (see `boulder/scenario_editor.py`'s module docstring) and Run Sweep in-process (see `boulder/api/routes/sweep.py`).
 
 # Boulder scenario editing (GUI + YAML)
 
@@ -11,13 +11,26 @@ when it should.
 
 ## Mental model — read this first
 
+**Nothing about scenario authoring touches disk.** Creating, editing,
+renaming, or deleting a scenario overlay only mutates this browser session's
+own in-memory state (`scenarioStore.overlays` — a `{scenario_id: overlay}`
+map, seeded once from the config's `scenarios:` block when the page loads and
+never re-read from disk after). The backend (`boulder/scenario_editor.py`,
+`boulder/api/routes/scenarios.py`) is a pure calculator: every scenario route
+takes the caller's *current* overlays map in the request body and returns the
+*new* one — same "validate/compute, never persist" pattern the main config
+YAML pane already used (`/configs/parse`). The one way to get a scenario onto
+disk is the Scenario YAML pane's **"Download full YAML"** button, which
+renders the base config deep-merged with that one scenario's overlay and
+downloads it as a file — the user decides what to do with it from there.
+
 Two independent things can be "active" in the left Network card / Properties
 panel, and edits go to different places depending on which:
 
 | Active selection | "Edit YAML" button | Where a Properties-panel Save lands |
 |---|---|---|
-| No scenario / **BASELINE** | Plain `Edit YAML` — full base config | The base network (`updateNode`/`updateConnection`, local + deferred to next sync) |
-| A real scenario (e.g. `C1T`) | `Edit YAML (<scenario>)` — scoped overlay | That scenario's overlay only (`PATCH /scenarios/{id}/entities/{entity_id}`, **written to disk immediately**) |
+| No scenario / **BASELINE** | Plain `Edit YAML` — full base config | The base network (`updateNode`/`updateConnection`, local + deferred to next sync — also never touches disk for a real preloaded file) |
+| A real scenario (e.g. `C1T`) | `Edit YAML (<scenario>)` — scoped overlay | That scenario's overlay only, in `scenarioStore.overlays` (in-memory) |
 
 STONE v2 is authored **per-stage** (or one flat `network:` list) with
 type-keyed properties — never a generic `nodes:`/`properties:` shape:
@@ -33,6 +46,14 @@ A scenario overlay mirrors this shape but only lists the fields that
 actually differ from the base — `scenario_editor._entity_location` finds
 which stage list and type key an entity uses from the base config, so the
 API only ever needs the entity id, never the stage/kind.
+
+**Run Sweep runs in-process now** (no subprocess, no `run_sweep.py`): the
+frontend POSTs its current base config's startup snapshot plus
+`scenarioStore.overlays` to `POST /api/sweep/run`, and the backend solves each
+expanded scenario through the exact same `SimulationWorker` a plain "Run
+Simulation" uses — one scenario after another, in a background thread. This
+means Run Sweep always sees this session's live, unsaved scenario edits, with
+no "did I save first?" step.
 
 ## Prerequisites
 
@@ -55,10 +76,13 @@ Scenario editing check:
 - [ ] Selecting it relabels the button "Edit YAML (<id>)"
 - [ ] GUI edit → Properties panel shows new value in amber, tooltip "Baseline value: <old>"
 - [ ] Base (BASELINE) value is unchanged after the scenario edit
-- [ ] GET /api/scenarios/{id}/source shows a *sparse* overlay (only the touched field)
+- [ ] Re-opening Edit on that field now shows the *override*, not the base value
+- [ ] The on-disk config file is byte-for-byte unchanged after the edit
 - [ ] Open the scenario's YAML pane → GUI edit appears there live, no reopen needed
 - [ ] Edit the YAML pane directly → Properties panel updates live, no reselect needed
+- [ ] "Download full YAML" produces a file with the base config merged with the edit
 - [ ] BASELINE: no working delete button; its pencil opens the full YAML pane
+- [ ] Run Sweep picks up the unsaved edit without any extra save step
 ```
 
 1. Navigate to `http://127.0.0.1:8050/`.
@@ -68,17 +92,22 @@ Scenario editing check:
    key and reload.
 1. Select a scenario (see the DOM-id trick below — do **not** rely on
    visible label text, which is `metadata.scenario_name` and can be
-   identical across scenarios).
+   identical across scenarios — see the Scenario Pane's id-first display).
 1. Select a node or connection on the graph (canvas — see the Cytoscape trick
    below, it's far more reliable than pixel-coordinate clicks for this).
-1. Click **Edit**. The field shown is always the **base** value, never the
-   active override — this is intentional (see Edge cases).
+1. Click **Edit**. The field shown is the scenario's *currently effective*
+   value — the override if one already exists, otherwise the base value.
 1. Change the value, click **Save**.
 1. Assert: the field re-renders in amber (`text-amber-600`/`text-amber-400`)
    with `title="Baseline value: <old>"`; a toast reads
    `Scenario "<id>" overlay updated`.
+1. Confirm the on-disk YAML file's mtime/content is unchanged (e.g. `git diff`
+   on a scratch config, or hash the file before/after) — the edit only exists
+   in this browser session.
 1. Click **Edit YAML (`<id>`)** (or the scenario row's pencil) to open the
    scoped pane and confirm the overlay text matches what was just saved.
+1. Click **Download full YAML** in that pane; confirm the downloaded file
+   contains both the base network and the edited field, merged.
 
 ### Reliable interactive-browser techniques
 
@@ -114,33 +143,39 @@ Array.from(document.querySelectorAll('[data-sonner-toast]')).map(t => t.textCont
 
 | Case | Expected behavior | Why it matters |
 |---|---|---|
-| **No-op save**: open Edit (shows base value), click Save without changing anything, while an override already exists for that field | Toast `No changes to save (edit the scenario's YAML directly to remove an override)`. No API call. The existing override is **left untouched** — the GUI cannot remove an override by "typing the base value back", because the diff is computed against the base, not the current override. | Previously silent — looked identical to a successful save with zero feedback. |
-| **Cross-node validation conflict**: e.g. set `pressure` on an `OutletSink`/boundary node when the model requires it declared on exactly one node | The write succeeds (`PATCH .../entities/{id}` → 200), but the follow-up preview refresh fails; toast reads `Scenario "<id>" overlay saved, but it no longer previews cleanly: <STONE v2 error detail>`. The overlay *is* saved on disk — this is a real, correct validation failure, not a client bug. | `loadPreview` catches its own error into `previewError` rather than rejecting; that field must be checked explicitly or the failure is silent. |
-| **Edit while calculating**: try to save a scenario-overlay edit while Run Sweep / Run Simulation is active | Blocked immediately: toast `Wait for the current calculation to finish before editing a scenario.` No API call. | The scenario-overlay write goes straight to disk; a sweep subprocess may be reading that same file for this (or a later) scenario. |
+| **No-op save**: open Edit (shows the current effective value), click Save without changing anything | Toast `No changes to save`. No API call. | Previously silent — looked identical to a successful save with zero feedback. |
+| **Re-editing an already-overridden field**: open Edit on a field that already has an override | Shows the *override*, not the base value — editing seeds from `previewDisplayProperties` (base ⊕ active scenario overlay), not the base alone. | The GUI must never show a stale/wrong starting point for an edit. |
+| **Cross-node validation conflict**: e.g. set `pressure` on an `OutletSink`/boundary node when the model requires it declared on exactly one node | The edit still applies to this session's in-memory overlay, but the follow-up preview refresh fails; toast reads `Scenario "<id>" overlay saved, but it no longer previews cleanly: <STONE v2 error detail>`. | `loadPreview` catches its own error into `previewError` rather than rejecting; that field must be checked explicitly or the failure is silent. |
+| **Edit while calculating**: try to save a scenario-overlay edit while Run Sweep / Run Simulation is active | Blocked immediately: toast `Wait for the current calculation to finish before editing a scenario.` No API call. | A running sweep already captured its own overlay snapshot when it started, so this can't race it — but its in-flight results still reflect the pre-edit values, which would be confusing. |
 | **GUI edit while the scenario's YAML pane is already open** | The open pane's Monaco content updates to include the new override, without closing/reopening. | Was fetched once on open; now also refetches on `scenarioStore.revision` bump. |
 | **YAML-pane edit while the Properties panel has the same node selected** | Properties panel re-renders with the new value immediately. | Was only refreshing the scenario list, not `previewNodes`/`previewConnections`. |
 | **Unsaved YAML-pane edit + an unrelated scenario write elsewhere** | The pane's unsaved text is **not** clobbered — the dirty-guard (`value !== baseline`) skips the auto-refetch. | Mirrors `YamlPane`'s existing guard for the base config; verify by typing in the pane, then triggering a save from the Properties panel for the same scenario, and confirming the typed (unsaved) text survives. |
 | **Kind-less logical connection** (`source`+`target`, no type key, e.g. an inter-stage handoff) | Edited properties land directly on the item (`{id, source, target, logical: true}`), not nested under a type key. | Only ~half of connections have a type key; the other half are pure topology edges. |
-| **Connection edit** (e.g. a `MassFlowController`'s `mass_flow_rate`) | Same overlay-write path as nodes; lands under the connection's own stage list. | Verify this isn't a nodes-only code path — `isNode` branches at the call site, not inside the API. |
+| **Connection edit** (e.g. a `MassFlowController`'s `mass_flow_rate`) | Same overlay path as nodes. | Verify this isn't a nodes-only code path — `isNode` branches at the call site, not inside the API. |
 | **First-ever override on an empty overlay** (`scenarios: {<id>: {}}`) | Creates the stage-list key and entry from scratch. | The common case for a freshly authored scenario. |
 | **Re-editing an already-overridden entity** (a second field on the same node) | Merges into the *same* entry — does not duplicate the entity or wipe the first override. | `update_scenario_entity` finds-or-creates the entry by id before merging properties. |
 | **BASELINE**: delete button | A disabled `Ban` icon in the same slot (not hidden — hiding it misaligned the row against others), tooltip explains why. | BASELINE is the base config's own unmodified run, not an authored overlay — nothing to delete. |
-| **BASELINE**: edit | Pencil / "Edit YAML" opens the **full** base YAML pane, not the scoped overlay editor (which would 404 — BASELINE has no `scenarios.BASELINE` entry). | |
+| **BASELINE**: edit | Pencil / "Edit YAML" opens the **full** base YAML pane, not the scoped overlay editor. | |
+| **Run Sweep after unsaved edits** | The sweep sees every scenario's *current* in-memory overlay, including edits never explicitly "saved to disk" (there's no such action) — no extra step needed before Run Sweep. | Confirms the frontend sends `scenarioStore.overlays` in the sweep request body, not something the backend re-reads from a file. |
+| **Page reload after editing a scenario** | Every in-memory edit is gone — the page reseeds `scenarioStore.overlays` from the config's on-disk `scenarios:` block, which was never touched. | This is the intended tradeoff: "Download full YAML" is the explicit save step; a reload is not a silent-loss bug. |
 
 ## Common failures
 
 | Symptom | Cause | Fix |
 |---|---|---|
-| "Editing doesn't seem to register" — value never changes | A **prior** edit already broke this scenario's preview (see cross-node conflict above) and every subsequent `loadPreview` 422s | Check for an error toast on save; `curl .../api/scenarios/{id}/preview` directly to read the detail; fix or reset the offending override (`PATCH .../scenarios/{id}` with `{"yaml": "{}"}` to clear it entirely) |
+| "Editing doesn't seem to register" — value never changes | A **prior** edit already broke this scenario's preview (see cross-node conflict above) and every subsequent `loadPreview` 422s | Check for an error toast on save; the browser Network tab's `POST .../scenarios/{id}/preview` response body has the detail; fix or clear the offending field via the scenario's YAML pane |
 | "Edit YAML" button doesn't say `(scenario)` | No scenario is actually active, or BASELINE is | Confirm via `document.getElementById('scenario-<id>')`'s classes, or just re-click the row |
 | Scenarios pane not visible at all | Right sidebar collapsed (persisted) | Click the sidebar toggle, or `localStorage.setItem('boulder-layout', JSON.stringify({...JSON.parse(localStorage.getItem('boulder-layout')), rightCollapsed: false}))` then reload |
 | YAML pane / Properties panel stays stale after a save elsewhere | Frontend build predates the revision-triggered refetch fix | `npm run build`; hard-reload; confirm the served JS bundle hash changed |
-| `PATCH .../entities/{id}` → 405 | Backend route added to source but the **Python server process** wasn't restarted (unlike frontend static assets, route registration only happens at process startup) | Kill and restart the `bloc`/`boulder` process |
+| A scenario edit "disappeared" | Page was reloaded — see the edge case above; this is expected, not a bug | Re-apply the edit, or use "Download full YAML" before reloading next time |
+| `PATCH .../entities/{id}` → 405 or unexpected response shape | Backend route source changed but the **Python server process** wasn't restarted (unlike frontend static assets, route registration only happens at process startup) | Kill and restart the `bloc`/`boulder` process |
 
 ## Further reading
 
 - [boulder-gui/SKILL.md](../boulder-gui/SKILL.md) — general server startup, canvas selection, results tabs
-- `boulder/scenario_editor.py` — `update_scenario_entity`, `_entity_location`
-- `boulder/api/routes/scenarios.py` — the entity-patch route
+- `boulder/scenario_editor.py` — pure overlay transforms (`create_scenario`, `update_scenario_entity`, `_entity_location`, `render_full_yaml`)
+- `boulder/api/routes/scenarios.py` — the stateless scenario routes
+- `boulder/api/routes/sweep.py` — Run Sweep's in-process loop over `SimulationWorker`
+- `frontend/src/stores/scenarioStore.ts` — `overlays`, the session's source of truth
 - `frontend/src/components/panels/PropertiesPanel.tsx` — scenario-aware `handleSave`
-- `frontend/src/components/panels/ScenarioYamlPane.tsx` — the docked overlay editor
+- `frontend/src/components/panels/ScenarioYamlPane.tsx` — the docked overlay editor + "Download full YAML"

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -152,9 +152,9 @@ Two **profiles** of this one encoding:
 |---|---|---|
 | File | `<cache>/<fp>/result.h5` (+ `meta.json` carries config_snapshot) | `results/<map>_scenarios.h5` |
 | Holds | one result (1..n reactors, groups `r0`,`r1`,…) | many single-reactor results, one group per scenario |
-| Producer / reader | `result_cache.save_result` / `load_result*` | `sweep_runner.py` (or a host `run_sweep.py`) / `api/routes/scenarios.py` |
+| Producer / reader | `result_cache.save_result` / `load_result*` | `api/routes/sweep.py` (GUI) or `sweep_runner.py` (CLI) / `api/routes/scenarios.py` |
 
-#### Run-set expansion and the generic sweep runner
+#### Run-set expansion and the sweep runners (GUI in-process, CLI out-of-process)
 
 `runset.py` is the reference implementation of the STONE `scenarios:`/`sweep:` semantics
 (STONE_SPECIFICATIONS.md §14): `expand_scenarios` (union run-set, id-keyed `deep_merge`, sweep-path
@@ -163,14 +163,21 @@ endpoint uses — same module, so the count can never drift from the expansion),
 `sweep_axis_values`, `resolve_store_path`, and `load_yaml_with_inheritance` (`from:` chains;
 `scenarios:` is deliberately not inherited, `sweep:` is).
 
-`sweep_runner.py` (`python -m boulder.sweep_runner <config.yaml>`) is the generic out-of-process
-runner behind the Run Sweep button: expand → skip runs whose per-scenario fingerprint is unchanged
-(incremental cache; `BOULDER_NO_CACHE` recreates the store) → solve via `DualCanteraConverter` →
-`write_payload` one group per scenario → prune groups whose id left the run-set. Host packages that
-need process setup (mechanism search paths), mechanism-path resolution, or extra per-scenario KPI
-attrs register their own thin wrapper via `plugins.sweep_runner` and pass the `setup` /
-`resolve_mechanism` / `scenario_attrs` hooks to `sweep_runner.run`; sweep-id naming is customized via
-`plugins.sweep_symbols`.
+The GUI's Run Sweep button (`api/routes/sweep.py`) runs **in-process**, in a background thread:
+`expand_scenarios` the caller's base-config snapshot ⊕ its current `scenarios` (the frontend's
+in-memory `scenarioStore.overlays` — scenario authoring never touches disk, see
+`boulder/scenario_editor.py`) → skip runs whose per-scenario fingerprint is unchanged (incremental
+cache; `no_cache` in the request recreates the store) → solve each one through the exact same
+`SimulationWorker` a plain "Run Simulation" uses (no separate solve implementation) →
+`write_payload` one group per scenario → prune groups whose id left the run-set.
+
+`sweep_runner.py` (`python -m boulder.sweep_runner <config.yaml>`) is a separate, disk-based,
+out-of-process runner for headless/CLI use — the GUI route above does not call it. Host packages
+needing process setup (mechanism search paths), mechanism-path resolution, or extra per-scenario KPI
+attrs for a *CLI* run pass their own `setup` / `resolve_mechanism` / `scenario_attrs` hooks directly to
+`sweep_runner.run`; sweep-id naming is customized via `plugins.sweep_symbols`. `plugins.sweep_runner`
+(a subprocess-argv override) is no longer consulted by anything — it backed only the GUI route's old
+out-of-process invocation, which the in-process rewrite above replaced.
 
 Both call `payload_store.gui_payload_from_solution_array` to rebuild the same `SimulationResults` the
 GUI renders. `CACHE_VERSION` (in `result_cache.py`) gates cache entries; `PAYLOAD_SCHEMA` (== the root

--- a/boulder/api/routes/scenarios.py
+++ b/boulder/api/routes/scenarios.py
@@ -29,7 +29,7 @@ except ImportError:  # pragma: no cover - environment-dependent
     h5py = None  # type: ignore[assignment]
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import StreamingResponse
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 router = APIRouter()
 
@@ -91,29 +91,44 @@ def _scenario_entries(h5_path: Path) -> List[Dict[str, Any]]:
     return entries
 
 
-def _authored_scenario_ids(request: Request) -> List[str]:
-    """Return every scenario id currently in the config's `scenarios:` mapping.
+def _base_scenarios_snapshot(request: Request) -> Dict[str, Any]:
+    """Return the ``scenarios:`` block as loaded at startup — frozen from then on.
 
-    Unlike the HDF5-derived list below (only scenarios a sweep has actually
-    computed), this reflects the source YAML directly — so a scenario that
-    was just created/edited but never swept still shows up, e.g. as a clone
-    base in the Add Scenario modal.
+    This is the *one* place scenario overlays are ever read from disk: the
+    initial seed for the frontend's own overlay state (``scenarioStore``),
+    exactly like ``configStore.config`` is seeded once from ``GET
+    /configs/preloaded`` and never re-read after. Every scenario authoring
+    route past this point is a pure function over whatever overlays map the
+    caller sends — nothing here is written back to disk or to ``app.state``.
     """
-    cfg_path = _config_path(request)
-    if cfg_path is None or not cfg_path.is_file():
-        return []
+    raw = _raw_base_config(request) or {}
+    overlays = raw.get("scenarios") or {}
+    return {k: dict(v or {}) for k, v in overlays.items()}
+
+
+def _authored_scenario_ids(overlays: Dict[str, Any]) -> List[str]:
     from ...scenario_editor import list_scenario_ids
 
-    return list_scenario_ids(cfg_path)
+    return list_scenario_ids(overlays)
 
 
 @router.get("")
 async def list_scenarios(request: Request) -> Dict[str, Any]:
-    """List the scenarios in the active store (fast — reads attrs only)."""
+    """List the scenarios in the active store (fast — reads attrs only).
+
+    Also seeds the frontend's scenario-overlay state via ``authored_overlays``
+    — see :func:`_base_scenarios_snapshot`.
+    """
     store = _store_path(request)
-    authored_ids = _authored_scenario_ids(request)
+    authored_overlays = _base_scenarios_snapshot(request)
+    authored_ids = _authored_scenario_ids(authored_overlays)
     if h5py is None or store is None or not store.is_file():
-        return {"available": False, "scenarios": [], "authored_ids": authored_ids}
+        return {
+            "available": False,
+            "scenarios": [],
+            "authored_ids": authored_ids,
+            "authored_overlays": authored_overlays,
+        }
     root = _root_attrs(store)
     return {
         "available": True,
@@ -123,6 +138,7 @@ async def list_scenarios(request: Request) -> Dict[str, Any]:
         "created_at": root.get("created_at"),
         "scenarios": _scenario_entries(store),
         "authored_ids": authored_ids,
+        "authored_overlays": authored_overlays,
     }
 
 
@@ -153,30 +169,49 @@ async def get_scenario(scenario_id: str, request: Request) -> Dict[str, Any]:
 
 
 # --------------------------------------------------------------------------- #
-# Scenario authoring — create/edit/delete a ``scenarios:`` overlay on disk.
+# Scenario authoring — create/edit/delete a scenario overlay, in memory only.
 #
-# Unlike the read routes above (which serve precomputed HDF5 trajectories),
-# these operate on the *source* config file (``app.state.preloaded_config_path``)
-# so a newly created or edited scenario is picked up by the next Run Sweep.
-# Only that scenario's subtree is touched on disk.
+# Nothing below writes to disk or to `app.state`: every route is a pure
+# transform over whatever overlays map the caller (the frontend's
+# `scenarioStore`) sends in the request body, mirroring how `/configs/parse`
+# already treats the base config (validate/compute, never persist). The only
+# way a user gets a scenario onto disk is the Scenario YAML pane's "Download
+# full YAML" button (`render_full_yaml` below).
 # --------------------------------------------------------------------------- #
 
 
 class CreateScenarioRequest(BaseModel):
+    overlays: Dict[str, Any] = Field(default_factory=dict)
     scenario_id: str
     base_scenario_id: Optional[str] = None
+    description: Optional[str] = None
+
+
+class RenderScenarioRequest(BaseModel):
+    overlay: Dict[str, Any] = Field(default_factory=dict)
+
+
+class PreviewScenarioRequest(BaseModel):
+    overlay: Dict[str, Any] = Field(default_factory=dict)
 
 
 class UpdateScenarioRequest(BaseModel):
+    overlays: Dict[str, Any] = Field(default_factory=dict)
     yaml: str
 
 
 class UpdateScenarioEntityRequest(BaseModel):
+    overlays: Dict[str, Any] = Field(default_factory=dict)
     properties: Dict[str, Any]
 
 
 class RenameScenarioRequest(BaseModel):
+    overlays: Dict[str, Any] = Field(default_factory=dict)
     new_id: str
+
+
+class DeleteScenarioRequest(BaseModel):
+    overlays: Dict[str, Any] = Field(default_factory=dict)
 
 
 def _config_path(request: Request) -> Optional[Path]:
@@ -184,58 +219,15 @@ def _config_path(request: Request) -> Optional[Path]:
     return Path(raw) if raw else None
 
 
-def _require_config_path(request: Request) -> Path:
-    cfg_path = _config_path(request)
-    if cfg_path is None:
-        raise HTTPException(
-            status_code=400,
-            detail="No configuration file loaded — scenarios can only be "
-            "authored against a config Boulder was started with (a file path, "
-            "not an uploaded/pasted config).",
-        )
-    return cfg_path
-
-
-def _reload_preloaded_state(request: Request, cfg_path: Path) -> None:
-    """Refresh the in-memory preloaded config after an on-disk scenario edit.
-
-    Mirrors the subset of the app's startup load that Run Sweep and the config
-    endpoints read (``preloaded_raw`` keeps ``scenarios:``/``sweep:`` for the
-    Run Sweep button; ``preloaded_config``/``preloaded_yaml`` back the editor
-    panel). Cached simulation results are untouched — editing a scenario
-    doesn't invalidate the base config's last solve.
-    """
-    from ...runner import BoulderRunner
-
-    runner_cls = getattr(request.app.state, "runner_class", None) or BoulderRunner
-    raw = runner_cls.load(str(cfg_path))
-    request.app.state.preloaded_raw = raw
-    with open(cfg_path, "r", encoding="utf-8") as f:
-        request.app.state.preloaded_yaml = f.read()
-    normalized = runner_cls.normalize(raw)
-    request.app.state.preloaded_config = runner_cls.validate(normalized)
-
-
-@router.get("/{scenario_id}/source")
-async def get_scenario_source(scenario_id: str, request: Request) -> Dict[str, Any]:
-    """Return one scenario overlay's raw YAML text (for the scoped editor)."""
-    cfg_path = _require_config_path(request)
-    try:
-        from ...scenario_editor import ScenarioEditError, read_scenario
-
-        yaml_text = read_scenario(cfg_path, scenario_id)
-    except ScenarioEditError as exc:
-        raise HTTPException(status_code=404, detail=str(exc)) from exc
-    return {"scenario_id": scenario_id, "yaml": yaml_text}
-
-
 def _raw_base_config(request: Request) -> Optional[Dict[str, Any]]:
     """Return the inheritance-resolved base config dict (keeps `scenarios:`/`sweep:`).
 
-    Prefers the in-memory snapshot (kept fresh by `_reload_preloaded_state` after
-    every scenario write); falls back to a fresh disk load so the preview route
-    also works against a config path set directly (e.g. in tests) without going
-    through a scenario CRUD call first.
+    Prefers the in-memory startup snapshot (`app.state.preloaded_raw`); falls
+    back to a fresh disk load so this also works against a config path set
+    directly (e.g. in tests) without a preload having happened yet. This is a
+    read-only structural reference for `_entity_location`/preview/render — not
+    kept in sync with scenario edits, which live entirely in the caller's
+    overlays map.
     """
     raw = getattr(request.app.state, "preloaded_raw", None)
     if raw:
@@ -249,34 +241,51 @@ def _raw_base_config(request: Request) -> Optional[Dict[str, Any]]:
     return runner_cls.load(str(cfg_path))
 
 
-@router.get("/{scenario_id}/preview")
-async def get_scenario_preview(scenario_id: str, request: Request) -> Dict[str, Any]:
+def _require_base_raw(request: Request) -> Dict[str, Any]:
+    raw = _raw_base_config(request)
+    if not raw:
+        raise HTTPException(status_code=404, detail="No configuration loaded")
+    return raw
+
+
+@router.post("/{scenario_id}/source")
+async def get_scenario_source(
+    scenario_id: str, body: RenderScenarioRequest
+) -> Dict[str, Any]:
+    """Render one scenario overlay's YAML text (for the scoped editor).
+
+    Stateless: *body.overlay* is whatever the caller currently has for this
+    scenario id (its own `scenarioStore.overlays[scenario_id]`) — there is no
+    server-side copy to fetch from.
+    """
+    from ...scenario_editor import _overlay_yaml_text
+
+    return {"scenario_id": scenario_id, "yaml": _overlay_yaml_text(body.overlay)}
+
+
+@router.post("/{scenario_id}/preview")
+async def get_scenario_preview(
+    scenario_id: str, body: PreviewScenarioRequest, request: Request
+) -> Dict[str, Any]:
     """Return the effective node/connection properties for one authored scenario.
 
     Lets the Inputs pane show a scenario's parameter overrides (e.g. a reactor's
     ``length``) the moment it's selected — even before Run Sweep has produced a
     trajectory for it. Mirrors :func:`boulder.runset.expand_scenarios`'s base ⊕
-    overlay merge for a single scenario id, using the overlay's own values as-is:
-    an inner ``sweep:`` block's axis values are not expanded here (this is a
-    static preview of the authored overlay, not a resolved run-set point).
+    overlay merge for a single scenario id, using *body.overlay* (the caller's
+    current in-memory overlay) as-is: an inner ``sweep:`` block's axis values
+    are not expanded here (this is a static preview, not a resolved run-set
+    point), and BASELINE is previewed by sending an empty overlay.
     """
-    raw = _raw_base_config(request)
-    if not raw:
-        raise HTTPException(status_code=404, detail="No configuration loaded")
+    raw = _require_base_raw(request)
 
     from ...runner import BoulderRunner
-    from ...runset import BASELINE_SCENARIO_ID, deep_merge
-
-    scenario_map = raw.get("scenarios") or {}
-    if scenario_id != BASELINE_SCENARIO_ID and scenario_id not in scenario_map:
-        raise HTTPException(status_code=404, detail=f"Unknown scenario {scenario_id!r}")
+    from ...runset import deep_merge
 
     base_clean = {
         k: v for k, v in raw.items() if k not in ("scenarios", "sweep", "sweeps")
     }
-    overlay = (
-        dict(scenario_map[scenario_id]) if scenario_id != BASELINE_SCENARIO_ID else {}
-    )
+    overlay = dict(body.overlay)
     overlay.pop("sweep", None)
     overlay.pop("sweeps", None)
     merged = deep_merge(base_clean, overlay)
@@ -297,38 +306,54 @@ async def get_scenario_preview(scenario_id: str, request: Request) -> Dict[str, 
     }
 
 
-@router.post("")
-async def create_scenario(
-    body: CreateScenarioRequest, request: Request
+@router.post("/{scenario_id}/render-full")
+async def render_full_yaml(
+    scenario_id: str, body: RenderScenarioRequest, request: Request
 ) -> Dict[str, Any]:
-    """Create a new scenario overlay — blank, or cloned from an existing one."""
-    cfg_path = _require_config_path(request)
-    try:
-        from ...scenario_editor import ScenarioEditError
-        from ...scenario_editor import create_scenario as _create
+    """Return the base config deep-merged with one scenario's overlay, as full YAML text.
 
-        yaml_text = _create(cfg_path, body.scenario_id, body.base_scenario_id)
+    Backs the Scenario YAML pane's "Download full YAML" button — the one
+    sanctioned way to get an edited scenario onto disk now that nothing here
+    auto-persists.
+    """
+    raw = _require_base_raw(request)
+    from ...scenario_editor import render_full_yaml as _render
+
+    return {"scenario_id": scenario_id, "yaml": _render(raw, body.overlay)}
+
+
+@router.post("")
+async def create_scenario(body: CreateScenarioRequest) -> Dict[str, Any]:
+    """Create a new scenario overlay — blank, or cloned from an existing one."""
+    from ...scenario_editor import ScenarioEditError
+    from ...scenario_editor import create_scenario as _create
+
+    try:
+        new_overlays, yaml_text = _create(
+            body.overlays, body.scenario_id, body.base_scenario_id, body.description
+        )
     except ScenarioEditError as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from exc
-    _reload_preloaded_state(request, cfg_path)
-    return {"scenario_id": body.scenario_id, "yaml": yaml_text}
+    return {
+        "scenario_id": body.scenario_id,
+        "yaml": yaml_text,
+        "overlays": new_overlays,
+    }
 
 
 @router.patch("/{scenario_id}")
 async def update_scenario(
-    scenario_id: str, body: UpdateScenarioRequest, request: Request
+    scenario_id: str, body: UpdateScenarioRequest
 ) -> Dict[str, Any]:
-    """Save edits to a scenario overlay's YAML text."""
-    cfg_path = _require_config_path(request)
-    try:
-        from ...scenario_editor import ScenarioEditError
-        from ...scenario_editor import update_scenario as _update
+    """Apply edits to a scenario overlay's YAML text."""
+    from ...scenario_editor import ScenarioEditError
+    from ...scenario_editor import update_scenario as _update
 
-        yaml_text = _update(cfg_path, scenario_id, body.yaml)
+    try:
+        new_overlays, yaml_text = _update(body.overlays, scenario_id, body.yaml)
     except ScenarioEditError as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from exc
-    _reload_preloaded_state(request, cfg_path)
-    return {"scenario_id": scenario_id, "yaml": yaml_text}
+    return {"scenario_id": scenario_id, "yaml": yaml_text, "overlays": new_overlays}
 
 
 @router.patch("/{scenario_id}/entities/{entity_id}")
@@ -346,33 +371,37 @@ async def update_scenario_entity(
     base config itself (see ``scenario_editor._entity_location``) — the
     caller only needs the id.
     """
-    cfg_path = _require_config_path(request)
-    try:
-        from ...scenario_editor import ScenarioEditError
-        from ...scenario_editor import update_scenario_entity as _update_entity
+    raw = _require_base_raw(request)
+    from ...scenario_editor import ScenarioEditError
+    from ...scenario_editor import update_scenario_entity as _update_entity
 
-        yaml_text = _update_entity(cfg_path, scenario_id, entity_id, body.properties)
+    try:
+        new_overlays, yaml_text = _update_entity(
+            body.overlays, raw, scenario_id, entity_id, body.properties
+        )
     except ScenarioEditError as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from exc
-    _reload_preloaded_state(request, cfg_path)
-    return {"scenario_id": scenario_id, "id": entity_id, "yaml": yaml_text}
+    return {
+        "scenario_id": scenario_id,
+        "id": entity_id,
+        "yaml": yaml_text,
+        "overlays": new_overlays,
+    }
 
 
 @router.patch("/{scenario_id}/rename")
 async def rename_scenario(
-    scenario_id: str, body: RenameScenarioRequest, request: Request
+    scenario_id: str, body: RenameScenarioRequest
 ) -> Dict[str, Any]:
-    """Rename a scenario's id (its ``scenarios:`` mapping key)."""
-    cfg_path = _require_config_path(request)
-    try:
-        from ...scenario_editor import ScenarioEditError
-        from ...scenario_editor import rename_scenario as _rename
+    """Rename a scenario's id (its overlays-map key)."""
+    from ...scenario_editor import ScenarioEditError
+    from ...scenario_editor import rename_scenario as _rename
 
-        _rename(cfg_path, scenario_id, body.new_id)
+    try:
+        new_overlays = _rename(body.overlays, scenario_id, body.new_id)
     except ScenarioEditError as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from exc
-    _reload_preloaded_state(request, cfg_path)
-    return {"ok": True, "scenario_id": body.new_id}
+    return {"ok": True, "scenario_id": body.new_id, "overlays": new_overlays}
 
 
 @router.post("/clear-cache")
@@ -381,8 +410,8 @@ async def clear_scenario_cache(request: Request) -> Dict[str, Any]:
 
     Deletes the whole HDF5 store file — the same thing ``--no-cache`` does
     before a sweep — so the next Run Sweep recomputes every scenario from
-    scratch. Scenario *definitions* in the config are untouched; only their
-    precomputed results disappear until then.
+    scratch. This only ever touched the *results cache*, not any scenario
+    definition, so it's unaffected by scenario authoring going in-memory.
     """
     store = _store_path(request)
     cleared = store is not None and store.is_file()
@@ -392,26 +421,31 @@ async def clear_scenario_cache(request: Request) -> Dict[str, Any]:
 
 
 @router.delete("/{scenario_id}")
-async def delete_scenario(scenario_id: str, request: Request) -> Dict[str, Any]:
+async def delete_scenario(
+    scenario_id: str, body: DeleteScenarioRequest, request: Request
+) -> Dict[str, Any]:
     """Delete a scenario overlay and purge its cached trajectory, if any.
 
-    Both happen immediately: the definition is removed from the config's
-    ``scenarios:`` mapping, and the matching HDF5 group (if the active store
-    has one) is deleted right away — not left for the next Run Sweep to
-    notice and prune. ``cache_purged`` in the response tells the caller
-    whether there was actually a cached result to clear.
+    The overlay is removed from the returned overlays map immediately; the
+    matching HDF5 group (if the active store has one) is deleted right away
+    too — not left for the next Run Sweep to notice and prune. ``cache_purged``
+    in the response tells the caller whether there was actually a cached
+    result to clear.
     """
-    cfg_path = _require_config_path(request)
-    try:
-        from ...scenario_editor import ScenarioEditError
-        from ...scenario_editor import delete_scenario as _delete
+    from ...scenario_editor import ScenarioEditError
+    from ...scenario_editor import delete_scenario as _delete
 
-        _delete(cfg_path, scenario_id)
+    try:
+        new_overlays = _delete(body.overlays, scenario_id)
     except ScenarioEditError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     cache_purged = _purge_cached_group(_store_path(request), scenario_id)
-    _reload_preloaded_state(request, cfg_path)
-    return {"ok": True, "scenario_id": scenario_id, "cache_purged": cache_purged}
+    return {
+        "ok": True,
+        "scenario_id": scenario_id,
+        "cache_purged": cache_purged,
+        "overlays": new_overlays,
+    }
 
 
 # --------------------------------------------------------------------------- #

--- a/boulder/api/routes/sweep.py
+++ b/boulder/api/routes/sweep.py
@@ -1,31 +1,46 @@
-"""Run-sweep API: execute a config's ``sweeps:`` as a background batch job.
+"""Run-sweep API: execute a config's ``scenarios:``/``sweep:`` run-set.
 
-A sweep is a heavy, host-specific batch (build + solve every scenario, write the
-scenario store), so it is run out-of-process by invoking a ``run_sweep.py`` script
-located next to the config. Progress is parsed from the subprocess stdout
-(``scenario N/M``); the frontend polls :func:`sweep_status` and refreshes the
-Scenario Pane on completion.
+Runs in-process, in a background thread, reusing the exact same solve path
+``/api/simulations`` uses for a single run (:class:`~boulder.simulation_worker.
+SimulationWorker`) — one scenario after another, not a second bespoke
+pipeline. Progress is written into ``app.state.sweep_job`` as it goes; the
+frontend polls :func:`sweep_status` and refreshes the Scenario Pane on
+completion.
+
+The base config comes from the one-time startup snapshot
+(``app.state.preloaded_raw``, unchanged for the process lifetime); the
+scenario overlays come from the request body — the caller's (``scenarioStore``)
+current in-memory overlays map, since scenario authoring no longer writes to
+disk (see ``boulder.scenario_editor``). Only the *results* — the HDF5 scenario
+store — are written to disk here, same as before.
 
 Endpoints (prefix ``/api/sweep``):
   GET  ""        -> availability / scenario count / can_run / running
-  POST "/run"    -> start the sweep subprocess (409 if one is already running)
+  POST "/run"    -> start the sweep (409 if one is already running)
   GET  "/status" -> current job status (idle | running | done | error)
 """
 
 from __future__ import annotations
 
-import os
-import re
-import subprocess
-import sys
 import threading
+import time
 from pathlib import Path
 from typing import Any, Dict, Optional
 
+import h5py
 from fastapi import APIRouter, HTTPException, Request
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
+from ...cantera_converter import DualCanteraConverter, get_plugins
+from ...payload_store import write_payload
 from ...runset import resolve_store_path, run_set_size, sweeps_of
+from ...simulation_worker import SimulationWorker
+from ...sweep_runner import (
+    _mechanism_of,
+    existing_fingerprints,
+    prepare_scenario,
+    prune_stale_groups,
+)
 
 __all__ = ["has_run_set", "resolve_store_path", "router"]
 
@@ -35,60 +50,25 @@ router = APIRouter()
 class SweepRunRequest(BaseModel):
     """Body for ``POST /run``. Defaults match the plain "Run Sweep" click."""
 
-    #: Force a full recompute: set BOULDER_NO_CACHE=1 for the subprocess so a
-    #: cache-aware host runner discards its collection store and re-solves
-    #: every scenario instead of skipping unchanged ones.
+    #: The caller's current in-memory scenario overlays map
+    #: (``{scenario_id: overlay_dict}``) — see ``boulder.scenario_editor``.
+    scenarios: Dict[str, Any] = Field(default_factory=dict)
+    #: Force a full recompute: discard the collection store and re-solve every
+    #: scenario instead of skipping ones whose fingerprint is unchanged.
     no_cache: bool = False
-
-
-_SCENARIO_RE = re.compile(r"scenario\s+(\d+)\s*/\s*(\d+)", re.IGNORECASE)
-#: Captures the scenario id `sweep_runner.run()` already prints in parens,
-#: e.g. "scenario 3/8 (cold_feed)" or "scenario 3/8 (cold_feed): cached, skipped".
-_SCENARIO_ID_RE = re.compile(r"scenario\s+\d+\s*/\s*\d+\s*\(([^)]+)\)", re.IGNORECASE)
-_SCENARIO_SKIP_RE = re.compile(
-    r"scenario\s+\d+\s*/\s*\d+\s*\([^)]+\)\s*:\s*cached,\s*skipped", re.IGNORECASE
-)
-#: `boulder.staged_solver`'s per-stage progress log line, e.g.
-#: "Staged solve: stage 'default' (1/3, 3 reactors)".
-_STAGE_RE = re.compile(
-    r"Staged solve:\s*stage\s+'([^']*)'\s*\((\d+)\s*/\s*(\d+)", re.IGNORECASE
-)
-_RUNNER_NAME = "run_sweep.py"
-
-
-# Run-set sizing lives in boulder.runset (the reference implementation of the
-# scenarios:/sweep: union semantics) — the old local mirror is gone.
-_run_set_size = run_set_size
-
-
-def _local_runner_path_for(config_path: Optional[str]) -> Optional[Path]:
-    """Return the ``run_sweep.py`` next to *config_path*, if present."""
-    if not config_path:
-        return None
-    local = Path(config_path).resolve().parent / _RUNNER_NAME
-    return local if local.is_file() else None
 
 
 def has_run_set(raw: Dict[str, Any], config_path: Optional[str]) -> bool:
     """Return whether *raw* (the inheritance-resolved config) declares a run-set.
 
-    True when it has an inline ``scenarios:``/``sweep:``/``sweeps:`` block, or a
-    ``run_sweep.py`` sits next to the config (a host-defined run-set: the runner
-    script decides the cases — e.g. adaptive/bisection sweeps a static ``sweep:``
-    block can't express). Pure function of ``(raw, config_path)`` so both the
-    request-scoped sweep routes and the app-startup lifespan can share one
-    detection rule instead of re-deciding "is this a sweep config?" twice.
+    True when it has an inline ``scenarios:``/``sweep:``/``sweeps:`` block.
+    Pure function of ``raw`` so both the request-scoped sweep routes and the
+    app-startup lifespan can share one detection rule. ``config_path`` is
+    accepted for signature compatibility with existing callers; it is not
+    otherwise used (Run Sweep runs in-process now — there is no external
+    runner script to look for next to the config).
     """
-    if raw.get("scenarios") or sweeps_of(raw):
-        return True
-    return _local_runner_path_for(config_path) is not None
-
-
-def _local_runner_path(request: Request) -> Optional[Path]:
-    """Return the ``run_sweep.py`` next to the preloaded config, if present."""
-    return _local_runner_path_for(
-        getattr(request.app.state, "preloaded_config_path", None)
-    )
+    return bool(raw.get("scenarios") or sweeps_of(raw))
 
 
 def _has_run_set(request: Request) -> bool:
@@ -101,6 +81,17 @@ def _raw(request: Request) -> Dict[str, Any]:
     return getattr(request.app.state, "preloaded_raw", None) or {}
 
 
+def _merged_raw(request: Request, scenarios: Dict[str, Any]) -> Dict[str, Any]:
+    """Return the base config snapshot with *scenarios* (the caller's overlays) merged in.
+
+    The base structure itself is the frozen startup snapshot — not re-read or
+    kept in sync with base-network edits, same as every other scenario route
+    in this module (see ``boulder.api.routes.scenarios._raw_base_config``).
+    """
+    base = {k: v for k, v in _raw(request).items() if k != "scenarios"}
+    return {**base, "scenarios": scenarios}
+
+
 def _store_path(request: Request) -> Optional[Path]:
     """Return the collection store the run-set writes to (request-scoped wrapper)."""
     return resolve_store_path(
@@ -108,56 +99,31 @@ def _store_path(request: Request) -> Optional[Path]:
     )
 
 
-def _runner_command(request: Request) -> Optional[Dict[str, Any]]:
-    """Resolve how to run the run-set.
-
-    A ``run_sweep.py`` next to the config, or a host-registered ``sweep_runner``
-    command. Returns ``{argv, cwd}`` or None.
-    """
-    cfg_path = getattr(request.app.state, "preloaded_config_path", None)
-    if not cfg_path:
-        return None
-    cfg = Path(cfg_path).resolve()
-    local = cfg.parent / _RUNNER_NAME
-    if local.is_file():
-        return {
-            "argv": [sys.executable, _RUNNER_NAME, cfg.name, "--no-plot"],
-            "cwd": str(cfg.parent),
-        }
-    from ...cantera_converter import get_plugins  # noqa: PLC0415
-
-    runner = getattr(get_plugins(), "sweep_runner", None)
-    if runner:
-        return {
-            "argv": [sys.executable, *runner, str(cfg), "--no-plot"],
-            "cwd": str(cfg.parent),
-        }
-    return None
-
-
 @router.get("")
 async def sweep_info(request: Request) -> Dict[str, Any]:
-    """Report whether a run-set (scenarios and/or sweep) can be run."""
+    """Report whether a run-set (scenarios and/or sweep) can be run.
+
+    Reflects the config's startup snapshot — a scenario created in this
+    session but not yet included in a run request isn't counted here (purely
+    informational; the actual run in :func:`sweep_run` always uses whatever
+    overlays the caller sends).
+    """
     has = _has_run_set(request)
-    n = _run_set_size(_raw(request))
-    cmd = _runner_command(request)
+    n = run_set_size(_raw(request))
     job = getattr(request.app.state, "sweep_job", None)
     running = bool(job and job.get("status") == "running")
 
     if not has:
         reason = "No scenarios or sweep in this config"
-    elif cmd is None:
-        reason = "No scenario runner available"
     elif n > 0:
         reason = f"Run {n} scenarios"
     else:
-        # Host-defined run-set (run_sweep.py decides the cases).
-        reason = f"Run the scenario sweep ({_RUNNER_NAME})"
+        reason = "Run the scenario sweep"
 
     return {
         "available": has,
         "n_scenarios": n,
-        "can_run": has and cmd is not None,
+        "can_run": has,
         "reason": reason,
         "running": running,
         # ``--sweep`` GUI mode → frontend defaults the split button to Run Sweep.
@@ -171,12 +137,13 @@ async def sweep_info(request: Request) -> Dict[str, Any]:
 async def sweep_run(
     request: Request, body: SweepRunRequest = SweepRunRequest()
 ) -> Dict[str, Any]:
-    """Start the run-set subprocess for the preloaded config.
+    """Run the run-set in-process, one scenario at a time.
 
     ``no_cache=true`` forces every scenario to re-solve from scratch.
     """
-    cmd = _runner_command(request)
-    if not _has_run_set(request) or cmd is None:
+    raw = _merged_raw(request, body.scenarios)
+    total = run_set_size(raw)
+    if total == 0:
         raise HTTPException(
             status_code=400, detail="No runnable run-set for this config"
         )
@@ -185,12 +152,16 @@ async def sweep_run(
     if job and job.get("status") == "running":
         raise HTTPException(status_code=409, detail="A sweep is already running")
 
-    total = _run_set_size(_raw(request))
     # Point the server at the store the run-set writes so the Scenario Pane shows
     # the results on refresh — even when the config declares no scenario_store.
-    store = _store_path(request)
-    if store is not None:
-        request.app.state.scenario_store_path = str(store)
+    store = resolve_store_path(
+        raw, getattr(request.app.state, "preloaded_config_path", None)
+    )
+    if store is None:
+        raise HTTPException(
+            status_code=400, detail="Could not resolve a scenario store path"
+        )
+    request.app.state.scenario_store_path = str(store)
     state: Dict[str, Any] = {
         "status": "running",
         "current": 0,
@@ -200,94 +171,142 @@ async def sweep_run(
         # Keyed by scenario id, e.g. {"cold_feed": {"stage": 1, "stage_total": 3}}.
         # A scenario id's presence here *is* "currently being solved" — a
         # deliberate map rather than a single "current scenario" scalar so a
-        # future parallel sweep runner can hold more than one entry at once
-        # without changing this shape.
+        # future parallel sweep could hold more than one entry at once without
+        # changing this shape.
         "scenario_progress": {},
-        # Most recent non-empty stdout line from the runner, verbatim — the
-        # frontend shows it under the "Calculating…" spinner so a long solve
-        # says *what* it is doing, not just that it is busy.
+        # Most recent progress line, verbatim — the frontend shows it under
+        # the "Calculating…" spinner so a long solve says *what* it is doing.
         "last_line": None,
     }
     request.app.state.sweep_job = state
-    # Surface on the server console by default — at least that the run started.
-    cache_note = " (no-cache: re-solving everything)" if body.no_cache else ""
-    print(
-        f"[sweep] starting {total} run(s){cache_note}: {' '.join(cmd['argv'])}",
-        flush=True,
-    )
+    print(f"[sweep] starting {total} run(s)", flush=True)
 
     def _worker() -> None:
         try:
-            env = os.environ.copy()
-            if body.no_cache:
-                env["BOULDER_NO_CACHE"] = "1"
-            proc = subprocess.Popen(
-                cmd["argv"],
-                cwd=cmd["cwd"],
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
-                text=True,
-                bufsize=1,
-                env=env,
-            )
-            tail: list[str] = []
-            assert proc.stdout is not None
-            for raw_line in proc.stdout:
-                line = raw_line.rstrip()
-                match = _SCENARIO_RE.search(line)
-                if match:
-                    state["current"] = int(match.group(1))
-                    state["total"] = int(match.group(2))
-                    state["message"] = line.strip()
-                    if _SCENARIO_SKIP_RE.search(line):
-                        # Cache hit: instantaneous, never "calculating".
-                        state["scenario_progress"] = {}
-                    else:
-                        id_match = _SCENARIO_ID_RE.search(line)
-                        sid = id_match.group(1).strip() if id_match else None
-                        # Serial today: one scenario in flight, so replace the
-                        # whole map. A parallel runner would add/remove keys
-                        # here instead of replacing.
-                        state["scenario_progress"] = (
-                            {
-                                sid: {
-                                    "stage": None,
-                                    "stage_total": None,
-                                    "stage_id": None,
-                                }
-                            }
-                            if sid
-                            else {}
-                        )
-                else:
-                    stage_match = _STAGE_RE.search(line)
-                    if stage_match:
-                        for progress in state["scenario_progress"].values():
-                            progress["stage_id"] = stage_match.group(1)
-                            progress["stage"] = int(stage_match.group(2))
-                            progress["stage_total"] = int(stage_match.group(3))
-                if line:
+            from ...runset import expand_scenarios
+
+            store.parent.mkdir(parents=True, exist_ok=True)
+            if body.no_cache and store.exists():
+                store.unlink()
+            cached_fps = {} if body.no_cache else existing_fingerprints(store)
+
+            runs = expand_scenarios(raw)
+            run_ids = {sid for sid, _ in runs}
+            mechanism = _mechanism_of(raw)
+            n_cached = 0
+            for i, (sid, cfg) in enumerate(runs):
+                config, mech_name, fingerprint = prepare_scenario(cfg, None)
+                label = str((cfg.get("metadata") or {}).get("scenario_name") or sid)
+                state["current"] = i + 1
+
+                if cached_fps.get(sid) == fingerprint:
+                    n_cached += 1
+                    line = f"scenario {i + 1}/{total} ({sid}): cached, skipped"
+                    state["scenario_progress"] = {}
+                    state["message"] = line
                     state["last_line"] = line
-                    tail.append(line)
-                    del tail[:-30]
-                    # Echo the runner's progress to the server console.
                     print(f"[sweep] {line}", flush=True)
-            proc.wait()
-            state["returncode"] = proc.returncode
-            # The last scenario processed may not have ended with a "cached,
-            # skipped" line clearing it — nothing is "calculating" once the
-            # subprocess itself has exited, one way or another.
+                    with h5py.File(str(store), "a") as handle:
+                        attrs = handle[sid].attrs
+                        attrs["label"] = label
+                        attrs["order"] = int(i)
+                    continue
+
+                line = f"scenario {i + 1}/{total} ({sid})"
+                state["scenario_progress"] = {
+                    sid: {"stage": None, "stage_total": None, "stage_id": None}
+                }
+                state["message"] = line
+                state["last_line"] = line
+                print(f"[sweep] {line}", flush=True)
+
+                plugins = get_plugins()
+                converter_cls = plugins.converter_class or DualCanteraConverter
+                conv = converter_cls(mechanism=mech_name or None, plugins=plugins)
+                settings = config.get("settings") or {}
+                sim_t = float(settings.get("end_time") or 0.0) or 1.0
+                dt = float(settings.get("dt") or 0.0) or (sim_t / 10.0)
+
+                # Same solve path `/api/simulations` uses for a single run
+                # (SimulationWorker) -- one backend, not a sweep-specific
+                # reimplementation. Poll instead of blocking synchronously so
+                # per-stage progress (staged solves) still streams to the UI.
+                started = time.perf_counter()
+                scenario_worker = SimulationWorker()
+                scenario_worker.start_simulation(conv, config, sim_t, dt)
+                while True:
+                    progress = scenario_worker.get_progress()
+                    if progress.n_stages:
+                        state["scenario_progress"] = {
+                            sid: {
+                                "stage": progress.stages_done,
+                                "stage_total": progress.n_stages,
+                                "stage_id": (
+                                    progress.completed_stage_ids[-1]
+                                    if progress.completed_stage_ids
+                                    else None
+                                ),
+                            }
+                        }
+                    if progress.is_complete or progress.error_message:
+                        break
+                    time.sleep(0.3)
+                if not progress.is_complete:
+                    raise RuntimeError(
+                        progress.error_message or f"scenario {sid!r} failed"
+                    )
+
+                gui = {
+                    "status": "complete",
+                    "is_running": False,
+                    "is_complete": True,
+                    "error_message": None,
+                    "times": progress.times,
+                    "reactors_series": progress.reactors_series,
+                    "reactor_reports": progress.reactor_reports,
+                    "connection_reports": progress.connection_reports,
+                    "code_str": progress.code_str,
+                    "summary": progress.summary,
+                    "sankey_links": progress.sankey_links,
+                    "sankey_nodes": progress.sankey_nodes,
+                    "elapsed_time": time.perf_counter() - started,
+                    "updated_nodes": progress.updated_nodes,
+                    "updated_connections": progress.updated_connections,
+                }
+                stored_mech = conv.mechanism
+                write_payload(store, gui, stored_mech, group=sid, fresh=False)
+                with h5py.File(str(store), "a") as handle:
+                    attrs = handle[sid].attrs
+                    attrs["label"] = label
+                    attrs["order"] = int(i)
+                    attrs["fingerprint"] = fingerprint
+                    attrs["computed_at"] = float(time.time())
+
+            stale = prune_stale_groups(store, run_ids)
+            if stale:
+                print(
+                    f"[sweep] pruned {len(stale)} stale scenario group(s): "
+                    f"{', '.join(stale)}",
+                    flush=True,
+                )
+
+            with h5py.File(str(store), "a") as handle:
+                cfg_path = getattr(request.app.state, "preloaded_config_path", None)
+                handle.attrs["map_config"] = Path(cfg_path).name if cfg_path else ""
+                handle.attrs["mechanism"] = mechanism
+                handle.attrs["mechanism_name"] = (
+                    Path(mechanism).name if mechanism else ""
+                )
+                handle.attrs["created_at"] = float(time.time())
+
             state["scenario_progress"] = {}
             state["last_line"] = None
-            if proc.returncode == 0:
-                state["status"] = "done"
-                state["message"] = "Sweep complete"
-                print(f"[sweep] complete — {state['total']} run(s)", flush=True)
-            else:
-                state["status"] = "error"
-                state["message"] = "\n".join(tail[-8:]) or f"exited {proc.returncode}"
-                print(f"[sweep] FAILED (exit {proc.returncode})", flush=True)
+            state["status"] = "done"
+            state["message"] = "Sweep complete"
+            print(f"[sweep] complete — {total} run(s)", flush=True)
         except Exception as exc:  # noqa: BLE001
+            state["scenario_progress"] = {}
+            state["last_line"] = None
             state["status"] = "error"
             state["message"] = str(exc)
             print(f"[sweep] FAILED: {exc}", flush=True)

--- a/boulder/scenario_editor.py
+++ b/boulder/scenario_editor.py
@@ -1,4 +1,4 @@
-"""Scenario authoring: create/update/delete a named ``scenarios:`` overlay on disk.
+"""Scenario authoring: create/update a named ``scenarios:`` overlay, in memory.
 
 Complements :mod:`boulder.api.routes.scenarios` (which only *reads* precomputed
 trajectories from the HDF5 scenario store) with the input side of the Scenario
@@ -6,29 +6,28 @@ Pane: creating a new scenario adds a new named overlay, editing it changes
 only that overlay's subtree, and ``Run Sweep`` is what turns overlays into
 trajectories.
 
-Every function here mutates only the targeted ``scenarios.<id>`` subtree of the
-YAML on disk via ``ruamel.yaml`` — nodes, connections, settings, and comments
-elsewhere in the file are left untouched.
+Every function here is a pure transform: it takes the *current* overlays map
+(``{scenario_id: overlay_dict}``) and returns the *new* one. Nothing here ever
+touches disk — the caller (the frontend, via ``scenarioStore``) is the sole
+owner of this state, exactly like the main config's ``configStore``/YAML pane
+already work. The one way a user gets scenario edits onto disk is the
+Scenario YAML pane's "Download full YAML" button (see
+``render_full_yaml`` and ``boulder.api.routes.scenarios``).
 """
 
 from __future__ import annotations
 
 import copy
 import re
-from pathlib import Path
-from typing import Any, List, Optional, Tuple
-
-from ruamel.yaml.comments import CommentedMap, CommentedSeq
+from typing import Any, Dict, List, Optional, Tuple
 
 from .config import (
     _CONN_STANDARD_FIELDS,
     _NODE_STANDARD_FIELDS,
-    get_yaml_with_comments,
-    load_config_file_with_comments,
     load_yaml_string_with_comments,
     yaml_to_string_with_comments,
 )
-from .runset import BASELINE_SCENARIO_ID
+from .runset import BASELINE_SCENARIO_ID, deep_merge
 
 _ID_RE = re.compile(r"^[A-Za-z0-9_-]+$")
 
@@ -54,84 +53,76 @@ def _validate_id(scenario_id: str) -> None:
         )
 
 
-def _load(cfg_path: Path) -> CommentedMap:
-    data = load_config_file_with_comments(str(cfg_path))
-    if not isinstance(data, CommentedMap):
-        raise ScenarioEditError(f"{cfg_path} does not contain a YAML mapping")
-    return data
-
-
-def _save(cfg_path: Path, data: CommentedMap) -> None:
-    yaml_obj = get_yaml_with_comments()
-    with open(cfg_path, "w", encoding="utf-8") as f:
-        yaml_obj.dump(data, f)
-
-
 def _overlay_yaml_text(overlay: Any) -> str:
-    return yaml_to_string_with_comments(
-        overlay if overlay is not None else CommentedMap()
-    )
+    return yaml_to_string_with_comments(overlay if overlay is not None else {})
 
 
-def list_scenario_ids(cfg_path: Path) -> List[str]:
+def list_scenario_ids(overlays: Dict[str, dict]) -> List[str]:
     """Return the run-set's scenario ids, in run-set order.
 
     The unmodified base config's own synthesized entry
-    (:data:`~boulder.runset.BASELINE_SCENARIO_ID`) is prepended whenever the
-    ``scenarios:`` mapping is non-empty — matching
-    :func:`boulder.runset.expand_scenarios`, which always solves it first —
-    so it's listed (and clonable, see :func:`create_scenario`) even before
-    the first Run Sweep.
+    (:data:`~boulder.runset.BASELINE_SCENARIO_ID`) is prepended whenever
+    *overlays* is non-empty — matching :func:`boulder.runset.expand_scenarios`,
+    which always solves it first — so it's listed (and clonable, see
+    :func:`create_scenario`) even before the first Run Sweep.
     """
-    data = _load(cfg_path)
-    scenario_map = data.get("scenarios") or {}
-    ids = list(scenario_map.keys())
+    ids = list(overlays.keys())
     if ids:
         ids.insert(0, BASELINE_SCENARIO_ID)
     return ids
 
 
 def create_scenario(
-    cfg_path: Path, scenario_id: str, base_scenario_id: Optional[str] = None
-) -> str:
-    """Add a new (blank or cloned) scenario overlay. Returns its YAML text."""
+    overlays: Dict[str, dict],
+    scenario_id: str,
+    base_scenario_id: Optional[str] = None,
+    description: Optional[str] = None,
+) -> Tuple[Dict[str, dict], str]:
+    """Add a new (blank or cloned) scenario overlay to *overlays*.
+
+    *overlays* is not mutated. Returns ``(new_overlays, new_overlay_yaml_text)``.
+
+    *description*, if given, is written to ``metadata.scenario_name`` -- the
+    field the Scenario Pane shows as each row's label. Optional: a cloned
+    overlay's own inherited name is kept as-is when omitted, and a blank one
+    simply has no label of its own (the Pane falls back to the id).
+    """
     _validate_id(scenario_id)
-    data = _load(cfg_path)
-    scenario_map = data.get("scenarios")
-    if scenario_map is None:
-        scenario_map = CommentedMap()
-        data["scenarios"] = scenario_map
-    if scenario_id in scenario_map:
+    if scenario_id in overlays:
         raise ScenarioEditError(f"Scenario {scenario_id!r} already exists")
 
     if base_scenario_id is not None and base_scenario_id != BASELINE_SCENARIO_ID:
-        if base_scenario_id not in scenario_map:
+        if base_scenario_id not in overlays:
             raise ScenarioEditError(f"Unknown base scenario {base_scenario_id!r}")
-        overlay = copy.deepcopy(scenario_map[base_scenario_id])
+        overlay = copy.deepcopy(overlays[base_scenario_id])
     else:
         # No base, or cloning BASELINE (the unmodified base config) -- either
         # way, a blank overlay: BASELINE has no overlay subtree of its own.
-        overlay = CommentedMap()
+        overlay = {}
 
-    scenario_map[scenario_id] = overlay
-    _save(cfg_path, data)
-    return _overlay_yaml_text(overlay)
+    if description:
+        metadata = overlay.get("metadata")
+        if metadata is None:
+            metadata = {}
+            overlay["metadata"] = metadata
+        metadata["scenario_name"] = description
+
+    new_overlays = {**overlays, scenario_id: overlay}
+    return new_overlays, _overlay_yaml_text(overlay)
 
 
-def read_scenario(cfg_path: Path, scenario_id: str) -> str:
+def read_scenario(overlays: Dict[str, dict], scenario_id: str) -> str:
     """Return one scenario overlay's YAML text (for the scoped editor)."""
-    data = _load(cfg_path)
-    scenario_map = data.get("scenarios") or {}
-    if scenario_id not in scenario_map:
+    if scenario_id not in overlays:
         raise ScenarioEditError(f"Unknown scenario {scenario_id!r}")
-    return _overlay_yaml_text(scenario_map[scenario_id])
+    return _overlay_yaml_text(overlays[scenario_id])
 
 
-def update_scenario(cfg_path: Path, scenario_id: str, yaml_text: str) -> str:
+def update_scenario(
+    overlays: Dict[str, dict], scenario_id: str, yaml_text: str
+) -> Tuple[Dict[str, dict], str]:
     """Replace one scenario overlay's subtree from edited YAML text."""
-    data = _load(cfg_path)
-    scenario_map = data.get("scenarios")
-    if not scenario_map or scenario_id not in scenario_map:
+    if scenario_id not in overlays:
         raise ScenarioEditError(f"Unknown scenario {scenario_id!r}")
     try:
         parsed = load_yaml_string_with_comments(yaml_text)
@@ -139,13 +130,13 @@ def update_scenario(cfg_path: Path, scenario_id: str, yaml_text: str) -> str:
         raise ScenarioEditError(f"Invalid YAML: {exc}") from exc
     if parsed is not None and not isinstance(parsed, dict):
         raise ScenarioEditError("A scenario overlay must be a YAML mapping")
-    scenario_map[scenario_id] = parsed if parsed is not None else CommentedMap()
-    _save(cfg_path, data)
-    return _overlay_yaml_text(scenario_map[scenario_id])
+    new_overlay = parsed if parsed is not None else {}
+    new_overlays = {**overlays, scenario_id: new_overlay}
+    return new_overlays, _overlay_yaml_text(new_overlay)
 
 
 def _entity_location(raw: dict, entity_id: str) -> Optional[Tuple[str, Optional[str]]]:
-    """Find *entity_id*'s declaration in the raw (pre-normalize) config.
+    """Find *entity_id*'s declaration in the raw (pre-normalize) base config.
 
     STONE v2 is authored as either one flat ``network:`` list, or one list
     per stage name (declared under ``stages:``, then repeated as its own
@@ -175,11 +166,12 @@ def _entity_location(raw: dict, entity_id: str) -> Optional[Tuple[str, Optional[
 
 
 def update_scenario_entity(
-    cfg_path: Path,
+    overlays: Dict[str, dict],
+    base_raw: dict,
     scenario_id: str,
     entity_id: str,
     properties: dict,
-) -> str:
+) -> Tuple[Dict[str, dict], str]:
     """Merge *properties* into one node/connection's overlay entry.
 
     Creates the scenario's per-stage (or ``network:``) overlay list and/or
@@ -190,34 +182,32 @@ def update_scenario_entity(
     are expected to have already diffed against the base value, so an
     unrelated field never gets duplicated into the overlay just because it
     happened to round-trip through an edit form.
+
+    *base_raw* supplies the entity's structural location (which stage list,
+    which type key) — it's the base config's raw structure, not this
+    scenario's overlay.
     """
     if scenario_id == BASELINE_SCENARIO_ID:
         raise ScenarioEditError(
             "BASELINE has no overlay of its own — edit the base config instead"
         )
-    if not properties:
-        return read_scenario(cfg_path, scenario_id)
-
-    data = _load(cfg_path)
-    scenario_map = data.get("scenarios")
-    if not scenario_map or scenario_id not in scenario_map:
+    if scenario_id not in overlays:
         raise ScenarioEditError(f"Unknown scenario {scenario_id!r}")
+    if not properties:
+        return overlays, _overlay_yaml_text(overlays[scenario_id])
 
-    located = _entity_location(data, entity_id)
+    located = _entity_location(base_raw, entity_id)
     if located is None:
         raise ScenarioEditError(
             f"Unknown node/connection {entity_id!r} in the base config"
         )
     list_key, kind_key = located
 
-    overlay = scenario_map[scenario_id]
-    if overlay is None:
-        overlay = CommentedMap()
-        scenario_map[scenario_id] = overlay
+    overlay = copy.deepcopy(overlays.get(scenario_id) or {})
 
     entity_list = overlay.get(list_key)
     if entity_list is None:
-        entity_list = CommentedSeq()
+        entity_list = []
         overlay[list_key] = entity_list
 
     entry = next(
@@ -225,13 +215,13 @@ def update_scenario_entity(
         None,
     )
     if entry is None:
-        entry = CommentedMap({"id": entity_id})
+        entry = {"id": entity_id}
         entity_list.append(entry)
 
     if kind_key is not None:
         kind_props = entry.get(kind_key)
         if kind_props is None:
-            kind_props = CommentedMap()
+            kind_props = {}
             entry[kind_key] = kind_props
         for key, value in properties.items():
             kind_props[key] = value
@@ -241,28 +231,40 @@ def update_scenario_entity(
         for key, value in properties.items():
             entry[key] = value
 
-    _save(cfg_path, data)
-    return _overlay_yaml_text(overlay)
+    new_overlays = {**overlays, scenario_id: overlay}
+    return new_overlays, _overlay_yaml_text(overlay)
 
 
-def rename_scenario(cfg_path: Path, scenario_id: str, new_id: str) -> None:
+def rename_scenario(
+    overlays: Dict[str, dict], scenario_id: str, new_id: str
+) -> Dict[str, dict]:
     """Rename a scenario's key. Note: moves it to the end of the mapping."""
     _validate_id(new_id)
-    data = _load(cfg_path)
-    scenario_map = data.get("scenarios")
-    if not scenario_map or scenario_id not in scenario_map:
+    if scenario_id not in overlays:
         raise ScenarioEditError(f"Unknown scenario {scenario_id!r}")
-    if new_id in scenario_map:
+    if new_id in overlays:
         raise ScenarioEditError(f"Scenario {new_id!r} already exists")
-    scenario_map[new_id] = scenario_map.pop(scenario_id)
-    _save(cfg_path, data)
+    new_overlays = {k: v for k, v in overlays.items() if k != scenario_id}
+    new_overlays[new_id] = overlays[scenario_id]
+    return new_overlays
 
 
-def delete_scenario(cfg_path: Path, scenario_id: str) -> None:
+def delete_scenario(overlays: Dict[str, dict], scenario_id: str) -> Dict[str, dict]:
     """Remove a scenario overlay. The next sweep prunes its stale HDF5 group."""
-    data = _load(cfg_path)
-    scenario_map = data.get("scenarios")
-    if not scenario_map or scenario_id not in scenario_map:
+    if scenario_id not in overlays:
         raise ScenarioEditError(f"Unknown scenario {scenario_id!r}")
-    del scenario_map[scenario_id]
-    _save(cfg_path, data)
+    return {k: v for k, v in overlays.items() if k != scenario_id}
+
+
+def render_full_yaml(base_raw: dict, overlay: dict) -> str:
+    """Return the base config deep-merged with one scenario's overlay, as YAML text.
+
+    Backs the Scenario YAML pane's "Download full YAML" button -- since
+    nothing here writes to disk anymore, this is the one way a user gets a
+    complete, ready-to-run config out of an edited scenario.
+    """
+    base_clean = {
+        k: v for k, v in base_raw.items() if k not in ("scenarios", "sweep", "sweeps")
+    }
+    merged = deep_merge(base_clean, overlay or {})
+    return yaml_to_string_with_comments(merged)

--- a/frontend/src/api/scenarios.ts
+++ b/frontend/src/api/scenarios.ts
@@ -9,6 +9,9 @@ import type { ConfigConnection, ConfigNode } from "@/types/config";
  */
 export const BASELINE_SCENARIO_ID = "BASELINE";
 
+/** A scenario overlay -- whatever subtree lives under `scenarios.<id>:` in STONE. */
+export type ScenarioOverlay = Record<string, unknown>;
+
 /** One precomputed scenario (trajectory) in the active store. */
 export interface ScenarioMeta {
   id: string;
@@ -39,6 +42,12 @@ export interface ScenarioListResponse {
    * ones a sweep has already run).
    */
   authored_ids?: string[];
+  /**
+   * The `scenarios:` block as loaded at server startup — the one-time seed
+   * for this store's own `overlays` state. Scenario authoring is in-memory
+   * from here on (see `scenarioStore.ts`); this is never re-fetched.
+   */
+  authored_overlays?: Record<string, ScenarioOverlay>;
 }
 
 /** List the scenarios available in the server's active store (fast — attrs only). */
@@ -67,9 +76,13 @@ export function focusScenario(id: string) {
 export const SCENARIO_FOCUS_STREAM_URL = "/api/scenarios/focus/stream";
 
 // ---------------------------------------------------------------------------
-// Scenario authoring — create/edit/delete a `scenario:` overlay on disk.
-// Unlike the read helpers above (precomputed HDF5 trajectories), these edit
-// the source config file so the next Run Sweep picks up the change.
+// Scenario authoring — create/edit/delete a scenario overlay, in memory only.
+//
+// Nothing here writes to disk: every call below is a stateless transform —
+// it sends the *current* overlays map (this store's own state) and gets back
+// the *new* one. The backend never keeps a copy between calls, exactly like
+// `/configs/parse` already treats the base config. The only way to get a
+// scenario onto disk is `renderFullYaml` + a client-side download.
 // ---------------------------------------------------------------------------
 
 export interface ScenarioSourceResponse {
@@ -77,10 +90,11 @@ export interface ScenarioSourceResponse {
   yaml: string;
 }
 
-/** Fetch one scenario overlay's raw YAML text (for the scoped editor). */
-export function fetchScenarioSource(id: string) {
+/** Render one scenario overlay's YAML text (for the scoped editor). */
+export function fetchScenarioSource(id: string, overlay: ScenarioOverlay) {
   return apiFetch<ScenarioSourceResponse>(
     `/scenarios/${encodeURIComponent(id)}/source`,
+    { method: "POST", body: JSON.stringify({ overlay }) },
   );
 }
 
@@ -92,31 +106,60 @@ export interface ScenarioPreviewResponse {
 
 /**
  * Fetch one scenario's effective node/connection properties (base config
- * deep-merged with its overlay) — works before Run Sweep has ever solved it,
- * unlike `fetchScenario` (which 404s until a trajectory is cached).
+ * deep-merged with *overlay*) — works before Run Sweep has ever solved it,
+ * unlike `fetchScenario` (which 404s until a trajectory is cached). Send an
+ * empty overlay for BASELINE.
  */
-export function fetchScenarioPreview(id: string) {
+export function fetchScenarioPreview(id: string, overlay: ScenarioOverlay) {
   return apiFetch<ScenarioPreviewResponse>(
     `/scenarios/${encodeURIComponent(id)}/preview`,
+    { method: "POST", body: JSON.stringify({ overlay }) },
   );
 }
 
+/**
+ * Render the full merged config (base ⊕ *overlay*) as YAML text — backs the
+ * Scenario YAML pane's "Download full YAML" button, the one sanctioned way
+ * to get an edited scenario onto disk.
+ */
+export function renderFullYaml(id: string, overlay: ScenarioOverlay) {
+  return apiFetch<ScenarioSourceResponse>(
+    `/scenarios/${encodeURIComponent(id)}/render-full`,
+    { method: "POST", body: JSON.stringify({ overlay }) },
+  );
+}
+
+export interface ScenarioMutationResponse extends ScenarioSourceResponse {
+  overlays: Record<string, ScenarioOverlay>;
+}
+
 /** Create a new scenario overlay — blank, or cloned from an existing one. */
-export function createScenario(scenarioId: string, baseScenarioId?: string) {
-  return apiFetch<ScenarioSourceResponse>("/scenarios", {
+export function createScenario(
+  overlays: Record<string, ScenarioOverlay>,
+  scenarioId: string,
+  baseScenarioId?: string,
+  description?: string,
+) {
+  return apiFetch<ScenarioMutationResponse>("/scenarios", {
     method: "POST",
     body: JSON.stringify({
+      overlays,
       scenario_id: scenarioId,
       base_scenario_id: baseScenarioId ?? null,
+      description: description || null,
     }),
   });
 }
 
-/** Save edits to a scenario overlay's YAML text. */
-export function updateScenario(id: string, yaml: string) {
-  return apiFetch<ScenarioSourceResponse>(
+/** Apply edits to a scenario overlay's YAML text. */
+export function updateScenario(
+  overlays: Record<string, ScenarioOverlay>,
+  id: string,
+  yaml: string,
+) {
+  return apiFetch<ScenarioMutationResponse>(
     `/scenarios/${encodeURIComponent(id)}`,
-    { method: "PATCH", body: JSON.stringify({ yaml }) },
+    { method: "PATCH", body: JSON.stringify({ overlays, yaml }) },
   );
 }
 
@@ -124,6 +167,7 @@ export interface ScenarioEntityUpdateResponse {
   scenario_id: string;
   id: string;
   yaml: string;
+  overlays: Record<string, ScenarioOverlay>;
 }
 
 /**
@@ -134,22 +178,40 @@ export interface ScenarioEntityUpdateResponse {
  * it belongs to, is resolved server-side from the base config itself.
  */
 export function updateScenarioEntity(
+  overlays: Record<string, ScenarioOverlay>,
   scenarioId: string,
   entityId: string,
   properties: Record<string, unknown>,
 ) {
   return apiFetch<ScenarioEntityUpdateResponse>(
     `/scenarios/${encodeURIComponent(scenarioId)}/entities/${encodeURIComponent(entityId)}`,
-    { method: "PATCH", body: JSON.stringify({ properties }) },
+    { method: "PATCH", body: JSON.stringify({ overlays, properties }) },
   );
 }
 
-/** Rename a scenario's id (its `scenario:` mapping key). */
-export function renameScenario(id: string, newId: string) {
-  return apiFetch<{ ok: boolean; scenario_id: string }>(
+export interface RenameScenarioResponse {
+  ok: boolean;
+  scenario_id: string;
+  overlays: Record<string, ScenarioOverlay>;
+}
+
+/** Rename a scenario's id (its overlays-map key). */
+export function renameScenario(
+  overlays: Record<string, ScenarioOverlay>,
+  id: string,
+  newId: string,
+) {
+  return apiFetch<RenameScenarioResponse>(
     `/scenarios/${encodeURIComponent(id)}/rename`,
-    { method: "PATCH", body: JSON.stringify({ new_id: newId }) },
+    { method: "PATCH", body: JSON.stringify({ overlays, new_id: newId }) },
   );
+}
+
+export interface DeleteScenarioResponse {
+  ok: boolean;
+  scenario_id: string;
+  cache_purged: boolean;
+  overlays: Record<string, ScenarioOverlay>;
 }
 
 /**
@@ -157,18 +219,18 @@ export function renameScenario(id: string, newId: string) {
  * if the active store has one — `cache_purged` reports whether there was
  * actually a cached result to clear.
  */
-export function deleteScenario(id: string) {
-  return apiFetch<{ ok: boolean; scenario_id: string; cache_purged: boolean }>(
-    `/scenarios/${encodeURIComponent(id)}`,
-    { method: "DELETE" },
-  );
+export function deleteScenario(overlays: Record<string, ScenarioOverlay>, id: string) {
+  return apiFetch<DeleteScenarioResponse>(`/scenarios/${encodeURIComponent(id)}`, {
+    method: "DELETE",
+    body: JSON.stringify({ overlays }),
+  });
 }
 
 /**
  * Clear every scenario's cached trajectory (deletes the whole HDF5 store).
- * Scenario definitions in the config are untouched — the next Run Sweep
- * recomputes them from scratch. `cleared` reports whether there was
- * actually a store on disk to remove.
+ * Scenario definitions are untouched — this only ever affected the results
+ * cache. `cleared` reports whether there was actually a store on disk to
+ * remove.
  */
 export function clearScenarioCache() {
   return apiFetch<{ ok: boolean; cleared: boolean }>("/scenarios/clear-cache", {

--- a/frontend/src/api/sweep.ts
+++ b/frontend/src/api/sweep.ts
@@ -1,4 +1,5 @@
 import { apiFetch } from "./client";
+import type { ScenarioOverlay } from "./scenarios";
 
 export interface SweepInfo {
   available: boolean;
@@ -40,16 +41,24 @@ export function getSweepInfo() {
 }
 
 /**
- * Start the sweep as a background batch job on the server.
+ * Start the sweep, in-process, on the server.
  *
- * `noCache` forces a full recompute: the server sets `BOULDER_NO_CACHE=1`
- * for the runner subprocess, so every scenario is re-solved instead of
- * skipping ones whose fingerprint is unchanged.
+ * `scenarios` is the caller's current in-memory scenario overlays map (see
+ * `scenarioStore.ts`) — the base config comes from the server's own startup
+ * snapshot, but overlays no longer live on disk, so they must be sent here
+ * for the sweep to see any edits made this session. `noCache` forces a full
+ * recompute, ignoring each scenario's fingerprint cache.
  */
-export function startSweep(options?: { noCache?: boolean }) {
+export function startSweep(options?: {
+  scenarios?: Record<string, ScenarioOverlay>;
+  noCache?: boolean;
+}) {
   return apiFetch<{ status: string; total: number }>("/sweep/run", {
     method: "POST",
-    body: JSON.stringify({ no_cache: options?.noCache ?? false }),
+    body: JSON.stringify({
+      scenarios: options?.scenarios ?? {},
+      no_cache: options?.noCache ?? false,
+    }),
   });
 }
 

--- a/frontend/src/components/modals/AddScenarioModal.tsx
+++ b/frontend/src/components/modals/AddScenarioModal.tsx
@@ -24,6 +24,7 @@ export function AddScenarioModal({ open, onClose, onCreated }: Props) {
   const createScenario = useScenarioStore((s) => s.createScenario);
   const [id, setId] = useState("");
   const [baseId, setBaseId] = useState(BLANK);
+  const [description, setDescription] = useState("");
   const [submitting, setSubmitting] = useState(false);
 
   if (!open) return null;
@@ -40,11 +41,16 @@ export function AddScenarioModal({ open, onClose, onCreated }: Props) {
     }
     setSubmitting(true);
     try {
-      await createScenario(trimmed, baseId === BLANK ? undefined : baseId);
+      await createScenario(
+        trimmed,
+        baseId === BLANK ? undefined : baseId,
+        description.trim() || undefined,
+      );
       toast.success(`Scenario "${trimmed}" created`);
       onCreated(trimmed);
       setId("");
       setBaseId(BLANK);
+      setDescription("");
       onClose();
     } catch (err) {
       toast.error(err instanceof Error ? err.message : String(err));
@@ -73,6 +79,20 @@ export function AddScenarioModal({ open, onClose, onCreated }: Props) {
             placeholder="e.g. C1T"
             className="block w-full mt-1 px-2 py-1.5 text-sm rounded-md bg-input border border-border text-foreground"
             autoFocus
+            onKeyDown={(e) => {
+              if (e.key === "Enter") void handleSubmit();
+            }}
+          />
+        </label>
+
+        <label className="block text-xs text-muted-foreground">
+          Description (optional)
+          <input
+            id="scenario-description"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            placeholder="e.g. Case 1 max: H2-NG (25 %vol H2)"
+            className="block w-full mt-1 px-2 py-1.5 text-sm rounded-md bg-input border border-border text-foreground"
             onKeyDown={(e) => {
               if (e.key === "Enter") void handleSubmit();
             }}

--- a/frontend/src/components/panels/PropertiesPanel.test.tsx
+++ b/frontend/src/components/panels/PropertiesPanel.test.tsx
@@ -77,8 +77,9 @@ let mockPreviewConnections: Array<{ id: string; properties: Record<string, unkno
   null;
 let mockActiveScenarioId: string | null = null;
 let mockPreviewErrorAfterLoad: string | null = null;
+let mockScenarioOverlays: Record<string, unknown> = {};
 const mockLoadScenarioPreview = vi.fn().mockResolvedValue(undefined);
-const mockRefreshScenarios = vi.fn();
+const mockApplyOverlays = vi.fn();
 
 vi.mock("@/stores/scenarioStore", () => {
   const useScenarioStore = (selector: (s: unknown) => unknown) => {
@@ -87,8 +88,9 @@ vi.mock("@/stores/scenarioStore", () => {
       previewNodes: mockPreviewNodes,
       previewConnections: mockPreviewConnections,
       activeId: mockActiveScenarioId,
+      overlays: mockScenarioOverlays,
+      applyOverlays: mockApplyOverlays,
       loadPreview: mockLoadScenarioPreview,
-      refresh: mockRefreshScenarios,
     };
     return selector(store);
   };
@@ -98,7 +100,7 @@ vi.mock("@/stores/scenarioStore", () => {
   return { useScenarioStore };
 });
 
-const mockUpdateScenarioEntity = vi.fn().mockResolvedValue(undefined);
+const mockUpdateScenarioEntity = vi.fn().mockResolvedValue({ overlays: {} });
 vi.mock("@/api/scenarios", () => ({
   BASELINE_SCENARIO_ID: "BASELINE",
   updateScenarioEntity: (...args: unknown[]) => mockUpdateScenarioEntity(...args),
@@ -558,6 +560,7 @@ describe("PropertiesPanel scenario preview", () => {
     mockPreviewConnections = null;
     mockActiveScenarioId = null;
     mockPreviewErrorAfterLoad = null;
+    mockScenarioOverlays = {};
     mockIsRunning = false;
     mockSweeping = false;
   });
@@ -639,7 +642,7 @@ describe("PropertiesPanel scenario preview", () => {
     expect(screen.getByText("0.60").className).toMatch(/amber/);
   });
 
-  it("editing still shows/edits the base value, not the previewed scenario's override", () => {
+  it("editing shows/edits the previewed scenario's override, not the base value", () => {
     mockPreviewId = "C600_P300";
     mockPreviewNodes = [
       { id: "reactor_1", properties: { temperature: 1273.15, length: 0.6 } },
@@ -649,11 +652,13 @@ describe("PropertiesPanel scenario preview", () => {
     render(<PropertiesPanel />);
     fireEvent.click(screen.getByRole("button", { name: "Edit" }));
 
-    expect(screen.getByDisplayValue("0.3")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("0.6")).toBeInTheDocument();
+    expect(screen.queryByDisplayValue("0.3")).not.toBeInTheDocument();
   });
 
   it("saves into the active scenario's overlay (not the base) and surfaces a failed preview instead of a plain success toast", async () => {
     mockActiveScenarioId = "C1T";
+    mockScenarioOverlays = { C1T: {} };
     // The write can succeed while the resulting merged config is invalid
     // (e.g. a cross-node consistency rule) -- loadPreview swallows that into
     // previewError rather than rejecting, so it must be surfaced explicitly.
@@ -665,9 +670,15 @@ describe("PropertiesPanel scenario preview", () => {
     fireEvent.click(screen.getByRole("button", { name: "Save" }));
 
     await waitFor(() =>
-      expect(mockUpdateScenarioEntity).toHaveBeenCalledWith("C1T", "reactor_1", { length: 0.6 }),
+      expect(mockUpdateScenarioEntity).toHaveBeenCalledWith(
+        { C1T: {} },
+        "C1T",
+        "reactor_1",
+        { length: 0.6 },
+      ),
     );
     expect(mockUpdateNode).not.toHaveBeenCalled();
+    await waitFor(() => expect(mockApplyOverlays).toHaveBeenCalledWith({}));
     await waitFor(() => expect(mockLoadScenarioPreview).toHaveBeenCalledWith("C1T"));
     await waitFor(() =>
       expect(toast.error).toHaveBeenCalledWith(
@@ -692,8 +703,8 @@ describe("PropertiesPanel scenario preview", () => {
     expect(toast.error).not.toHaveBeenCalled();
   });
 
-  it("saving an unchanged (base-shown) field while a scenario is active is a no-op, not a silent write", () => {
-    // Edit mode always shows the base value (0.3), not any active override
+  it("saving an unchanged field while a scenario is active is a no-op, not a silent write", () => {
+    // No override is previewed here, so edit mode shows the base value (0.3)
     // -- saving it back unmodified must not call the overlay API, and must
     // say so rather than looking identical to a successful save.
     mockActiveScenarioId = "C1T";
@@ -709,9 +720,9 @@ describe("PropertiesPanel scenario preview", () => {
   });
 
   it("blocks saving a scenario overlay edit while a sweep is running", () => {
-    // Unlike the base network (a local, deferred-to-sync edit), this writes
-    // straight to the scenario's YAML on disk -- unsafe while a sweep
-    // subprocess may be reading that same file.
+    // A running sweep's in-flight results reflect the overlay's *current*
+    // values -- editing mid-sweep would be confusing even though it can't
+    // race the sweep (which already captured its own overlay snapshot).
     mockActiveScenarioId = "C1T";
     mockSweeping = true;
 

--- a/frontend/src/components/panels/PropertiesPanel.tsx
+++ b/frontend/src/components/panels/PropertiesPanel.tsx
@@ -105,8 +105,9 @@ export function PropertiesPanel() {
   const previewNodes = useScenarioStore((s) => s.previewNodes);
   const previewConnections = useScenarioStore((s) => s.previewConnections);
   const activeScenarioId = useScenarioStore((s) => s.activeId);
+  const scenarioOverlays = useScenarioStore((s) => s.overlays);
+  const applyScenarioOverlays = useScenarioStore((s) => s.applyOverlays);
   const loadScenarioPreview = useScenarioStore((s) => s.loadPreview);
-  const refreshScenarios = useScenarioStore((s) => s.refresh);
   const isSimulating = useSimulationStore((s) => s.isRunning);
   const isSweeping = useSweepRunStore((s) => s.sweeping);
   const [isEditing, setIsEditing] = useState(false);
@@ -233,10 +234,12 @@ export function PropertiesPanel() {
   const previewDisplayProperties = previewEntity
     ? unfoldInitialConditions(previewEntity.properties as Record<string, unknown>)
     : displayProperties;
-  // While editing, always show/edit the base config's own values — a scenario
-  // overlay is a separate, scoped edit (via "Edit scenario YAML"), not
-  // something a Save here should fold into the base network.
-  const renderProperties = isEditing ? displayProperties : previewDisplayProperties;
+  // What's shown, editing or not, is always the *currently effective* value
+  // (base, or the active scenario's override if there is one) -- Save now
+  // folds into that same scenario's overlay (see handleSave), so editing the
+  // base value while a 0.20 override is in effect would silently show the
+  // wrong starting point.
+  const renderProperties = previewDisplayProperties;
 
   // Stream-point nodes (inter-stage diamonds) and legacy terminal OutletSink nodes
   // are computed from upstream reactors.  OutletSink + terminal_sink is deprecated;
@@ -270,7 +273,7 @@ export function PropertiesPanel() {
 
   // Start editing
   const handleEdit = () => {
-    setEditValues(buildEditValuesFromProperties(displayProperties));
+    setEditValues(buildEditValuesFromProperties(previewDisplayProperties));
     setIsEditing(true);
   };
 
@@ -278,7 +281,7 @@ export function PropertiesPanel() {
   const handleSave = () => {
     const updated: Record<string, unknown> = {};
     for (const [key, val] of Object.entries(editValues)) {
-      const original = properties[key];
+      const original = previewDisplayProperties[key];
       if (key === "temperature") {
         updated[key] = celsiusToKelvin(parseFloat(val) || 0);
       } else if (typeof original === "object" && original !== null) {
@@ -298,45 +301,47 @@ export function PropertiesPanel() {
 
     // A real scenario (not BASELINE, which has no overlay of its own) is
     // active: land the edit in its overlay instead of the base network --
-    // otherwise "Save" would silently change the base for every scenario,
-    // while this panel still shows the previewed scenario's (unrelated)
-    // values. Only send keys that actually changed, so untouched fields
-    // that merely round-tripped through the edit form don't get duplicated
-    // into the overlay.
+    // otherwise "Save" would silently change the base for every scenario.
+    // Only send keys that actually changed, so untouched fields that merely
+    // round-tripped through the edit form don't get duplicated into the
+    // overlay.
     if (activeScenarioId && activeScenarioId !== BASELINE_SCENARIO_ID) {
-      // Unlike the base network (a local, deferred-to-sync edit -- see the
-      // fallback branch below), this writes straight to the scenario's YAML
-      // on disk. A sweep subprocess may be reading that same file for this
-      // (or a later) scenario right now -- same guard the YAML panes use.
+      // A running sweep already captured its own snapshot of every overlay
+      // when it started, so editing mid-sweep can't race it -- but the
+      // sweep's in-flight results still reflect the *old* values, which
+      // would be confusing to edit against. Same guard the YAML panes use.
       if (isSimulating || isSweeping) {
         toast.error("Wait for the current calculation to finish before editing a scenario.");
         return;
       }
       const changed: Record<string, unknown> = {};
       for (const [key, val] of Object.entries(updated)) {
-        if (JSON.stringify(val) !== JSON.stringify(properties[key])) {
+        if (JSON.stringify(val) !== JSON.stringify(previewDisplayProperties[key])) {
           changed[key] = val;
         }
       }
       if (Object.keys(changed).length === 0) {
-        // Edit mode always shows/edits the base value (see handleEdit), so
-        // typing that same value back and saving looks like "reset to
-        // base" -- it isn't: the diff is against the base, so this is a
-        // true no-op and any existing override is left exactly as it was.
-        // Removing an override entirely still requires the scenario's raw
-        // YAML pane. Surfaced explicitly rather than silently doing
-        // nothing, which otherwise looks identical to a successful save.
+        // Diffed against what was actually shown/edited (the scenario's
+        // current effective value -- base or an existing override, per
+        // handleEdit) -- an unmodified Save is a true no-op here, distinct
+        // from the case where an override already existed and got typed
+        // back to the *base* value (that lands in `changed` above and is
+        // sent, redundantly setting the overlay to match base -- harmless,
+        // and clears the amber "overridden" styling since the effective
+        // value now equals base again). Surfaced explicitly rather than
+        // silently doing nothing, which otherwise looks identical to a
+        // successful save.
         setIsEditing(false);
-        toast.info("No changes to save (edit the scenario's YAML directly to remove an override)");
+        toast.info("No changes to save");
         return;
       }
-      updateScenarioEntity(activeScenarioId, id, changed)
-        .then(async () => {
+      updateScenarioEntity(scenarioOverlays, activeScenarioId, id, changed)
+        .then(async (resp) => {
           setIsEditing(false);
           // Bumps scenarioStore.revision -- lets a scenario YAML pane left
           // open on this same scenario notice this out-of-band edit and
           // refetch its content instead of showing stale text.
-          void refreshScenarios();
+          applyScenarioOverlays(resp.overlays);
           // The write itself can succeed while leaving the scenario's
           // *merged* config invalid (e.g. a cross-node consistency rule) --
           // loadPreview swallows that into previewError rather than

--- a/frontend/src/components/panels/RunControl.test.tsx
+++ b/frontend/src/components/panels/RunControl.test.tsx
@@ -25,14 +25,20 @@ vi.mock("sonner", () => ({
 }));
 
 let mockScenarioRevision = 0;
+let mockAuthoredIdsLength = 0;
 const mockRefresh = vi.fn();
 vi.mock("@/stores/scenarioStore", () => {
   // sweepStore (a real module, exercised via useSweepRunStore below) reads
   // this through the static `.getState()` accessor, not the selector-hook
   // call form the rest of this test file uses -- both need to work.
-  const hook = (selector: (s: unknown) => unknown) =>
-    selector({ refresh: mockRefresh, revision: mockScenarioRevision });
-  hook.getState = () => ({ refresh: mockRefresh, revision: mockScenarioRevision });
+  const state = () => ({
+    refresh: mockRefresh,
+    revision: mockScenarioRevision,
+    overlays: {},
+    authoredIds: Array.from({ length: mockAuthoredIdsLength }, (_, i) => String(i)),
+  });
+  const hook = (selector: (s: unknown) => unknown) => selector(state());
+  hook.getState = state;
   return { useScenarioStore: hook };
 });
 
@@ -43,6 +49,7 @@ describe("RunControl", () => {
     vi.clearAllMocks();
     mockGetSweepInfo.mockResolvedValue({ can_run: false, reason: "No sweep" });
     mockScenarioRevision = 0;
+    mockAuthoredIdsLength = 0;
     useSweepRunStore.setState({ sweeping: false, progress: { current: 0, total: 0 } });
   });
 
@@ -157,12 +164,28 @@ describe("RunControl", () => {
 
       fireEvent.click(screen.getByRole("button", { name: /run sweep/i }));
 
-      expect(mockStartSweep).toHaveBeenCalledWith({ noCache: undefined });
+      expect(mockStartSweep).toHaveBeenCalledWith({ scenarios: {}, noCache: undefined });
       await vi.advanceTimersByTimeAsync(0);
       await vi.advanceTimersByTimeAsync(1000);
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("enables Run Sweep from a session-created scenario even before the backend's snapshot catches up", async () => {
+    // Scenario authoring is in-memory now (scenarioStore.overlays) -- a
+    // scenario created this session isn't reflected in getSweepInfo's
+    // startup-snapshot-based response until a reload, so the live
+    // authoredIds count must be able to enable the button on its own.
+    mockGetSweepInfo.mockResolvedValue({ can_run: false, reason: "No sweep" });
+    mockAuthoredIdsLength = 2; // BASELINE + one session-created scenario
+    render(
+      <RunControl onRunSimulation={onRunSimulation} isRunning={false} runDisabled={false} />,
+    );
+    await waitFor(() => expect(mockGetSweepInfo).toHaveBeenCalled());
+
+    fireEvent.click(screen.getByLabelText("Choose run action"));
+    expect(screen.getByRole("menuitemradio", { name: /run sweep/i })).not.toBeDisabled();
   });
 
   it("re-fetches sweep info when a scenario is added/edited/renamed/deleted elsewhere", async () => {

--- a/frontend/src/components/panels/RunControl.tsx
+++ b/frontend/src/components/panels/RunControl.tsx
@@ -39,6 +39,7 @@ export function RunControl({ onRunSimulation, isRunning, runDisabled }: RunContr
   const appliedDefault = useRef(false);
   const appliedAutorun = useRef(false);
   const scenarioRevision = useScenarioStore((s) => s.revision);
+  const authoredScenarioCount = useScenarioStore((s) => s.authoredIds.length);
   const [addScenarioOpen, setAddScenarioOpen] = useState(false);
   const openScenarioYamlEditor = useLayoutStore((s) => s.openScenarioYamlEditor);
   const notifyShortcutUsage = useShortcutNudge();
@@ -88,7 +89,13 @@ export function RunControl({ onRunSimulation, isRunning, runDisabled }: RunContr
     };
   }, [menuOpen]);
 
-  const canSweep = Boolean(sweep?.can_run);
+  // `sweep` reflects the config's startup snapshot (scenario authoring is
+  // in-memory now — see scenarioStore.ts's `overlays`), so a scenario
+  // created this session wouldn't otherwise be counted until a page reload.
+  // `authoredScenarioCount` covers that; `sweep?.can_run` still covers a
+  // host-defined `sweep:` block with no scenario overlays at all.
+  const canSweep = Boolean(sweep?.can_run) || authoredScenarioCount > 0;
+  const nScenarios = Math.max(sweep?.n_scenarios ?? 0, authoredScenarioCount);
   // If sweep is unavailable, fall back to simulation (force_sim is kept as-is).
   const effectiveMode: RunMode =
     runMode === "sweep" && canSweep
@@ -102,8 +109,8 @@ export function RunControl({ onRunSimulation, isRunning, runDisabled }: RunContr
   // via scenarioStore.refresh() on completion -- no separate wiring needed
   // here, and it stays in sync even when a sweep is started elsewhere.
   const handleRunSweep = useCallback(() => {
-    runSweepJob({ total: sweep?.n_scenarios ?? 0 });
-  }, [runSweepJob, sweep]);
+    runSweepJob({ total: nScenarios });
+  }, [runSweepJob, nScenarios]);
 
   // `--run`: auto-start the run once, as soon as it is actually runnable.
   useEffect(() => {
@@ -136,7 +143,7 @@ export function RunControl({ onRunSimulation, isRunning, runDisabled }: RunContr
     effectiveMode === "sweep"
       ? sweeping
         ? `Sweeping… ${progress.current}/${progress.total}`
-        : `Run Sweep (${sweep?.n_scenarios ?? 0} scenarios)`
+        : `Run Sweep (${nScenarios} scenarios)`
       : effectiveMode === "force_sim"
         ? isRunning
           ? "Running…"

--- a/frontend/src/components/panels/ScenarioPane.tsx
+++ b/frontend/src/components/panels/ScenarioPane.tsx
@@ -267,7 +267,7 @@ export function ScenarioPane() {
                   ].join(" ")}
                 >
                   <div className="flex items-center justify-between gap-2">
-                    <span className="font-medium truncate">{s?.label ?? row.id}</span>
+                    <span className="font-medium truncate">{row.id}</span>
                     {isCalculating ? (
                       <span className="shrink-0 text-[10px] text-primary animate-pulse">
                         Calculating…
@@ -284,6 +284,15 @@ export function ScenarioPane() {
                       </span>
                     )}
                   </div>
+                  {/* Descriptive scenario_name, when it adds anything beyond
+                      the id -- often identical/inherited across scenarios,
+                      which made every row look the same (the id, always
+                      unique, is the primary label above). */}
+                  {s?.label && s.label !== row.id && (
+                    <div className="text-[10px] text-muted-foreground truncate">
+                      {s.label}
+                    </div>
+                  )}
                   {s?.reactor_mode && (
                     <div className="text-[10px] text-muted-foreground">
                       {s.reactor_mode}

--- a/frontend/src/components/panels/ScenarioYamlPane.test.tsx
+++ b/frontend/src/components/panels/ScenarioYamlPane.test.tsx
@@ -19,10 +19,10 @@ vi.mock("@monaco-editor/react", () => ({
 }));
 
 const mockFetchScenarioSource = vi.fn();
-const mockUpdateScenario = vi.fn().mockResolvedValue(undefined);
+const mockRenderFullYaml = vi.fn();
 vi.mock("@/api/scenarios", () => ({
   fetchScenarioSource: (...args: unknown[]) => mockFetchScenarioSource(...args),
-  updateScenario: (...args: unknown[]) => mockUpdateScenario(...args),
+  renderFullYaml: (...args: unknown[]) => mockRenderFullYaml(...args),
 }));
 
 vi.mock("@/stores/themeStore", () => ({
@@ -30,9 +30,16 @@ vi.mock("@/stores/themeStore", () => ({
 }));
 
 let mockRevision = 0;
-vi.mock("@/stores/scenarioStore", () => ({
-  useScenarioStore: (selector: (s: unknown) => unknown) => selector({ revision: mockRevision }),
-}));
+let mockOverlays: Record<string, unknown> = {};
+const mockStoreUpdateScenario = vi.fn().mockResolvedValue(undefined);
+vi.mock("@/stores/scenarioStore", () => {
+  const useScenarioStore = (selector: (s: unknown) => unknown) =>
+    selector({ revision: mockRevision, updateScenario: mockStoreUpdateScenario });
+  (useScenarioStore as unknown as { getState: () => unknown }).getState = () => ({
+    overlays: mockOverlays,
+  });
+  return { useScenarioStore };
+});
 
 let mockIsRunning = false;
 vi.mock("@/stores/simulationStore", () => ({
@@ -57,16 +64,17 @@ describe("ScenarioYamlPane", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockRevision = 0;
+    mockOverlays = {};
     mockIsRunning = false;
     mockSweeping = false;
     mockFetchScenarioSource.mockResolvedValue({ scenario_id: "C1T", yaml: "torch_eff: 0.85\n" });
-    mockUpdateScenario.mockResolvedValue(undefined);
+    mockStoreUpdateScenario.mockResolvedValue(undefined);
   });
 
   it("fetches the scenario's overlay text when opened", async () => {
     render(<ScenarioYamlPane scenarioId="C1T" onClose={vi.fn()} />);
 
-    expect(mockFetchScenarioSource).toHaveBeenCalledWith("C1T");
+    expect(mockFetchScenarioSource).toHaveBeenCalledWith("C1T", {});
     expect(await editorValue()).toHaveValue("torch_eff: 0.85\n");
   });
 
@@ -107,7 +115,9 @@ describe("ScenarioYamlPane", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Save" }));
 
-    await waitFor(() => expect(mockUpdateScenario).toHaveBeenCalledWith("C1T", "torch_eff: 0.99\n"));
+    await waitFor(() =>
+      expect(mockStoreUpdateScenario).toHaveBeenCalledWith("C1T", "torch_eff: 0.99\n"),
+    );
     await waitFor(() => expect(onSaved).toHaveBeenCalledWith("C1T"));
   });
 
@@ -118,5 +128,28 @@ describe("ScenarioYamlPane", () => {
 
     expect(screen.getByText(/locked until it finishes/)).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
+  });
+
+  it("downloads the full merged YAML (base + this scenario's overlay)", async () => {
+    mockOverlays = { C1T: { torch_eff: 0.99 } };
+    mockRenderFullYaml.mockResolvedValue({
+      scenario_id: "C1T",
+      yaml: "network:\n- id: torch\n  torch_eff: 0.99\n",
+    });
+    const createObjectURL = vi.fn(() => "blob:mock-url");
+    const revokeObjectURL = vi.fn();
+    vi.stubGlobal("URL", { ...URL, createObjectURL, revokeObjectURL });
+    const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {});
+
+    render(<ScenarioYamlPane scenarioId="C1T" onClose={vi.fn()} />);
+    await editorValue();
+
+    fireEvent.click(screen.getByRole("button", { name: "Download full YAML" }));
+
+    await waitFor(() =>
+      expect(mockRenderFullYaml).toHaveBeenCalledWith("C1T", { torch_eff: 0.99 }),
+    );
+    await waitFor(() => expect(clickSpy).toHaveBeenCalledOnce());
+    clickSpy.mockRestore();
   });
 });

--- a/frontend/src/components/panels/ScenarioYamlPane.tsx
+++ b/frontend/src/components/panels/ScenarioYamlPane.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef, lazy, Suspense } from "react";
 import { FileCode, X } from "lucide-react";
-import { fetchScenarioSource, updateScenario } from "@/api/scenarios";
+import { fetchScenarioSource, renderFullYaml } from "@/api/scenarios";
 import { useThemeStore } from "@/stores/themeStore";
 import { useScenarioStore } from "@/stores/scenarioStore";
 import { Button } from "@/components/ui/Button";
@@ -23,21 +23,24 @@ interface Props {
  * Scoped scenario editor — same docked-pane chrome as `YamlPane` (so editing
  * BASELINE vs. a scenario feels like the same feature, not two different
  * UIs), but limited to one scenario's overlay subtree (`scenarios.<id>`)
- * instead of the whole config file. Editing here never touches the base
- * network, so there's nothing to sync against a live structured config: the
- * overlay text is the whole story.
+ * instead of the whole config file. Nothing here touches disk — "Save"
+ * updates this session's in-memory overlay (`scenarioStore.overlays`) only;
+ * "Download full YAML" is the one way to get a complete, ready-to-run config
+ * out of an edited scenario.
  */
 export function ScenarioYamlPane({ scenarioId, baseScenarioId, onClose, onSaved }: Props) {
   const theme = useThemeStore((s) => s.theme);
-  // Bumped by any scenario write, from any source (see scenarioStore.refresh
-  // and AppShell's/this pane's own onSaved wiring) -- used below to refetch
-  // this pane's content when a *different* editor (e.g. the Properties
-  // panel) changes the same scenario while this pane is sitting open.
+  // Bumped by any scenario write, from any source (see scenarioStore's
+  // applyOverlays and this pane's own onSaved wiring) -- used below to
+  // refetch this pane's content when a *different* editor (e.g. the
+  // Properties panel) changes the same scenario while this pane is open.
   const revision = useScenarioStore((s) => s.revision);
+  const updateScenario = useScenarioStore((s) => s.updateScenario);
   const [value, setValue] = useState("");
   const [baseline, setBaseline] = useState("");
   const [loading, setLoading] = useState(false);
   const [saving, setSaving] = useState(false);
+  const [downloading, setDownloading] = useState(false);
   const [loadError, setLoadError] = useState<string | null>(null);
   const isSimulating = useSimulationStore((s) => s.isRunning);
   const isSweeping = useSweepRunStore((s) => s.sweeping);
@@ -55,7 +58,8 @@ export function ScenarioYamlPane({ scenarioId, baseScenarioId, onClose, onSaved 
     if (isDirtyRef.current) return;
     setLoadError(null);
     setLoading(true);
-    fetchScenarioSource(scenarioId)
+    const overlay = useScenarioStore.getState().overlays[scenarioId] ?? {};
+    fetchScenarioSource(scenarioId, overlay)
       .then((resp) => {
         setValue(resp.yaml);
         setBaseline(resp.yaml);
@@ -78,15 +82,37 @@ export function ScenarioYamlPane({ scenarioId, baseScenarioId, onClose, onSaved 
     setSaving(true);
     try {
       await updateScenario(scenarioId, value);
-      toast.success(`Scenario "${scenarioId}" saved`);
+      toast.success(`Scenario "${scenarioId}" updated`);
       onSaved?.(scenarioId);
       onClose();
     } catch (err) {
       toast.error(
-        `Could not save scenario: ${err instanceof Error ? err.message : String(err)}`,
+        `Could not update scenario: ${err instanceof Error ? err.message : String(err)}`,
       );
     } finally {
       setSaving(false);
+    }
+  };
+
+  const handleDownloadFullYaml = async () => {
+    setDownloading(true);
+    try {
+      const overlay = useScenarioStore.getState().overlays[scenarioId] ?? {};
+      const resp = await renderFullYaml(scenarioId, overlay);
+      const blob = new Blob([resp.yaml], { type: "text/yaml" });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `${scenarioId}.yaml`;
+      a.click();
+      URL.revokeObjectURL(url);
+      toast.success(`Downloaded ${scenarioId}.yaml`);
+    } catch (err) {
+      toast.error(
+        `Could not render full YAML: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    } finally {
+      setDownloading(false);
     }
   };
 
@@ -160,6 +186,16 @@ export function ScenarioYamlPane({ scenarioId, baseScenarioId, onClose, onSaved 
       </div>
 
       <div className="flex justify-end gap-2 p-3 border-t border-border shrink-0">
+        <Button
+          id="download-full-scenario-yaml-btn"
+          onClick={() => void handleDownloadFullYaml()}
+          disabled={downloading || loading || !!loadError}
+          variant="muted"
+          size="sm"
+          title="Download the full config (base + this scenario's overlay) as one YAML file"
+        >
+          {downloading ? "Rendering…" : "Download full YAML"}
+        </Button>
         <Button onClick={onClose} variant="secondary" size="sm">
           Cancel
         </Button>

--- a/frontend/src/stores/scenarioStore.test.ts
+++ b/frontend/src/stores/scenarioStore.test.ts
@@ -1,12 +1,11 @@
 /**
- * Asserts scenarioStore: refresh() populates authoredIds (the full,
- * sweep-independent scenario list) and bumps revision; create/rename/delete
- * each refresh internally afterward — so callers never have to remember to
- * do it themselves (the bug that let Run Sweep's scenario count and the Add
- * Scenario clone-base list go stale); and each of those four also pushes the
- * freshly-written config YAML into `configStore` (the bug where the "Edit
- * YAML" pane kept showing a load-time snapshot after a scenario write went
- * straight to disk, unrelated to any `configStore.config`/graph state).
+ * Asserts scenarioStore: refresh() seeds `overlays`/authoredIds from the
+ * server's startup snapshot only on the *first* call — a later refresh()
+ * must never clobber local edits with that now-stale snapshot (the whole
+ * point of scenario authoring moving in-memory, see scenario_editor.py's
+ * module docstring). Every mutator (create/update/rename/delete) applies its
+ * response's `overlays` locally instead of refetching/resyncing anything —
+ * nothing here touches disk or `configStore` anymore.
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
@@ -15,6 +14,7 @@ import { useSimulationStore } from "./simulationStore";
 
 const mockListScenarios = vi.fn();
 const mockCreateScenario = vi.fn();
+const mockUpdateScenario = vi.fn();
 const mockRenameScenario = vi.fn();
 const mockDeleteScenario = vi.fn();
 const mockFetchScenario = vi.fn();
@@ -22,30 +22,20 @@ const mockClearScenarioCache = vi.fn();
 const mockFetchScenarioPreview = vi.fn();
 
 vi.mock("@/api/scenarios", () => ({
+  BASELINE_SCENARIO_ID: "BASELINE",
   listScenarios: (...args: unknown[]) => mockListScenarios(...args),
   createScenario: (...args: unknown[]) => mockCreateScenario(...args),
+  updateScenario: (...args: unknown[]) => mockUpdateScenario(...args),
   renameScenario: (...args: unknown[]) => mockRenameScenario(...args),
   deleteScenario: (...args: unknown[]) => mockDeleteScenario(...args),
   fetchScenario: (...args: unknown[]) => mockFetchScenario(...args),
   clearScenarioCache: (...args: unknown[]) => mockClearScenarioCache(...args),
   fetchScenarioPreview: (...args: unknown[]) => mockFetchScenarioPreview(...args),
-  updateScenario: vi.fn(),
-}));
-
-const mockFetchPreloadedConfig = vi.fn();
-vi.mock("@/api/configs", () => ({
-  fetchPreloadedConfig: (...args: unknown[]) => mockFetchPreloadedConfig(...args),
-}));
-
-const mockSetOriginalYaml = vi.fn();
-vi.mock("./configStore", () => ({
-  useConfigStore: { getState: () => ({ setOriginalYaml: mockSetOriginalYaml }) },
 }));
 
 describe("scenarioStore", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockFetchPreloadedConfig.mockResolvedValue({ preloaded: false });
     mockFetchScenarioPreview.mockResolvedValue({
       scenario_id: "unset",
       nodes: [],
@@ -55,6 +45,8 @@ describe("scenarioStore", () => {
       available: false,
       scenarios: [],
       authoredIds: [],
+      overlays: {},
+      overlaysSeeded: false,
       activeId: null,
       loading: false,
       error: null,
@@ -69,76 +61,125 @@ describe("scenarioStore", () => {
     });
   });
 
-  it("refresh() populates authoredIds and bumps revision", async () => {
+  it("refresh() seeds overlays/authoredIds from authored_overlays and bumps revision", async () => {
     mockListScenarios.mockResolvedValue({
       available: true,
       scenarios: [{ id: "A", t0_K: 300, label: "A" }],
-      authored_ids: ["A", "B"],
+      authored_ids: ["BASELINE", "A", "B"],
+      authored_overlays: { A: { metadata: {} }, B: {} },
       created_at: 123,
     });
 
     await useScenarioStore.getState().refresh();
 
     const state = useScenarioStore.getState();
-    expect(state.authoredIds).toEqual(["A", "B"]);
+    expect(state.overlays).toEqual({ A: { metadata: {} }, B: {} });
+    expect(state.authoredIds).toEqual(["BASELINE", "A", "B"]);
     expect(state.scenarios).toHaveLength(1);
     expect(state.revision).toBe(1);
   });
 
-  it("refresh() still bumps revision on failure, resetting authoredIds", async () => {
+  it("refresh() still bumps revision on failure, resetting available/scenarios", async () => {
     mockListScenarios.mockRejectedValue(new Error("network error"));
 
     await useScenarioStore.getState().refresh();
 
     const state = useScenarioStore.getState();
     expect(state.available).toBe(false);
-    expect(state.authoredIds).toEqual([]);
+    expect(state.scenarios).toEqual([]);
     expect(state.revision).toBe(1);
   });
 
-  it("createScenario refreshes afterward, so authoredIds/revision reflect the new scenario", async () => {
-    mockCreateScenario.mockResolvedValue({ scenario_id: "C", yaml: "" });
+  it("a second refresh() never clobbers locally-edited overlays with the stale server snapshot", async () => {
     mockListScenarios.mockResolvedValue({
       available: false,
       scenarios: [],
-      authored_ids: ["A", "C"],
+      authored_ids: ["BASELINE", "A"],
+      authored_overlays: { A: {} },
+    });
+    await useScenarioStore.getState().refresh();
+    expect(useScenarioStore.getState().overlays).toEqual({ A: {} });
+
+    // Something (e.g. createScenario) mutates overlays locally in between.
+    useScenarioStore.getState().applyOverlays({ A: {}, B: { metadata: {} } });
+
+    // The server still only knows about "A" (nothing persists there), but a
+    // second refresh (e.g. after a sweep finishes) must not overwrite "B".
+    mockListScenarios.mockResolvedValue({
+      available: true,
+      scenarios: [{ id: "A", t0_K: 300, label: "A" }],
+      authored_ids: ["BASELINE", "A"],
+      authored_overlays: { A: {} },
+    });
+    await useScenarioStore.getState().refresh();
+
+    const state = useScenarioStore.getState();
+    expect(state.overlays).toEqual({ A: {}, B: { metadata: {} } });
+    expect(state.available).toBe(true); // unrelated fields still refresh normally
+  });
+
+  it("createScenario sends the current overlays and applies the response locally", async () => {
+    useScenarioStore.getState().applyOverlays({ A: {} });
+    mockCreateScenario.mockResolvedValue({
+      scenario_id: "C",
+      yaml: "",
+      overlays: { A: {}, C: {} },
     });
 
+    const revisionBefore = useScenarioStore.getState().revision;
     await useScenarioStore.getState().createScenario("C");
 
-    expect(mockListScenarios).toHaveBeenCalledOnce();
+    expect(mockCreateScenario).toHaveBeenCalledWith({ A: {} }, "C", undefined, undefined);
+    expect(mockListScenarios).not.toHaveBeenCalled(); // no refresh -- nothing to resync from disk
     const state = useScenarioStore.getState();
     expect(state.activeId).toBe("C");
-    expect(state.authoredIds).toEqual(["A", "C"]);
-    expect(state.revision).toBe(1);
+    expect(state.overlays).toEqual({ A: {}, C: {} });
+    expect(state.authoredIds).toEqual(["BASELINE", "A", "C"]);
+    expect(state.revision).toBe(revisionBefore + 1);
   });
 
-  it("renameScenario refreshes afterward and updates activeId if it matched", async () => {
-    useScenarioStore.setState({ activeId: "A" });
-    mockRenameScenario.mockResolvedValue({ ok: true, scenario_id: "A2" });
-    mockListScenarios.mockResolvedValue({
-      available: false,
-      scenarios: [],
-      authored_ids: ["A2"],
+  it("updateScenario applies the response's overlays locally", async () => {
+    useScenarioStore.getState().applyOverlays({ A: {} });
+    mockUpdateScenario.mockResolvedValue({
+      scenario_id: "A",
+      yaml: "torch_eff: 0.5\n",
+      overlays: { A: { torch_eff: 0.5 } },
     });
+
+    await useScenarioStore.getState().updateScenario("A", "torch_eff: 0.5\n");
+
+    expect(mockUpdateScenario).toHaveBeenCalledWith({ A: {} }, "A", "torch_eff: 0.5\n");
+    expect(useScenarioStore.getState().overlays).toEqual({ A: { torch_eff: 0.5 } });
+  });
+
+  it("renameScenario applies the response's overlays and updates activeId if it matched", async () => {
+    useScenarioStore.setState({ activeId: "A" });
+    useScenarioStore.getState().applyOverlays({ A: {} });
+    mockRenameScenario.mockResolvedValue({ ok: true, scenario_id: "A2", overlays: { A2: {} } });
 
     await useScenarioStore.getState().renameScenario("A", "A2");
 
-    expect(mockListScenarios).toHaveBeenCalledOnce();
+    expect(mockRenameScenario).toHaveBeenCalledWith({ A: {} }, "A", "A2");
     const state = useScenarioStore.getState();
     expect(state.activeId).toBe("A2");
-    expect(state.revision).toBe(1);
+    expect(state.overlays).toEqual({ A2: {} });
   });
 
-  it("deleteScenario refreshes afterward and clears activeId if it matched", async () => {
+  it("deleteScenario applies the response's overlays and clears activeId if it matched", async () => {
     useScenarioStore.setState({ activeId: "A" });
-    mockDeleteScenario.mockResolvedValue({ ok: true, scenario_id: "A" });
-    mockListScenarios.mockResolvedValue({ available: false, scenarios: [], authored_ids: [] });
+    useScenarioStore.getState().applyOverlays({ A: {} });
+    mockDeleteScenario.mockResolvedValue({
+      ok: true,
+      scenario_id: "A",
+      cache_purged: false,
+      overlays: {},
+    });
 
     await useScenarioStore.getState().deleteScenario("A");
 
-    expect(mockListScenarios).toHaveBeenCalledOnce();
+    expect(mockDeleteScenario).toHaveBeenCalledWith({ A: {} }, "A");
     expect(useScenarioStore.getState().activeId).toBeNull();
+    expect(useScenarioStore.getState().overlays).toEqual({});
   });
 
   it("clearCache refreshes afterward and clears activeId", async () => {
@@ -178,8 +219,7 @@ describe("scenarioStore", () => {
       previewNodes: [{ id: "r1", type: "x", properties: {} }],
       previewConnections: [],
     });
-    mockDeleteScenario.mockResolvedValue({ ok: true, scenario_id: "A" });
-    mockListScenarios.mockResolvedValue({ available: false, scenarios: [], authored_ids: [] });
+    mockDeleteScenario.mockResolvedValue({ ok: true, scenario_id: "A", overlays: {} });
 
     await useScenarioStore.getState().deleteScenario("A");
 
@@ -188,7 +228,8 @@ describe("scenarioStore", () => {
     expect(state.previewNodes).toBeNull();
   });
 
-  it("setActive on an authored-but-uncomputed scenario loads its preview without fetching a trajectory", async () => {
+  it("setActive on an authored-but-uncomputed scenario loads its preview (using its current overlay) without fetching a trajectory", async () => {
+    useScenarioStore.getState().applyOverlays({ C600_P300: { length: 0.6 } });
     mockFetchScenarioPreview.mockResolvedValue({
       scenario_id: "C600_P300",
       nodes: [{ id: "reactor1", type: "IdealGasReactor", properties: { length: 0.6 } }],
@@ -197,6 +238,7 @@ describe("scenarioStore", () => {
 
     await useScenarioStore.getState().setActive("C600_P300");
 
+    expect(mockFetchScenarioPreview).toHaveBeenCalledWith("C600_P300", { length: 0.6 });
     expect(mockFetchScenario).not.toHaveBeenCalled();
     const state = useScenarioStore.getState();
     expect(state.activeId).toBe("C600_P300");
@@ -204,6 +246,14 @@ describe("scenarioStore", () => {
     expect(state.previewNodes).toEqual([
       { id: "reactor1", type: "IdealGasReactor", properties: { length: 0.6 } },
     ]);
+  });
+
+  it("setActive on BASELINE previews with an empty overlay", async () => {
+    useScenarioStore.getState().applyOverlays({ A: { length: 0.6 } });
+
+    await useScenarioStore.getState().setActive("BASELINE");
+
+    expect(mockFetchScenarioPreview).toHaveBeenCalledWith("BASELINE", {});
   });
 
   it("setActive on a computed scenario loads its preview alongside the trajectory", async () => {
@@ -255,56 +305,5 @@ describe("scenarioStore", () => {
     await Promise.all([p1, p2]);
 
     expect(useScenarioStore.getState().previewId).toBe("B");
-  });
-
-  it("createScenario pushes the freshly-written config YAML into configStore", async () => {
-    mockCreateScenario.mockResolvedValue({ scenario_id: "C", yaml: "" });
-    mockListScenarios.mockResolvedValue({ available: false, scenarios: [], authored_ids: ["C"] });
-    mockFetchPreloadedConfig.mockResolvedValue({
-      preloaded: true,
-      yaml: "scenario:\n  C: {}\n",
-      filename: "config.yaml",
-    });
-
-    await useScenarioStore.getState().createScenario("C");
-
-    expect(mockSetOriginalYaml).toHaveBeenCalledWith("scenario:\n  C: {}\n", "config.yaml");
-  });
-
-  it("updateScenario/renameScenario/deleteScenario each also resync configStore's YAML", async () => {
-    mockRenameScenario.mockResolvedValue({ ok: true, scenario_id: "A2" });
-    mockDeleteScenario.mockResolvedValue({ ok: true, scenario_id: "A2" });
-    mockListScenarios.mockResolvedValue({ available: false, scenarios: [], authored_ids: [] });
-    mockFetchPreloadedConfig.mockResolvedValue({
-      preloaded: true,
-      yaml: "resynced",
-      filename: "config.yaml",
-    });
-
-    await useScenarioStore.getState().renameScenario("A", "A2");
-    expect(mockSetOriginalYaml).toHaveBeenCalledWith("resynced", "config.yaml");
-
-    mockSetOriginalYaml.mockClear();
-    await useScenarioStore.getState().deleteScenario("A2");
-    expect(mockSetOriginalYaml).toHaveBeenCalledWith("resynced", "config.yaml");
-  });
-
-  it("does not touch configStore when nothing is preloaded (e.g. an uploaded/pasted config)", async () => {
-    mockCreateScenario.mockResolvedValue({ scenario_id: "C", yaml: "" });
-    mockListScenarios.mockResolvedValue({ available: false, scenarios: [], authored_ids: ["C"] });
-    mockFetchPreloadedConfig.mockResolvedValue({ preloaded: false });
-
-    await useScenarioStore.getState().createScenario("C");
-
-    expect(mockSetOriginalYaml).not.toHaveBeenCalled();
-  });
-
-  it("swallows a resync fetch failure instead of rejecting the caller's promise", async () => {
-    mockCreateScenario.mockResolvedValue({ scenario_id: "C", yaml: "" });
-    mockListScenarios.mockResolvedValue({ available: false, scenarios: [], authored_ids: ["C"] });
-    mockFetchPreloadedConfig.mockRejectedValue(new Error("network error"));
-
-    await expect(useScenarioStore.getState().createScenario("C")).resolves.toBeUndefined();
-    expect(mockSetOriginalYaml).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/stores/scenarioStore.ts
+++ b/frontend/src/stores/scenarioStore.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
 import {
+  BASELINE_SCENARIO_ID,
   clearScenarioCache as apiClearScenarioCache,
   createScenario as apiCreateScenario,
   deleteScenario as apiDeleteScenario,
@@ -9,48 +10,40 @@ import {
   renameScenario as apiRenameScenario,
   updateScenario as apiUpdateScenario,
   type ScenarioMeta,
+  type ScenarioOverlay,
 } from "@/api/scenarios";
-import { fetchPreloadedConfig } from "@/api/configs";
 import type { ConfigConnection, ConfigNode } from "@/types/config";
-import { useConfigStore } from "./configStore";
 import { useSimulationStore } from "./simulationStore";
 import { useSelectionStore } from "./selectionStore";
 
-/**
- * Scenario authoring (create/update/rename/delete) writes straight to the
- * config file on disk, bypassing the in-memory graph entirely — so the YAML
- * pane's `originalYaml` snapshot (fetched once on load) goes stale the
- * moment a scenario changes. Re-fetch and push just that snapshot into
- * `configStore` (not the whole `config`, which would clobber any unsaved
- * node/connection edits) so the editor picks it up on its next refresh.
- */
-async function resyncConfigYaml(): Promise<void> {
-  try {
-    const resp = await fetchPreloadedConfig();
-    if (resp.preloaded && resp.yaml !== undefined) {
-      useConfigStore.getState().setOriginalYaml(resp.yaml, resp.filename);
-    }
-  } catch {
-    // Best-effort — the YAML pane just keeps showing its last-known text.
-  }
+function idsFromOverlays(overlays: Record<string, ScenarioOverlay>): string[] {
+  const ids = Object.keys(overlays);
+  return ids.length ? [BASELINE_SCENARIO_ID, ...ids] : [];
 }
 
 interface ScenarioState {
   available: boolean;
   scenarios: ScenarioMeta[];
-  /** Every scenario id in the config, computed or not — see `authored_ids`. */
+  /** Every scenario id, computed or not -- derived from `overlays`. */
   authoredIds: string[];
+  /**
+   * This session's in-memory scenario overlays -- the sole source of truth
+   * for scenario authoring now that it no longer touches disk. Seeded once
+   * from the server's startup snapshot (the first `refresh()`) and mutated
+   * locally from then on via `applyOverlays`; the only way any of this
+   * reaches disk is the Scenario YAML pane's "Download full YAML" button.
+   */
+  overlays: Record<string, ScenarioOverlay>;
+  overlaysSeeded: boolean;
   /** Unix seconds the store was written; drives the "computed X ago" label. */
   createdAt?: number;
   activeId: string | null;
   loading: boolean;
   error: string | null;
   /**
-   * Bumped by every `refresh()` (including the ones create/update/rename/
-   * delete already trigger internally) — listen to this instead of
-   * `scenarios` when you only care "did something about the scenarios
-   * change", e.g. to re-fetch unrelated derived info like Run Sweep's
-   * scenario count.
+   * Bumped by every `refresh()`/`applyOverlays()` call — listen to this
+   * instead of `scenarios`/`overlays` when you only care "did something
+   * about the scenarios change", e.g. to re-fetch unrelated derived info.
    */
   revision: number;
 
@@ -74,17 +67,25 @@ interface ScenarioState {
   setActive: (id: string) => Promise<void>;
   /**
    * Fetch `id`'s effective node/connection properties (base ⊕ overlay) into
-   * `previewNodes`/`previewConnections`. Called by `setActive` for every
-   * selection, so callers normally don't need to call this directly.
+   * `previewNodes`/`previewConnections`, using this store's own current
+   * overlay for `id`. Called by `setActive` for every selection, so callers
+   * normally don't need to call this directly.
    */
   loadPreview: (id: string) => Promise<void>;
   /**
-   * Create a new scenario overlay (blank, or cloned from `baseId`) and mark
-   * it active for editing. Throws on failure (id collision, no config file,
-   * bad YAML) so callers can show the error inline.
+   * Apply a scenario-mutation response's overlays map — every mutator below
+   * calls this. Exposed so a caller that mutates overlays directly through
+   * the API (e.g. the Properties panel's per-entity save) can fold its
+   * result back into this store without duplicating the bookkeeping.
    */
-  createScenario: (id: string, baseId?: string) => Promise<void>;
-  /** Save edits to a scenario overlay's YAML text. */
+  applyOverlays: (overlays: Record<string, ScenarioOverlay>) => void;
+  /**
+   * Create a new scenario overlay (blank, or cloned from `baseId`) and mark
+   * it active for editing. Throws on failure (id collision, bad base id) so
+   * callers can show the error inline.
+   */
+  createScenario: (id: string, baseId?: string, description?: string) => Promise<void>;
+  /** Apply edits to a scenario overlay's YAML text. */
   updateScenario: (id: string, yaml: string) => Promise<void>;
   /** Rename a scenario's id. */
   renameScenario: (id: string, newId: string) => Promise<void>;
@@ -98,6 +99,8 @@ export const useScenarioStore = create<ScenarioState>((set, get) => ({
   available: false,
   scenarios: [],
   authoredIds: [],
+  overlays: {},
+  overlaysSeeded: false,
   activeId: null,
   loading: false,
   error: null,
@@ -112,56 +115,65 @@ export const useScenarioStore = create<ScenarioState>((set, get) => ({
   refresh: async () => {
     try {
       const resp = await listScenarios();
-      set((s) => ({
-        available: resp.available,
-        scenarios: resp.scenarios ?? [],
-        authoredIds: resp.authored_ids ?? [],
-        createdAt: resp.created_at ?? undefined,
-        revision: s.revision + 1,
-      }));
+      set((s) => {
+        // The server's `authored_overlays` is its startup snapshot -- only
+        // the seed for this store's own state, never applied again after
+        // the first call, or every refresh would clobber local edits with
+        // stale disk content.
+        const overlays = s.overlaysSeeded ? s.overlays : resp.authored_overlays ?? {};
+        return {
+          available: resp.available,
+          scenarios: resp.scenarios ?? [],
+          overlays,
+          overlaysSeeded: true,
+          authoredIds: idsFromOverlays(overlays),
+          createdAt: resp.created_at ?? undefined,
+          revision: s.revision + 1,
+        };
+      });
     } catch {
       // No store / API not ready: the pane simply stays hidden.
       set((s) => ({
         available: false,
         scenarios: [],
-        authoredIds: [],
         revision: s.revision + 1,
       }));
     }
   },
 
-  createScenario: async (id, baseId) => {
-    await apiCreateScenario(id, baseId);
+  applyOverlays: (overlays) => {
+    set((s) => ({
+      overlays,
+      overlaysSeeded: true,
+      authoredIds: idsFromOverlays(overlays),
+      revision: s.revision + 1,
+    }));
+  },
+
+  createScenario: async (id, baseId, description) => {
+    const resp = await apiCreateScenario(get().overlays, id, baseId, description);
+    get().applyOverlays(resp.overlays);
     set({ activeId: id });
-    // The scenario config now exists but has no precomputed trajectory yet
-    // (that needs a Run Sweep) — refresh so it shows up as a clone base and
-    // Run Sweep's scenario count picks it up, even though `scenarios` (the
-    // HDF5-derived list) won't include it until a sweep actually runs.
-    await get().refresh();
-    await resyncConfigYaml();
   },
 
   updateScenario: async (id, yaml) => {
-    await apiUpdateScenario(id, yaml);
-    await get().refresh();
-    await resyncConfigYaml();
+    const resp = await apiUpdateScenario(get().overlays, id, yaml);
+    get().applyOverlays(resp.overlays);
   },
 
   renameScenario: async (id, newId) => {
-    await apiRenameScenario(id, newId);
+    const resp = await apiRenameScenario(get().overlays, id, newId);
+    get().applyOverlays(resp.overlays);
     if (get().activeId === id) set({ activeId: newId });
-    await get().refresh();
-    await resyncConfigYaml();
   },
 
   deleteScenario: async (id) => {
-    const resp = await apiDeleteScenario(id);
+    const resp = await apiDeleteScenario(get().overlays, id);
+    get().applyOverlays(resp.overlays);
     if (get().activeId === id) set({ activeId: null });
     if (get().previewId === id) {
       set({ previewId: null, previewNodes: null, previewConnections: null, previewError: null });
     }
-    await get().refresh();
-    await resyncConfigYaml();
     return { cachePurged: resp.cache_purged };
   },
 
@@ -219,8 +231,9 @@ export const useScenarioStore = create<ScenarioState>((set, get) => ({
   loadPreview: async (id) => {
     const seq = get().previewSeq + 1;
     set({ previewSeq: seq, previewLoading: true, previewError: null });
+    const overlay = id === BASELINE_SCENARIO_ID ? {} : get().overlays[id] ?? {};
     try {
-      const preview = await fetchScenarioPreview(id);
+      const preview = await fetchScenarioPreview(id, overlay);
       if (get().previewSeq !== seq) return; // superseded by a newer selection
       set({
         previewId: id,

--- a/frontend/src/stores/sweepStore.test.ts
+++ b/frontend/src/stores/sweepStore.test.ts
@@ -18,11 +18,13 @@ const mockRefresh = vi.fn();
 const mockSetActive = vi.fn();
 let mockActiveId: string | null = null;
 let mockScenarios: Array<{ id: string }> = [];
+let mockOverlays: Record<string, unknown> = {};
 vi.mock("./scenarioStore", () => ({
   useScenarioStore: {
     getState: () => ({
       refresh: mockRefresh,
       setActive: mockSetActive,
+      overlays: mockOverlays,
       get activeId() {
         return mockActiveId;
       },
@@ -49,6 +51,7 @@ describe("sweepStore", () => {
     vi.clearAllMocks();
     mockActiveId = null;
     mockScenarios = [];
+    mockOverlays = {};
     useSweepRunStore.setState({
       sweeping: false,
       progress: { current: 0, total: 0 },
@@ -100,13 +103,17 @@ describe("sweepStore", () => {
     expect(mockRefresh).not.toHaveBeenCalled();
   });
 
-  it("run() passes noCache through to startSweep, forcing a full recompute", async () => {
+  it("run() passes noCache and the current scenario overlays through to startSweep", async () => {
     vi.useFakeTimers();
+    mockOverlays = { a: { torch_eff: 0.5 } };
     mockStartSweep.mockResolvedValue({ status: "running", total: 1 });
     mockGetSweepStatus.mockResolvedValueOnce({ status: "done", current: 1, total: 1 });
 
     useSweepRunStore.getState().run({ total: 1, noCache: true });
-    expect(mockStartSweep).toHaveBeenCalledWith({ noCache: true });
+    expect(mockStartSweep).toHaveBeenCalledWith({
+      scenarios: { a: { torch_eff: 0.5 } },
+      noCache: true,
+    });
 
     await vi.advanceTimersByTimeAsync(0);
     await vi.advanceTimersByTimeAsync(1000);

--- a/frontend/src/stores/sweepStore.ts
+++ b/frontend/src/stores/sweepStore.ts
@@ -135,7 +135,8 @@ export const useSweepRunStore = create<SweepRunState>((set, get) => {
         return;
       }
       set({ sweeping: true, progress: { current: 0, total: options?.total ?? 0 } });
-      startSweep({ noCache: options?.noCache })
+      const scenarios = useScenarioStore.getState().overlays;
+      startSweep({ scenarios, noCache: options?.noCache })
         .then(() => startPolling())
         .catch((e) => {
           set({ sweeping: false });

--- a/tests/test_live_config_adoption.py
+++ b/tests/test_live_config_adoption.py
@@ -160,9 +160,9 @@ class TestParseYamlAdoptsLiveConfig:
     def test_sweep_info_reflects_scenarios_after_parse(self):
         """GET /api/sweep sees a browser-pasted `scenarios:` block after Save.
 
-        `can_run` still correctly requires an actual runner (none registered
-        here) -- but `available`/`n_scenarios` must reflect the live config
-        instead of staying stuck at the pre-adoption "no file" defaults.
+        `available`/`n_scenarios`/`can_run` must reflect the live config
+        instead of staying stuck at the pre-adoption "no file" defaults. Run
+        Sweep runs in-process now -- no external runner to register/check for.
         """
         client, app = _client()
         try:
@@ -174,8 +174,8 @@ class TestParseYamlAdoptsLiveConfig:
             assert info["available"] is True
             # Union run-set size: the baseline config + the one named scenario.
             assert info["n_scenarios"] == 2
-            assert info["can_run"] is False  # no sweep_runner plugin registered
-            assert info["reason"] == "No scenario runner available"
+            assert info["can_run"] is True
+            assert info["reason"] == "Run 2 scenarios"
         finally:
             client.__exit__(None, None, None)
 

--- a/tests/test_scenario_editing.py
+++ b/tests/test_scenario_editing.py
@@ -1,14 +1,20 @@
 """Tests for scenario authoring: POST/PATCH/DELETE /api/scenarios*.
 
 Unlike the read routes in ``test_scenario_focus.py`` (which serve precomputed
-HDF5 trajectories), these edit the *source* config file's ``scenarios:``
-mapping on disk — the input side of the Scenario Pane's create/edit workflow.
+HDF5 trajectories), these cover the input side of the Scenario Pane's
+create/edit workflow. Every mutating route here is a pure, stateless
+transform: the caller sends the *current* overlays map and gets back the
+*new* one — nothing is written to disk or kept on ``app.state`` between
+requests (see ``boulder/scenario_editor.py``'s module docstring). Tests fetch
+the config's startup `scenarios:` block once via `GET /api/scenarios`
+(mirroring what the frontend's `scenarioStore` does on load), then thread the
+returned `overlays` through each call exactly like the frontend would.
 """
 
 from __future__ import annotations
 
 from pathlib import Path
-from typing import List
+from typing import Any, Dict, List
 
 import pytest
 
@@ -55,43 +61,57 @@ def _client_with_config(cfg_path: Path):
     return client, app
 
 
-def _scenario_ids(cfg_path: Path) -> List[str]:
-    from boulder.scenario_editor import list_scenario_ids
+def _authored_overlays(client: TestClient) -> Dict[str, Any]:
+    """Return the config's startup `scenarios:` block -- what `scenarioStore` seeds from."""
+    return client.get("/api/scenarios").json()["authored_overlays"]
 
-    return list_scenario_ids(cfg_path)
+
+def _authored_ids(client: TestClient) -> List[str]:
+    return client.get("/api/scenarios").json()["authored_ids"]
 
 
-def test_create_scenario_requires_config_path() -> None:
+def test_create_scenario_works_without_a_config_path() -> None:
+    """Scenario creation is a pure function now -- no config file is required."""
     app = create_app()
     with TestClient(app) as client:
         app.state.preloaded_config_path = None
-        resp = client.post("/api/scenarios", json={"scenario_id": "new1"})
-        assert resp.status_code == 400
+        resp = client.post(
+            "/api/scenarios", json={"overlays": {}, "scenario_id": "new1"}
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["overlays"] == {"new1": {}}
 
 
 def test_create_scenario_blank(tmp_path: Path) -> None:
     cfg = _write_config(tmp_path)
-    client, app = _client_with_config(cfg)
+    client, _app = _client_with_config(cfg)
     try:
-        resp = client.post("/api/scenarios", json={"scenario_id": "new1"})
+        overlays = _authored_overlays(client)
+        resp = client.post(
+            "/api/scenarios", json={"overlays": overlays, "scenario_id": "new1"}
+        )
         assert resp.status_code == 200, resp.text
         assert resp.json()["scenario_id"] == "new1"
-        assert _scenario_ids(cfg) == ["BASELINE", "base_case", "new1"]
-        # preloaded_raw refreshed so Run Sweep sees the new scenario immediately.
-        assert "new1" in (app.state.preloaded_raw.get("scenarios") or {})
-        # The pre-existing comment elsewhere in the file survives.
-        assert "keep this comment" in cfg.read_text(encoding="utf-8")
+        assert set(resp.json()["overlays"].keys()) == {"base_case", "new1"}
+        # Nothing here ever touches disk -- the pre-existing comment (and
+        # everything else in the file) is exactly as it was.
+        assert cfg.read_text(encoding="utf-8") == _BASE_YAML
     finally:
         client.__exit__(None, None, None)
 
 
 def test_create_scenario_clone(tmp_path: Path) -> None:
     cfg = _write_config(tmp_path)
-    client, app = _client_with_config(cfg)
+    client, _app = _client_with_config(cfg)
     try:
+        overlays = _authored_overlays(client)
         resp = client.post(
             "/api/scenarios",
-            json={"scenario_id": "clone1", "base_scenario_id": "base_case"},
+            json={
+                "overlays": overlays,
+                "scenario_id": "clone1",
+                "base_scenario_id": "base_case",
+            },
         )
         assert resp.status_code == 200, resp.text
         assert "scenario_name:" in resp.json()["yaml"]
@@ -100,11 +120,55 @@ def test_create_scenario_clone(tmp_path: Path) -> None:
         client.__exit__(None, None, None)
 
 
+def test_create_scenario_with_description(tmp_path: Path) -> None:
+    cfg = _write_config(tmp_path)
+    client, _app = _client_with_config(cfg)
+    try:
+        overlays = _authored_overlays(client)
+        resp = client.post(
+            "/api/scenarios",
+            json={
+                "overlays": overlays,
+                "scenario_id": "new1",
+                "description": "Case 1 max",
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        assert "Case 1 max" in resp.json()["yaml"]
+    finally:
+        client.__exit__(None, None, None)
+
+
+def test_create_scenario_clone_description_overrides_inherited(tmp_path: Path) -> None:
+    cfg = _write_config(tmp_path)
+    client, _app = _client_with_config(cfg)
+    try:
+        overlays = _authored_overlays(client)
+        resp = client.post(
+            "/api/scenarios",
+            json={
+                "overlays": overlays,
+                "scenario_id": "clone1",
+                "base_scenario_id": "base_case",
+                "description": "Distinct description",
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        yaml_text = resp.json()["yaml"]
+        assert "Distinct description" in yaml_text
+        assert "Base Case" not in yaml_text
+    finally:
+        client.__exit__(None, None, None)
+
+
 def test_create_scenario_duplicate_422(tmp_path: Path) -> None:
     cfg = _write_config(tmp_path)
     client, _app = _client_with_config(cfg)
     try:
-        resp = client.post("/api/scenarios", json={"scenario_id": "base_case"})
+        overlays = _authored_overlays(client)
+        resp = client.post(
+            "/api/scenarios", json={"overlays": overlays, "scenario_id": "base_case"}
+        )
         assert resp.status_code == 422
     finally:
         client.__exit__(None, None, None)
@@ -114,7 +178,9 @@ def test_create_scenario_bad_id_422(tmp_path: Path) -> None:
     cfg = _write_config(tmp_path)
     client, _app = _client_with_config(cfg)
     try:
-        resp = client.post("/api/scenarios", json={"scenario_id": "bad id!"})
+        resp = client.post(
+            "/api/scenarios", json={"overlays": {}, "scenario_id": "bad id!"}
+        )
         assert resp.status_code == 422
     finally:
         client.__exit__(None, None, None)
@@ -129,7 +195,9 @@ def test_create_scenario_reserved_baseline_id_422(tmp_path: Path) -> None:
     cfg = _write_config(tmp_path)
     client, _app = _client_with_config(cfg)
     try:
-        resp = client.post("/api/scenarios", json={"scenario_id": "BASELINE"})
+        resp = client.post(
+            "/api/scenarios", json={"overlays": {}, "scenario_id": "BASELINE"}
+        )
         assert resp.status_code == 422
     finally:
         client.__exit__(None, None, None)
@@ -138,14 +206,19 @@ def test_create_scenario_reserved_baseline_id_422(tmp_path: Path) -> None:
 def test_create_scenario_clone_from_baseline_is_blank(tmp_path: Path) -> None:
     """Cloning "BASELINE" must produce a blank overlay, not an unknown-base error.
 
-    BASELINE is the unmodified base config, not a real scenario_map entry.
+    BASELINE is the unmodified base config, not a real overlays-map entry.
     """
     cfg = _write_config(tmp_path)
     client, _app = _client_with_config(cfg)
     try:
+        overlays = _authored_overlays(client)
         resp = client.post(
             "/api/scenarios",
-            json={"scenario_id": "from_baseline", "base_scenario_id": "BASELINE"},
+            json={
+                "overlays": overlays,
+                "scenario_id": "from_baseline",
+                "base_scenario_id": "BASELINE",
+            },
         )
         assert resp.status_code == 200, resp.text
         assert resp.json()["yaml"].strip() in ("", "{}")
@@ -159,7 +232,7 @@ def test_create_scenario_unknown_base_422(tmp_path: Path) -> None:
     try:
         resp = client.post(
             "/api/scenarios",
-            json={"scenario_id": "new1", "base_scenario_id": "nope"},
+            json={"overlays": {}, "scenario_id": "new1", "base_scenario_id": "nope"},
         )
         assert resp.status_code == 422
     finally:
@@ -170,41 +243,48 @@ def test_get_scenario_source(tmp_path: Path) -> None:
     cfg = _write_config(tmp_path)
     client, _app = _client_with_config(cfg)
     try:
-        resp = client.get("/api/scenarios/base_case/source")
+        overlays = _authored_overlays(client)
+        resp = client.post(
+            "/api/scenarios/base_case/source", json={"overlay": overlays["base_case"]}
+        )
         assert resp.status_code == 200
         assert "scenario_name" in resp.json()["yaml"]
     finally:
         client.__exit__(None, None, None)
 
 
-def test_get_scenario_source_unknown_404(tmp_path: Path) -> None:
+def test_get_scenario_source_renders_whatever_overlay_is_sent(tmp_path: Path) -> None:
+    """Stateless: there's no server-side "unknown scenario" to 404 on anymore."""
     cfg = _write_config(tmp_path)
     client, _app = _client_with_config(cfg)
     try:
-        resp = client.get("/api/scenarios/nope/source")
-        assert resp.status_code == 404
+        resp = client.post("/api/scenarios/nope/source", json={"overlay": {}})
+        assert resp.status_code == 200
+        assert resp.json()["yaml"].strip() in ("", "{}")
     finally:
         client.__exit__(None, None, None)
 
 
 def test_update_scenario(tmp_path: Path) -> None:
     cfg = _write_config(tmp_path)
-    client, app = _client_with_config(cfg)
+    client, _app = _client_with_config(cfg)
     try:
+        overlays = _authored_overlays(client)
         new_yaml = (
             "metadata:\n  scenario_name: Updated\n"
             "network:\n  - id: feed\n    Reservoir:\n      temperature: 350.0\n"
         )
-        resp = client.patch("/api/scenarios/base_case", json={"yaml": new_yaml})
+        resp = client.patch(
+            "/api/scenarios/base_case", json={"overlays": overlays, "yaml": new_yaml}
+        )
         assert resp.status_code == 200, resp.text
         assert "Updated" in resp.json()["yaml"]
-        assert "350.0" in cfg.read_text(encoding="utf-8")
         assert (
-            app.state.preloaded_raw["scenarios"]["base_case"]["metadata"][
-                "scenario_name"
-            ]
+            resp.json()["overlays"]["base_case"]["metadata"]["scenario_name"]
             == "Updated"
         )
+        # Nothing here ever touches disk.
+        assert "Updated" not in cfg.read_text(encoding="utf-8")
     finally:
         client.__exit__(None, None, None)
 
@@ -213,8 +293,10 @@ def test_update_scenario_invalid_yaml_422(tmp_path: Path) -> None:
     cfg = _write_config(tmp_path)
     client, _app = _client_with_config(cfg)
     try:
+        overlays = _authored_overlays(client)
         resp = client.patch(
-            "/api/scenarios/base_case", json={"yaml": "not: [valid: yaml"}
+            "/api/scenarios/base_case",
+            json={"overlays": overlays, "yaml": "not: [valid: yaml"},
         )
         assert resp.status_code == 422
     finally:
@@ -225,7 +307,9 @@ def test_update_scenario_unknown_422(tmp_path: Path) -> None:
     cfg = _write_config(tmp_path)
     client, _app = _client_with_config(cfg)
     try:
-        resp = client.patch("/api/scenarios/nope", json={"yaml": "a: 1"})
+        resp = client.patch(
+            "/api/scenarios/nope", json={"overlays": {}, "yaml": "a: 1"}
+        )
         assert resp.status_code == 422
     finally:
         client.__exit__(None, None, None)
@@ -290,15 +374,16 @@ def _write_staged_config(tmp_path: Path) -> Path:
 
 def test_update_scenario_entity_creates_overlay_entry(tmp_path: Path) -> None:
     cfg = _write_staged_config(tmp_path)
-    client, app = _client_with_config(cfg)
+    client, _app = _client_with_config(cfg)
     try:
+        overlays = _authored_overlays(client)
         resp = client.patch(
             "/api/scenarios/s_case/entities/torch",
-            json={"properties": {"volume": 2.0}},
+            json={"overlays": overlays, "properties": {"volume": 2.0}},
         )
         assert resp.status_code == 200, resp.text
         # Lands under the node's own stage list ("torch_stage"), not "network".
-        overlay = app.state.preloaded_raw["scenarios"]["s_case"]
+        overlay = resp.json()["overlays"]["s_case"]
         torch_entry = next(n for n in overlay["torch_stage"] if n["id"] == "torch")
         assert torch_entry["IdealGasReactor"]["volume"] == 2.0
     finally:
@@ -308,18 +393,20 @@ def test_update_scenario_entity_creates_overlay_entry(tmp_path: Path) -> None:
 def test_update_scenario_entity_merges_into_existing_entry(tmp_path: Path) -> None:
     """A second edit adds a key without clobbering the first override."""
     cfg = _write_staged_config(tmp_path)
-    client, app = _client_with_config(cfg)
+    client, _app = _client_with_config(cfg)
     try:
-        client.patch(
+        overlays = _authored_overlays(client)
+        resp1 = client.patch(
             "/api/scenarios/s_case/entities/torch",
-            json={"properties": {"volume": 2.0}},
+            json={"overlays": overlays, "properties": {"volume": 2.0}},
         )
-        resp = client.patch(
+        overlays2 = resp1.json()["overlays"]
+        resp2 = client.patch(
             "/api/scenarios/s_case/entities/inlet_to_torch",
-            json={"properties": {"mass_flow_rate": 0.2}},
+            json={"overlays": overlays2, "properties": {"mass_flow_rate": 0.2}},
         )
-        assert resp.status_code == 200, resp.text
-        overlay = app.state.preloaded_raw["scenarios"]["s_case"]
+        assert resp2.status_code == 200, resp2.text
+        overlay = resp2.json()["overlays"]["s_case"]
         torch_entry = next(n for n in overlay["torch_stage"] if n["id"] == "torch")
         assert torch_entry["IdealGasReactor"]["volume"] == 2.0
         mfc_entry = next(
@@ -333,14 +420,15 @@ def test_update_scenario_entity_merges_into_existing_entry(tmp_path: Path) -> No
 def test_update_scenario_entity_kindless_logical_connection(tmp_path: Path) -> None:
     """A logical connection (no type key) gets properties directly on the item."""
     cfg = _write_staged_config(tmp_path)
-    client, app = _client_with_config(cfg)
+    client, _app = _client_with_config(cfg)
     try:
+        overlays = _authored_overlays(client)
         resp = client.patch(
             "/api/scenarios/s_case/entities/torch_to_psr",
-            json={"properties": {"logical": True}},
+            json={"overlays": overlays, "properties": {"logical": True}},
         )
         assert resp.status_code == 200, resp.text
-        overlay = app.state.preloaded_raw["scenarios"]["s_case"]
+        overlay = resp.json()["overlays"]["s_case"]
         entry = next(n for n in overlay["psr_stage"] if n["id"] == "torch_to_psr")
         assert entry["logical"] is True
     finally:
@@ -351,9 +439,10 @@ def test_update_scenario_entity_baseline_422(tmp_path: Path) -> None:
     cfg = _write_staged_config(tmp_path)
     client, _app = _client_with_config(cfg)
     try:
+        overlays = _authored_overlays(client)
         resp = client.patch(
             "/api/scenarios/BASELINE/entities/torch",
-            json={"properties": {"volume": 2.0}},
+            json={"overlays": overlays, "properties": {"volume": 2.0}},
         )
         assert resp.status_code == 422
     finally:
@@ -364,9 +453,10 @@ def test_update_scenario_entity_unknown_scenario_422(tmp_path: Path) -> None:
     cfg = _write_staged_config(tmp_path)
     client, _app = _client_with_config(cfg)
     try:
+        overlays = _authored_overlays(client)
         resp = client.patch(
             "/api/scenarios/nope/entities/torch",
-            json={"properties": {"volume": 2.0}},
+            json={"overlays": overlays, "properties": {"volume": 2.0}},
         )
         assert resp.status_code == 422
     finally:
@@ -377,9 +467,10 @@ def test_update_scenario_entity_unknown_entity_422(tmp_path: Path) -> None:
     cfg = _write_staged_config(tmp_path)
     client, _app = _client_with_config(cfg)
     try:
+        overlays = _authored_overlays(client)
         resp = client.patch(
             "/api/scenarios/s_case/entities/nope",
-            json={"properties": {"volume": 2.0}},
+            json={"overlays": overlays, "properties": {"volume": 2.0}},
         )
         assert resp.status_code == 422
     finally:
@@ -390,9 +481,10 @@ def test_update_scenario_entity_empty_properties_is_noop(tmp_path: Path) -> None
     cfg = _write_staged_config(tmp_path)
     client, _app = _client_with_config(cfg)
     try:
+        overlays = _authored_overlays(client)
         resp = client.patch(
             "/api/scenarios/s_case/entities/torch",
-            json={"properties": {}},
+            json={"overlays": overlays, "properties": {}},
         )
         assert resp.status_code == 200, resp.text
         assert resp.json()["yaml"].strip() in ("", "{}")
@@ -404,23 +496,27 @@ def test_rename_scenario(tmp_path: Path) -> None:
     cfg = _write_config(tmp_path)
     client, _app = _client_with_config(cfg)
     try:
+        overlays = _authored_overlays(client)
         resp = client.patch(
-            "/api/scenarios/base_case/rename", json={"new_id": "renamed"}
+            "/api/scenarios/base_case/rename",
+            json={"overlays": overlays, "new_id": "renamed"},
         )
         assert resp.status_code == 200, resp.text
-        assert _scenario_ids(cfg) == ["BASELINE", "renamed"]
+        assert set(resp.json()["overlays"].keys()) == {"renamed"}
     finally:
         client.__exit__(None, None, None)
 
 
 def test_delete_scenario(tmp_path: Path) -> None:
     cfg = _write_config(tmp_path)
-    client, app = _client_with_config(cfg)
+    client, _app = _client_with_config(cfg)
     try:
-        resp = client.delete("/api/scenarios/base_case")
+        overlays = _authored_overlays(client)
+        resp = client.request(
+            "DELETE", "/api/scenarios/base_case", json={"overlays": overlays}
+        )
         assert resp.status_code == 200, resp.text
-        assert _scenario_ids(cfg) == []
-        assert not (app.state.preloaded_raw.get("scenarios") or {})
+        assert resp.json()["overlays"] == {}
     finally:
         client.__exit__(None, None, None)
 
@@ -444,7 +540,10 @@ def test_delete_scenario_purges_cached_group(tmp_path: Path) -> None:
             grp.create_dataset("payload_json", data=b"{}")
         app.state.scenario_store_path = str(store)
 
-        resp = client.delete("/api/scenarios/base_case")
+        overlays = _authored_overlays(client)
+        resp = client.request(
+            "DELETE", "/api/scenarios/base_case", json={"overlays": overlays}
+        )
         assert resp.status_code == 200, resp.text
         assert resp.json()["cache_purged"] is True
 
@@ -459,7 +558,10 @@ def test_delete_scenario_without_cached_group_reports_false(tmp_path: Path) -> N
     cfg = _write_config(tmp_path)
     client, _app = _client_with_config(cfg)
     try:
-        resp = client.delete("/api/scenarios/base_case")
+        overlays = _authored_overlays(client)
+        resp = client.request(
+            "DELETE", "/api/scenarios/base_case", json={"overlays": overlays}
+        )
         assert resp.status_code == 200, resp.text
         assert resp.json()["cache_purged"] is False
     finally:
@@ -470,7 +572,7 @@ def test_delete_scenario_unknown_404(tmp_path: Path) -> None:
     cfg = _write_config(tmp_path)
     client, _app = _client_with_config(cfg)
     try:
-        resp = client.delete("/api/scenarios/nope")
+        resp = client.request("DELETE", "/api/scenarios/nope", json={"overlays": {}})
         assert resp.status_code == 404
     finally:
         client.__exit__(None, None, None)
@@ -493,8 +595,9 @@ def test_clear_scenario_cache_deletes_the_store(tmp_path: Path) -> None:
         assert resp.status_code == 200, resp.text
         assert resp.json() == {"ok": True, "cleared": True}
         assert not store.exists()
-        # Scenario definitions in the config are untouched.
-        assert _scenario_ids(cfg) == ["BASELINE", "base_case"]
+        # Scenario definitions are untouched -- this only ever affected the
+        # results cache, never the scenario overlays themselves.
+        assert _authored_ids(client) == ["BASELINE", "base_case"]
     finally:
         client.__exit__(None, None, None)
 
@@ -511,11 +614,9 @@ def test_clear_scenario_cache_without_a_store_reports_false(tmp_path: Path) -> N
 
 
 def test_list_scenarios_includes_authored_ids_without_a_store(tmp_path: Path) -> None:
-    """authored_ids reflects the YAML directly, even with no HDF5 store.
+    """authored_ids/authored_overlays reflect the YAML directly, even with no HDF5 store.
 
-    So a scenario created (or edited) since the last sweep can still be
-    offered as an Add Scenario clone base, instead of only ones a sweep has
-    already computed.
+    This is the seed `scenarioStore` uses even before the first sweep.
     """
     cfg = _write_config(tmp_path)
     client, _app = _client_with_config(cfg)
@@ -525,19 +626,25 @@ def test_list_scenarios_includes_authored_ids_without_a_store(tmp_path: Path) ->
         body = resp.json()
         assert body["available"] is False
         assert body["authored_ids"] == ["BASELINE", "base_case"]
+        assert "base_case" in body["authored_overlays"]
     finally:
         client.__exit__(None, None, None)
 
 
-def test_list_scenarios_authored_ids_reflects_a_newly_created_scenario(
-    tmp_path: Path,
-) -> None:
+def test_list_scenarios_reflects_only_the_startup_snapshot(tmp_path: Path) -> None:
+    """Creating/editing a scenario doesn't persist anywhere server-side.
+
+    A later GET still only reflects the config's startup `scenarios:` block,
+    not anything created via a previous, independent request. From here on,
+    a newly created scenario lives only in the caller's own state (mirrored
+    by `scenarioStore.overlays` in the frontend).
+    """
     cfg = _write_config(tmp_path)
     client, _app = _client_with_config(cfg)
     try:
-        client.post("/api/scenarios", json={"scenario_id": "new1"})
+        client.post("/api/scenarios", json={"overlays": {}, "scenario_id": "new1"})
         resp = client.get("/api/scenarios")
-        assert resp.json()["authored_ids"] == ["BASELINE", "base_case", "new1"]
+        assert resp.json()["authored_ids"] == ["BASELINE", "base_case"]
     finally:
         client.__exit__(None, None, None)
 

--- a/tests/test_scenario_preview.py
+++ b/tests/test_scenario_preview.py
@@ -1,14 +1,18 @@
-"""Tests for GET /api/scenarios/{id}/preview.
+"""Tests for POST /api/scenarios/{id}/preview.
 
 Unlike `/scenarios/{id}` (a precomputed HDF5 trajectory — 404s until a sweep has
 solved it), `/preview` deep-merges an authored scenario's overlay onto the base
 config and returns the effective node/connection properties, so the GUI's Inputs
 pane can show a scenario's parameter overrides before it has ever been solved.
+Stateless: the caller sends the overlay to preview (its own `scenarioStore.
+overlays[id]`, or `{}` for BASELINE) — there's no server-side scenario lookup
+by id to 404 on anymore.
 """
 
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any, Dict
 
 import pytest
 
@@ -67,6 +71,10 @@ def _client_fully_preloaded(cfg_path: Path):
     return client, app
 
 
+def _authored_overlays(client: TestClient) -> Dict[str, Any]:
+    return client.get("/api/scenarios").json()["authored_overlays"]
+
+
 def _node(body: dict, node_id: str) -> dict:
     return next(n for n in body["nodes"] if n["id"] == node_id)
 
@@ -76,7 +84,10 @@ def test_preview_authored_scenario_overrides_property(tmp_path: Path) -> None:
     cfg = _write_config(tmp_path)
     client, _app = _client_with_config(cfg)
     try:
-        resp = client.get("/api/scenarios/base_case/preview")
+        overlay = _authored_overlays(client)["base_case"]
+        resp = client.post(
+            "/api/scenarios/base_case/preview", json={"overlay": overlay}
+        )
         assert resp.status_code == 200, resp.text
         body = resp.json()
         assert body["scenario_id"] == "base_case"
@@ -89,7 +100,7 @@ def test_preview_baseline_returns_unmodified_base_values(tmp_path: Path) -> None
     cfg = _write_config(tmp_path)
     client, _app = _client_with_config(cfg)
     try:
-        resp = client.get("/api/scenarios/BASELINE/preview")
+        resp = client.post("/api/scenarios/BASELINE/preview", json={"overlay": {}})
         assert resp.status_code == 200, resp.text
         body = resp.json()
         assert _node(body, "feed")["properties"]["temperature"] == 298.15
@@ -97,12 +108,21 @@ def test_preview_baseline_returns_unmodified_base_values(tmp_path: Path) -> None
         client.__exit__(None, None, None)
 
 
-def test_preview_unknown_scenario_404(tmp_path: Path) -> None:
+def test_preview_ignores_the_path_id_and_just_renders_whatever_overlay_is_sent(
+    tmp_path: Path,
+) -> None:
+    """Stateless: there's no server-side "unknown scenario" to 404 on anymore.
+
+    The `{id}` in the path is just an echo label in the response.
+    """
     cfg = _write_config(tmp_path)
     client, _app = _client_with_config(cfg)
     try:
-        resp = client.get("/api/scenarios/nope/preview")
-        assert resp.status_code == 404
+        overlay = _authored_overlays(client)["base_case"]
+        resp = client.post("/api/scenarios/nope/preview", json={"overlay": overlay})
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["scenario_id"] == "nope"
+        assert _node(resp.json(), "feed")["properties"]["temperature"] == 320.0
     finally:
         client.__exit__(None, None, None)
 
@@ -111,21 +131,24 @@ def test_preview_without_a_config_404() -> None:
     app = create_app()
     with TestClient(app) as client:
         app.state.preloaded_config_path = None
-        resp = client.get("/api/scenarios/base_case/preview")
+        resp = client.post("/api/scenarios/base_case/preview", json={"overlay": {}})
         assert resp.status_code == 404
 
 
 def test_preview_falls_back_to_disk_when_preloaded_raw_is_unset(tmp_path: Path) -> None:
     """The `preloaded_config_path`-only setup (as in scenario-editing tests) still works.
 
-    `preloaded_raw` isn't populated until a scenario CRUD call reloads it, but
-    the preview route must not depend on that having happened yet.
+    `preloaded_raw` isn't populated by these tests' minimal setup, but the
+    preview route must not depend on that having happened.
     """
     cfg = _write_config(tmp_path)
     client, app = _client_with_config(cfg)
     try:
         assert app.state.preloaded_raw is None
-        resp = client.get("/api/scenarios/base_case/preview")
+        overlay = _authored_overlays(client)["base_case"]
+        resp = client.post(
+            "/api/scenarios/base_case/preview", json={"overlay": overlay}
+        )
         assert resp.status_code == 200, resp.text
         assert _node(resp.json(), "feed")["properties"]["temperature"] == 320.0
     finally:
@@ -136,7 +159,10 @@ def test_preview_reflects_fully_preloaded_app_state(tmp_path: Path) -> None:
     cfg = _write_config(tmp_path)
     client, _app = _client_fully_preloaded(cfg)
     try:
-        resp = client.get("/api/scenarios/base_case/preview")
+        overlay = _authored_overlays(client)["base_case"]
+        resp = client.post(
+            "/api/scenarios/base_case/preview", json={"overlay": overlay}
+        )
         assert resp.status_code == 200, resp.text
         assert _node(resp.json(), "feed")["properties"]["temperature"] == 320.0
     finally:

--- a/tests/test_sweep_run_no_cache.py
+++ b/tests/test_sweep_run_no_cache.py
@@ -1,17 +1,19 @@
-"""Tests for POST /api/sweep/run's `no_cache` passthrough.
+"""Tests for POST /api/sweep/run's `no_cache` behavior.
 
-A caller can reuse the plain "Run Sweep" endpoint with ``no_cache: true`` to
-force a full recompute, which must set ``BOULDER_NO_CACHE=1`` in the
-subprocess env so a cache-aware host runner discards its collection store
-instead of skipping unchanged scenarios.
+Run Sweep runs in-process now (see `boulder/api/routes/sweep.py`) -- `no_cache`
+deletes the collection store before running instead of setting an env var for
+a subprocess, so a cache-aware host discards unchanged-fingerprint skips and
+re-solves every scenario. These tests stand in for `SimulationWorker` with a
+fake (see `test_sweep_status_scenario_progress.py`) so caching behavior can be
+asserted without a real Cantera solve.
 """
 
 from __future__ import annotations
 
-import threading
+import time
 from pathlib import Path
-from typing import Any, Dict
-from unittest.mock import MagicMock, patch
+from typing import Any, Callable, List
+from unittest.mock import patch
 
 import pytest
 
@@ -20,6 +22,7 @@ pytest.importorskip("fastapi")
 from fastapi.testclient import TestClient  # noqa: E402
 
 from boulder.api.main import create_app  # noqa: E402
+from boulder.simulation_worker import SimulationProgress  # noqa: E402
 
 _CONFIG_YAML = """\
 metadata:
@@ -33,88 +36,126 @@ network:
       temperature: 298.15
       pressure: 101325
       composition: "CH4:1"
-scenarios:
-  a:
-    metadata:
-      scenario_name: "A"
 """
 
 
-def _client_with_local_runner(tmp_path: Path):
+def _client_with_config(tmp_path: Path):
+    from boulder.runner import BoulderRunner
+
     cfg = tmp_path / "config.yaml"
     cfg.write_text(_CONFIG_YAML, encoding="utf-8")
-    (tmp_path / "run_sweep.py").write_text("", encoding="utf-8")
 
     app = create_app()
     client = TestClient(app)
     client.__enter__()
     app.state.preloaded_config_path = str(cfg)
-    app.state.preloaded_raw = {"scenarios": {"a": {}}}
+    app.state.preloaded_raw = BoulderRunner.load(str(cfg))
     return client, app
 
 
-def _mock_popen_factory(started: threading.Event, captured: Dict[str, Any]):
-    """Build a Popen stand-in that exits immediately with no output."""
-    proc = MagicMock()
-    proc.stdout = iter([])
-    proc.wait.return_value = None
-    proc.returncode = 0
-
-    def _factory(*args: Any, **kwargs: Any) -> MagicMock:
-        captured["kwargs"] = kwargs
-        started.set()
-        return proc
-
-    return _factory
+def _wait_until(predicate: Callable[[], bool], timeout: float = 10.0) -> None:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if predicate():
+            return
+        time.sleep(0.02)
+    raise AssertionError("condition not met within timeout")
 
 
-def test_sweep_run_default_does_not_set_no_cache_env(tmp_path: Path) -> None:
-    client, _app = _client_with_local_runner(tmp_path)
-    started = threading.Event()
-    captured: Dict[str, Any] = {}
+class _FakeWorker:
+    """Completes instantly -- these tests care about caching, not progress."""
+
+    def __init__(self) -> None:
+        self.progress = SimulationProgress(is_complete=True)
+
+    def start_simulation(self, *args: Any, **kwargs: Any) -> None:
+        pass
+
+    def get_progress(self) -> SimulationProgress:
+        return self.progress
+
+
+def test_sweep_run_reuses_the_cache_when_unchanged(tmp_path: Path) -> None:
+    """A second run of the same config skips every scenario (fingerprint match)."""
+    client, app = _client_with_config(tmp_path)
+    calls: List[None] = []
+
+    def _factory() -> _FakeWorker:
+        calls.append(None)
+        return _FakeWorker()
+
     try:
-        with patch(
-            "boulder.api.routes.sweep.subprocess.Popen",
-            side_effect=_mock_popen_factory(started, captured),
-        ):
-            resp = client.post("/api/sweep/run", json={})
-            assert resp.status_code == 200, resp.text
-            assert started.wait(timeout=2), "subprocess.Popen was never called"
-        assert "BOULDER_NO_CACHE" not in captured["kwargs"]["env"]
+        with patch("boulder.api.routes.sweep.SimulationWorker", side_effect=_factory):
+            resp1 = client.post("/api/sweep/run", json={"scenarios": {"a": {}}})
+            assert resp1.status_code == 200, resp1.text
+            _wait_until(lambda: app.state.sweep_job.get("status") == "done")
+            # Two runs: BASELINE (unmodified base) + "a".
+            assert len(calls) == 2
+
+            resp2 = client.post("/api/sweep/run", json={"scenarios": {"a": {}}})
+            assert resp2.status_code == 200, resp2.text
+            _wait_until(lambda: app.state.sweep_job.get("status") == "done")
+            assert len(calls) == 2  # unchanged config -- nothing re-solved
     finally:
         client.__exit__(None, None, None)
 
 
-def test_sweep_run_no_body_also_does_not_set_no_cache_env(tmp_path: Path) -> None:
-    """A client that omits the body entirely gets the same default as `{}`."""
-    client, _app = _client_with_local_runner(tmp_path)
-    started = threading.Event()
-    captured: Dict[str, Any] = {}
+def test_sweep_run_no_cache_forces_a_full_recompute(tmp_path: Path) -> None:
+    client, app = _client_with_config(tmp_path)
+    calls: List[None] = []
+
+    def _factory() -> _FakeWorker:
+        calls.append(None)
+        return _FakeWorker()
+
     try:
-        with patch(
-            "boulder.api.routes.sweep.subprocess.Popen",
-            side_effect=_mock_popen_factory(started, captured),
-        ):
-            resp = client.post("/api/sweep/run")
-            assert resp.status_code == 200, resp.text
-            assert started.wait(timeout=2), "subprocess.Popen was never called"
-        assert "BOULDER_NO_CACHE" not in captured["kwargs"]["env"]
+        with patch("boulder.api.routes.sweep.SimulationWorker", side_effect=_factory):
+            resp1 = client.post("/api/sweep/run", json={"scenarios": {"a": {}}})
+            assert resp1.status_code == 200, resp1.text
+            _wait_until(lambda: app.state.sweep_job.get("status") == "done")
+            assert len(calls) == 2
+
+            resp2 = client.post(
+                "/api/sweep/run", json={"scenarios": {"a": {}}, "no_cache": True}
+            )
+            assert resp2.status_code == 200, resp2.text
+            _wait_until(lambda: app.state.sweep_job.get("status") == "done")
+            assert len(calls) == 4  # store wiped first -- both re-solved
     finally:
         client.__exit__(None, None, None)
 
 
-def test_sweep_run_no_cache_sets_env(tmp_path: Path) -> None:
-    client, _app = _client_with_local_runner(tmp_path)
-    started = threading.Event()
-    captured: Dict[str, Any] = {}
+def test_sweep_run_rejects_a_second_run_while_one_is_in_flight(tmp_path: Path) -> None:
+    client, app = _client_with_config(tmp_path)
+    workers: List[_FakeWorker] = []
+
+    def _factory() -> _FakeWorker:
+        w = _FakeWorker()
+        w.progress = SimulationProgress()  # starts un-complete -- "in flight"
+        workers.append(w)
+        return w
+
     try:
-        with patch(
-            "boulder.api.routes.sweep.subprocess.Popen",
-            side_effect=_mock_popen_factory(started, captured),
-        ):
-            resp = client.post("/api/sweep/run", json={"no_cache": True})
-            assert resp.status_code == 200, resp.text
-            assert started.wait(timeout=2), "subprocess.Popen was never called"
-        assert captured["kwargs"]["env"].get("BOULDER_NO_CACHE") == "1"
+        with patch("boulder.api.routes.sweep.SimulationWorker", side_effect=_factory):
+            resp1 = client.post("/api/sweep/run", json={"scenarios": {"a": {}}})
+            assert resp1.status_code == 200, resp1.text
+            _wait_until(lambda: app.state.sweep_job.get("status") == "running")
+
+            resp2 = client.post("/api/sweep/run", json={"scenarios": {"a": {}}})
+            assert resp2.status_code == 409
+
+            # Let the in-flight sweep's background thread actually finish
+            # (still inside the patch -- every remaining scenario's worker
+            # must be a fake too, including ones not constructed yet) instead
+            # of leaking a "while True: time.sleep(0.3)" daemon thread that
+            # would otherwise keep running, and competing for the GIL, for
+            # the rest of this process's test session.
+            for _ in range(200):
+                if app.state.sweep_job.get("status") in ("done", "error"):
+                    break
+                for w in list(workers):
+                    w.progress = SimulationProgress(is_complete=True)
+                time.sleep(0.05)
+            assert app.state.sweep_job.get("status") == "done"
     finally:
         client.__exit__(None, None, None)

--- a/tests/test_sweep_runset.py
+++ b/tests/test_sweep_runset.py
@@ -4,18 +4,19 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from boulder.api.routes.sweep import _run_set_size, has_run_set, resolve_store_path
+from boulder.api.routes.sweep import has_run_set, resolve_store_path
+from boulder.runset import run_set_size
 
 
 def test_sweep_only_counts_cartesian():
     raw = {"sweep": {"T": {"values": [1, 2, 3]}, "P": {"values": [10, 20]}}}
-    assert _run_set_size(raw) == 6  # 3 × 2
+    assert run_set_size(raw) == 6  # 3 × 2
 
 
 def test_scenario_only_counts_entries():
     raw = {"scenarios": {"a": {}, "b": {}, "c": {}}}
     # BASELINE (the unmodified base) + 3 named entries = 4.
-    assert _run_set_size(raw) == 4
+    assert run_set_size(raw) == 4
 
 
 def test_union_not_cartesian():
@@ -24,7 +25,7 @@ def test_union_not_cartesian():
         "scenarios": {"hot": {}, "cold": {}},
     }
     # BASELINE + 2 global sweep points + 2 scenarios = 5 (not a cross product).
-    assert _run_set_size(raw) == 5
+    assert run_set_size(raw) == 5
 
 
 def test_scenario_local_sweep_multiplies_only_itself():
@@ -35,11 +36,11 @@ def test_scenario_local_sweep_multiplies_only_itself():
         }
     }
     # BASELINE (1) + plain (1) + swept's inner sweep (3) = 5.
-    assert _run_set_size(raw) == 5
+    assert run_set_size(raw) == 5
 
 
 def test_empty_is_zero():
-    assert _run_set_size({}) == 0
+    assert run_set_size({}) == 0
 
 
 def test_has_run_set_true_for_scenario_block():
@@ -51,19 +52,21 @@ def test_has_run_set_true_for_sweep_block():
     assert has_run_set({"sweeps": {"T": {"values": [1]}}}, None) is True
 
 
-def test_has_run_set_false_without_block_or_runner(tmp_path: Path):
-    cfg = tmp_path / "config.yaml"
-    cfg.write_text("metadata: {}\n", encoding="utf-8")
-    assert has_run_set({}, str(cfg)) is False
+def test_has_run_set_false_without_a_block():
+    assert has_run_set({}, None) is False
 
 
-def test_has_run_set_true_for_local_run_sweep_script(tmp_path: Path):
+def test_has_run_set_ignores_a_local_run_sweep_script(tmp_path: Path):
+    """Run Sweep runs in-process now (no subprocess).
+
+    A host's own `run_sweep.py` script next to the config is no longer a
+    run-set source on its own; only an inline `scenarios:`/`sweep:`/`sweeps:`
+    block counts.
+    """
     cfg = tmp_path / "config.yaml"
     cfg.write_text("metadata: {}\n", encoding="utf-8")
     (tmp_path / "run_sweep.py").write_text("", encoding="utf-8")
-    # No inline scenarios:/sweep: block at all — the local runner script alone
-    # is enough (host-defined run-set, e.g. the CH4 reactor-map sandbox).
-    assert has_run_set({}, str(cfg)) is True
+    assert has_run_set({}, str(cfg)) is False
 
 
 def test_resolve_store_path_defaults_next_to_config(tmp_path: Path):

--- a/tests/test_sweep_status_scenario_progress.py
+++ b/tests/test_sweep_status_scenario_progress.py
@@ -1,26 +1,26 @@
 """Tests for `sweep_status`'s per-scenario `scenario_progress` map.
 
-`sweep_runner.run()` already prints the scenario id inline
-("scenario N/M (id)", or "... (id): cached, skipped" for a cache hit), and
-`boulder.staged_solver`'s per-stage INFO logs reach the same captured
-subprocess output. `sweep.py`'s stdout parser turns those lines into
-`scenario_progress`: a `{scenario_id: {stage, stage_total, stage_id}}` map (keyed by id,
-not a single "current scenario" scalar, so a future parallel sweep runner can
-hold more than one entry at once without a shape change) that
-`GET /api/sweep/status` passes straight through.
+Run Sweep runs in-process now, one scenario at a time through the same
+`SimulationWorker` `/api/simulations` uses (see `boulder/api/routes/sweep.py`)
+-- no subprocess, no stdout parsing. These tests stand in for the real
+`SimulationWorker` with a fake whose progress the test controls directly, so
+`scenario_progress`/`last_line` transitions can be asserted deterministically
+without running a real Cantera network.
 
-Also covers `last_line`: the runner's most recent non-empty stdout line, kept
-verbatim for the frontend's "Calculating…" detail line and cleared once the
-subprocess exits.
+`scenario_progress`: a `{scenario_id: {stage, stage_total, stage_id}}` map
+(keyed by id, not a single "current scenario" scalar, so a future parallel
+sweep could hold more than one entry at once without a shape change) that
+`GET /api/sweep/status` passes straight through. `last_line` mirrors the most
+recent progress message, for the frontend's "Calculating…" detail line, and
+both clear the moment a scenario finishes (or the whole sweep stops).
 """
 
 from __future__ import annotations
 
-import threading
 import time
 from pathlib import Path
-from typing import Any, Dict
-from unittest.mock import MagicMock, patch
+from typing import Any, Callable, List
+from unittest.mock import patch
 
 import pytest
 
@@ -29,6 +29,7 @@ pytest.importorskip("fastapi")
 from fastapi.testclient import TestClient  # noqa: E402
 
 from boulder.api.main import create_app  # noqa: E402
+from boulder.simulation_worker import SimulationProgress  # noqa: E402
 
 _CONFIG_YAML = """\
 metadata:
@@ -42,135 +43,142 @@ network:
       temperature: 298.15
       pressure: 101325
       composition: "CH4:1"
-scenarios:
-  a:
-    metadata:
-      scenario_name: "A"
-  b:
-    metadata:
-      scenario_name: "B"
 """
 
 
-def _client_with_local_runner(tmp_path: Path):
+def _client_with_config(tmp_path: Path):
+    from boulder.runner import BoulderRunner
+
     cfg = tmp_path / "config.yaml"
     cfg.write_text(_CONFIG_YAML, encoding="utf-8")
-    (tmp_path / "run_sweep.py").write_text("", encoding="utf-8")
 
     app = create_app()
     client = TestClient(app)
     client.__enter__()
     app.state.preloaded_config_path = str(cfg)
-    app.state.preloaded_raw = {"scenarios": {"a": {}, "b": {}}}
+    # Mirrors what the app's startup lifespan would have loaded -- these
+    # tests bypass that (no CLI arg was ever passed), so it's set directly.
+    app.state.preloaded_raw = BoulderRunner.load(str(cfg))
     return client, app
 
 
-def test_scenario_progress_tracks_stage_then_clears_on_skip(tmp_path: Path) -> None:
+def _wait_until(predicate: Callable[[], bool], timeout: float = 10.0) -> None:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if predicate():
+            return
+        time.sleep(0.02)
+    raise AssertionError("condition not met within timeout")
+
+
+class _FakeWorker:
+    """Stand-in for SimulationWorker.
+
+    The test drives `.progress` directly instead of letting a real network
+    build/solve, so scenario_progress transitions can be asserted
+    deterministically and fast.
+    """
+
+    def __init__(self) -> None:
+        self.progress = SimulationProgress()
+
+    def start_simulation(self, *args: Any, **kwargs: Any) -> None:
+        pass
+
+    def get_progress(self) -> SimulationProgress:
+        return self.progress
+
+
+def test_scenario_progress_tracks_stage_then_moves_to_the_next_scenario(
+    tmp_path: Path,
+) -> None:
     """A solving scenario's stage updates land in scenario_progress[id].
 
-    A subsequent "cached, skipped" scenario line clears the map instead of
-    ever showing that scenario as "calculating" (a cache hit is instant).
-    `last_line` holds the runner's latest stdout line verbatim while solving.
+    A fresh scenario starts with no stage info of its own -- BASELINE (the
+    unmodified base config) always solves first, then each named scenario.
     """
-    client, app = _client_with_local_runner(tmp_path)
-    after_stage_line = threading.Event()
-    resume_after_stage = threading.Event()
-    after_skip_line = threading.Event()
+    client, app = _client_with_config(tmp_path)
+    workers: List[_FakeWorker] = []
 
-    def stdout_gen():
-        yield "scenario 1/2 (a)"
-        yield (
-            "2026-01-01 00:00:00 - boulder.staged_solver - INFO - "
-            "Staged solve: stage 'default' (1/3, 3 reactors)"
-        )
-        # Pause here (holding the for-loop mid-iteration) so the test can
-        # assert the in-flight state before the next line arrives.
-        after_stage_line.set()
-        resume_after_stage.wait(timeout=5)
-        yield "scenario 2/2 (b): cached, skipped"
-        after_skip_line.set()
-
-    proc = MagicMock()
-    proc.stdout = stdout_gen()
-    proc.wait.return_value = None
-    proc.returncode = 0
-    captured: Dict[str, Any] = {}
-
-    def _factory(*args: Any, **kwargs: Any) -> MagicMock:
-        captured["kwargs"] = kwargs
-        return proc
+    def _factory() -> _FakeWorker:
+        w = _FakeWorker()
+        workers.append(w)
+        return w
 
     try:
-        with patch("boulder.api.routes.sweep.subprocess.Popen", side_effect=_factory):
-            resp = client.post("/api/sweep/run", json={})
+        with patch("boulder.api.routes.sweep.SimulationWorker", side_effect=_factory):
+            resp = client.post("/api/sweep/run", json={"scenarios": {"a": {}}})
             assert resp.status_code == 200, resp.text
 
-            assert after_stage_line.wait(timeout=2), "stage line was never processed"
-            job = app.state.sweep_job
-            assert job["scenario_progress"] == {
-                "a": {"stage": 1, "stage_total": 3, "stage_id": "default"}
-            }
-            assert job["last_line"] == (
-                "2026-01-01 00:00:00 - boulder.staged_solver - INFO - "
-                "Staged solve: stage 'default' (1/3, 3 reactors)"
+            _wait_until(lambda: len(workers) >= 1)
+            workers[0].progress = SimulationProgress(
+                stages_done=1, n_stages=2, completed_stage_ids=["default"]
             )
+            _wait_until(
+                lambda: app.state.sweep_job.get("scenario_progress", {})
+                .get("BASELINE", {})
+                .get("stage")
+                == 1
+            )
+            assert app.state.sweep_job["scenario_progress"] == {
+                "BASELINE": {"stage": 1, "stage_total": 2, "stage_id": "default"}
+            }
 
-            resume_after_stage.set()
-            assert after_skip_line.wait(timeout=2), "skip line was never processed"
+            # BASELINE finishes -- the sweep moves on to "a".
+            workers[0].progress = SimulationProgress(is_complete=True)
+            _wait_until(lambda: len(workers) >= 2)
+            _wait_until(lambda: app.state.sweep_job.get("current") == 2)
+            # "a"'s freshly constructed worker hasn't reported a stage yet.
+            assert app.state.sweep_job["scenario_progress"] == {
+                "a": {"stage": None, "stage_total": None, "stage_id": None}
+            }
+
+            workers[1].progress = SimulationProgress(is_complete=True)
+            _wait_until(lambda: app.state.sweep_job.get("status") == "done")
             assert app.state.sweep_job["scenario_progress"] == {}
-
-            status = client.get("/api/sweep/status").json()
-            assert status["scenario_progress"] == {}
-            assert status["current"] == 2
-            assert status["total"] == 2
+            assert app.state.sweep_job["last_line"] is None
     finally:
         client.__exit__(None, None, None)
 
 
-def test_scenario_progress_clears_once_the_process_exits_mid_solve(
+def test_scenario_progress_clears_if_a_scenario_errors_mid_solve(
     tmp_path: Path,
 ) -> None:
-    """The last scenario solved may not end with a "cached, skipped" line.
+    """A scenario that fails mid-solve still clears scenario_progress.
 
-    Nothing should linger as "calculating" once the subprocess has exited,
-    one way or another.
+    Nothing is left "calculating" once the sweep has stopped, one way or another.
     """
-    client, app = _client_with_local_runner(tmp_path)
-    after_stage_line = threading.Event()
-    resume_after_stage = threading.Event()
+    client, app = _client_with_config(tmp_path)
+    workers: List[_FakeWorker] = []
 
-    def stdout_gen():
-        yield "scenario 1/1 (a)"
-        yield (
-            "2026-01-01 00:00:00 - boulder.staged_solver - INFO - "
-            "Staged solve: stage 'default' (1/1, 3 reactors)"
-        )
-        after_stage_line.set()
-        resume_after_stage.wait(timeout=5)
-
-    proc = MagicMock()
-    proc.stdout = stdout_gen()
-    proc.wait.return_value = None
-    proc.returncode = 0
+    def _factory() -> _FakeWorker:
+        w = _FakeWorker()
+        workers.append(w)
+        return w
 
     try:
-        with patch("boulder.api.routes.sweep.subprocess.Popen", return_value=proc):
-            resp = client.post("/api/sweep/run", json={})
+        with patch("boulder.api.routes.sweep.SimulationWorker", side_effect=_factory):
+            resp = client.post("/api/sweep/run", json={"scenarios": {"a": {}}})
             assert resp.status_code == 200, resp.text
 
-            assert after_stage_line.wait(timeout=2), "stage line was never processed"
+            _wait_until(lambda: len(workers) >= 1)
+            workers[0].progress = SimulationProgress(
+                stages_done=1, n_stages=1, completed_stage_ids=["default"]
+            )
+            _wait_until(
+                lambda: app.state.sweep_job.get("scenario_progress", {})
+                .get("BASELINE", {})
+                .get("stage")
+                == 1
+            )
             assert app.state.sweep_job["scenario_progress"] == {
-                "a": {"stage": 1, "stage_total": 1, "stage_id": "default"}
+                "BASELINE": {"stage": 1, "stage_total": 1, "stage_id": "default"}
             }
 
-            resume_after_stage.set()  # let stdout end -> proc.wait() -> "done"
-
-            for _ in range(50):
-                if app.state.sweep_job.get("status") == "done":
-                    break
-                time.sleep(0.05)
-            assert app.state.sweep_job["status"] == "done"
+            workers[0].progress = SimulationProgress(error_message="boom")
+            _wait_until(lambda: app.state.sweep_job.get("status") == "error")
             assert app.state.sweep_job["scenario_progress"] == {}
             assert app.state.sweep_job["last_line"] is None
+            assert "boom" in app.state.sweep_job["message"]
     finally:
         client.__exit__(None, None, None)


### PR DESCRIPTION
## Summary

- Scenario CRUD (create/edit/rename/delete, entity edits, preview, download) no longer touches disk. Every scenario route is now a pure, stateless transform: the caller sends its current overlays map, gets back the new one. `scenarioStore.overlays` (frontend) is the sole source of truth for the session, seeded once from the config's `scenarios:` block on load.
- The Scenario YAML pane gained a **"Download full YAML"** button (base config deep-merged with the open scenario's overlay) — the one sanctioned way to get an edited scenario onto disk now that nothing auto-persists.
- **Run Sweep runs in-process**, reusing the exact same `SimulationWorker` a plain "Run Simulation" uses — one scenario after another in a background thread — instead of shelling out to `run_sweep.py`. It always sees this session's live (possibly unsaved) scenario overlays, since it takes them from the request body.
- Properties panel "Edit" now shows/edits a scenario's *current effective* value (override if one exists, base otherwise) instead of always the base value.
- Scenario Pane rows show the scenario id as the primary label (unique) instead of the often-duplicated description; "Add Scenario" gained an optional description field.

Scope cut: a host's custom `run_sweep.py`/`plugins.sweep_runner` script for the GUI's Run Sweep button is no longer supported (there's no subprocess to hand it to). The CLI entry point (`python -m boulder.sweep_runner`) is unaffected.

## Test plan

- [x] `pytest tests/` — 791 passed, 1 skipped, 7 xfailed
- [x] `npx vitest run` — 218 passed
- [x] `npx tsc -b` and `npm run build` clean
- [x] `pre-commit run --files <changed>` clean
- [x] Live-verified against a scratch config: create/clone/edit scenarios, confirmed the on-disk file's hash never changes across any of it, ran a real in-process sweep to completion, downloaded the merged full YAML from the browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)