### PR TITLE
fix(gui): BASELINE Properties panel showed a stale value after a base edit

### DIFF
--- a/frontend/src/components/panels/PropertiesPanel.test.tsx
+++ b/frontend/src/components/panels/PropertiesPanel.test.tsx
@@ -584,6 +584,23 @@ describe("PropertiesPanel scenario preview", () => {
     expect(screen.queryByText("0.30")).not.toBeInTheDocument();
   });
 
+  it("BASELINE always shows the live base value, never a (possibly stale) preview snapshot", () => {
+    // BASELINE has no overlay of its own -- its "preview" would always just
+    // restate the base config, so this panel must not prefer a
+    // server-fetched snapshot over the live base value, which reflects
+    // local base-network edits the preview fetch has no way to see.
+    mockPreviewId = "BASELINE";
+    mockPreviewNodes = [
+      { id: "reactor_1", properties: { temperature: 1273.15, length: 0.99 } },
+    ];
+    mockPreviewConnections = [];
+
+    render(<PropertiesPanel />);
+
+    expect(screen.getByText("0.30")).toBeInTheDocument();
+    expect(screen.queryByText("0.99")).not.toBeInTheDocument();
+  });
+
   it("never names the previewed scenario in this panel", () => {
     // The panel shows the element's own identity (id + kind); which scenario
     // is being previewed belongs to the Scenario Pane, not here. Overridden

--- a/frontend/src/components/panels/PropertiesPanel.tsx
+++ b/frontend/src/components/panels/PropertiesPanel.tsx
@@ -227,10 +227,18 @@ export function PropertiesPanel() {
   // element — lets the Inputs pane preview a scenario's overrides (e.g. a
   // reactor's length) the moment it's selected, even before Run Sweep has
   // solved it. Falls back to the base properties when nothing is previewed,
-  // or when this element has no counterpart in the preview (shouldn't happen
-  // in practice — the preview mirrors the whole network — but is not fatal).
+  // when this element has no counterpart in the preview (shouldn't happen in
+  // practice — the preview mirrors the whole network — but is not fatal), or
+  // when BASELINE is active: BASELINE has no overlay of its own, so its
+  // "preview" is always identical to the live base config -- going through
+  // the (server-computed, fetch-once) preview instead of the live base
+  // properties would show a stale value after editing the base network
+  // while BASELINE happens to be the active selection.
   const previewList = isNode ? previewNodes : previewConnections;
-  const previewEntity = previewId ? previewList?.find((e) => e.id === id) : undefined;
+  const previewEntity =
+    previewId && previewId !== BASELINE_SCENARIO_ID
+      ? previewList?.find((e) => e.id === id)
+      : undefined;
   const previewDisplayProperties = previewEntity
     ? unfoldInitialConditions(previewEntity.properties as Record<string, unknown>)
     : displayProperties;


### PR DESCRIPTION
## Summary

Found while live-verifying #133's scenario-editing behavior specifically for BASELINE: editing a node's properties in the Properties panel while BASELINE is the active selection left the panel showing the *pre-edit* value, until the scenario was deselected and reselected.

Root cause: the panel prefers the server-fetched scenario preview (`previewNodes`) over the live `configStore` value whenever a scenario is "active" — including BASELINE. But BASELINE has no overlay of its own, so its preview is always just the base config restated; the preview fetch is a one-shot snapshot that has no way to see a purely client-side base-network edit. Fix: BASELINE now always renders the live base properties directly, skipping the preview lookup entirely.

Pre-existing bug, unrelated to #133's actual changes (the same staleness existed in view mode before that PR too) — just surfaced during its verification.

## Test plan

- [x] Added a regression test asserting BASELINE shows the live value over a stale preview snapshot
- [x] `npx vitest run` — 219 passed
- [x] `npx tsc -b` clean
- [x] Live-verified: edited a reactor's volume via the GUI while BASELINE was selected, confirmed the panel updates immediately (previously stuck on the old value); confirmed the on-disk config is untouched throughout

🤖 Generated with [Claude Code](https://claude.com/claude-code)