### PR TITLE
fix: resolve mechanism before storing sweep results

### DIFF
--- a/boulder/api/routes/sweep.py
+++ b/boulder/api/routes/sweep.py
@@ -194,8 +194,24 @@ async def sweep_run(
             run_ids = {sid for sid, _ in runs}
             mechanism = _mechanism_of(raw)
             n_cached = 0
+            # The active converter class -- e.g. a host's own subclass with
+            # its own mechanism search convention -- lives on `app.state`
+            # (set once by the CLI at startup; see `boulder/api/main.py`),
+            # the same source `/api/simulations` reads. `get_plugins()` is a
+            # *different*, entry-point/env-var-driven registry that a host
+            # need not populate the same way, so it can't be relied on here.
+            converter_cls = (
+                getattr(request.app.state, "converter_class", None)
+                or DualCanteraConverter
+            )
+            # `__new__` avoids constructing a real instance (which would
+            # eagerly load a Cantera Solution) just to obtain a method
+            # reference -- same trick `_default_resolve_mechanism` uses.
+            resolve_mechanism = converter_cls.__new__(converter_cls).resolve_mechanism
             for i, (sid, cfg) in enumerate(runs):
-                config, mech_name, fingerprint = prepare_scenario(cfg, None)
+                config, mech_name, fingerprint = prepare_scenario(
+                    cfg, resolve_mechanism
+                )
                 label = str((cfg.get("metadata") or {}).get("scenario_name") or sid)
                 state["current"] = i + 1
 
@@ -220,9 +236,7 @@ async def sweep_run(
                 state["last_line"] = line
                 print(f"[sweep] {line}", flush=True)
 
-                plugins = get_plugins()
-                converter_cls = plugins.converter_class or DualCanteraConverter
-                conv = converter_cls(mechanism=mech_name or None, plugins=plugins)
+                conv = converter_cls(mechanism=mech_name or None, plugins=get_plugins())
                 settings = config.get("settings") or {}
                 sim_t = float(settings.get("end_time") or 0.0) or 1.0
                 dt = float(settings.get("dt") or 0.0) or (sim_t / 10.0)
@@ -273,7 +287,13 @@ async def sweep_run(
                     "updated_nodes": progress.updated_nodes,
                     "updated_connections": progress.updated_connections,
                 }
-                stored_mech = conv.mechanism
+                # `conv.mechanism` is whatever bare name/spec the converter was
+                # constructed with -- resolving it (again) to a real, absolute
+                # path is exactly what `resolve_mechanism` is for; `conv`
+                # itself never updates `.mechanism` after resolving it
+                # internally to load its own `ct.Solution`, so skipping this
+                # would hand `write_payload` an unresolved name it can't load.
+                stored_mech = resolve_mechanism(conv.mechanism)
                 write_payload(store, gui, stored_mech, group=sid, fresh=False)
                 with h5py.File(str(store), "a") as handle:
                     attrs = handle[sid].attrs
@@ -290,10 +310,13 @@ async def sweep_run(
                     flush=True,
                 )
 
+            resolved_mechanism = (
+                resolve_mechanism(mechanism) if mechanism else mechanism
+            )
             with h5py.File(str(store), "a") as handle:
                 cfg_path = getattr(request.app.state, "preloaded_config_path", None)
                 handle.attrs["map_config"] = Path(cfg_path).name if cfg_path else ""
-                handle.attrs["mechanism"] = mechanism
+                handle.attrs["mechanism"] = resolved_mechanism
                 handle.attrs["mechanism_name"] = (
                     Path(mechanism).name if mechanism else ""
                 )

--- a/tests/test_sweep_run_no_cache.py
+++ b/tests/test_sweep_run_no_cache.py
@@ -75,6 +75,29 @@ class _FakeWorker:
         return self.progress
 
 
+class _StubConverter:
+    """Records that it was actually constructed.
+
+    Proves the sweep used `app.state.converter_class` (a host's own
+    converter, e.g. Bloc's) instead of silently falling back to plain
+    `DualCanteraConverter`, which doesn't know how to resolve a host's own
+    mechanism names and would fail for real (`CanteraError: findInputFile`)
+    outside these mocked tests.
+    """
+
+    instances: List["_StubConverter"] = []
+
+    def __init__(self, mechanism: Any = None, plugins: Any = None) -> None:
+        # Passthrough -- a fictional resolved path would make write_payload's
+        # own mechanism-file hashing fail for real; the instance count below
+        # is sufficient proof this class (not DualCanteraConverter) was used.
+        self.mechanism = mechanism
+        _StubConverter.instances.append(self)
+
+    def resolve_mechanism(self, name: str) -> str:
+        return name
+
+
 def test_sweep_run_reuses_the_cache_when_unchanged(tmp_path: Path) -> None:
     """A second run of the same config skips every scenario (fingerprint match)."""
     client, app = _client_with_config(tmp_path)
@@ -158,4 +181,90 @@ def test_sweep_run_rejects_a_second_run_while_one_is_in_flight(tmp_path: Path) -
                 time.sleep(0.05)
             assert app.state.sweep_job.get("status") == "done"
     finally:
+        client.__exit__(None, None, None)
+
+
+def test_sweep_run_uses_app_state_converter_class_for_mechanism_resolution(
+    tmp_path: Path,
+) -> None:
+    """A host's own converter class must be used to resolve mechanism names.
+
+    That class is set on `app.state` at startup (e.g. by Bloc's CLI) -- it
+    must not be silently dropped in favor of plain `DualCanteraConverter`,
+    which doesn't know a host's mechanism search convention and would fail
+    for real (`CanteraError: findInputFile`) outside these mocks.
+    """
+    client, app = _client_with_config(tmp_path)
+    app.state.converter_class = _StubConverter
+    _StubConverter.instances.clear()
+
+    try:
+        with patch(
+            "boulder.api.routes.sweep.SimulationWorker",
+            side_effect=lambda: _FakeWorker(),
+        ):
+            resp = client.post("/api/sweep/run", json={"scenarios": {"a": {}}})
+            assert resp.status_code == 200, resp.text
+            _wait_until(lambda: app.state.sweep_job.get("status") == "done")
+
+        # Two runs: BASELINE + "a" -- both must have gone through _StubConverter.
+        assert len(_StubConverter.instances) == 2
+    finally:
+        _StubConverter.instances.clear()
+        client.__exit__(None, None, None)
+
+
+def test_sweep_run_stores_a_resolved_mechanism_not_convs_raw_attribute(
+    tmp_path: Path,
+) -> None:
+    """`write_payload` must get a resolved mechanism, not `conv`'s raw one.
+
+    `conv.mechanism` never updates after construction -- it stays whatever
+    bare name/spec the converter was built with, even though construction
+    itself resolves and loads the real one internally (see
+    `DualCanteraConverter.__init__`). `write_payload`'s own `ct.Solution(...)`
+    call needs a real, resolved path -- passing `conv.mechanism` straight
+    through fails for real for any host whose bare mechanism names aren't
+    Cantera built-ins (`CanteraError: findInputFile`).
+    """
+
+    class _PrefixResolvingConverter(_StubConverter):
+        def resolve_mechanism(self, name: str) -> str:
+            return f"/resolved/{name}"
+
+    client, app = _client_with_config(tmp_path)
+    app.state.converter_class = _PrefixResolvingConverter
+    _StubConverter.instances.clear()
+    captured_mechanisms: List[str] = []
+
+    def _fake_write_payload(
+        store: Path, gui: Any, mechanism: str, **kwargs: Any
+    ) -> None:
+        captured_mechanisms.append(mechanism)
+        import h5py
+
+        with h5py.File(str(store), "a") as handle:
+            if kwargs.get("group") not in handle:
+                grp = handle.create_group(kwargs["group"])
+                grp.create_dataset("payload_json", data=b"{}")
+
+    try:
+        with (
+            patch(
+                "boulder.api.routes.sweep.SimulationWorker",
+                side_effect=lambda: _FakeWorker(),
+            ),
+            patch(
+                "boulder.api.routes.sweep.write_payload",
+                side_effect=_fake_write_payload,
+            ),
+        ):
+            resp = client.post("/api/sweep/run", json={"scenarios": {"a": {}}})
+            assert resp.status_code == 200, resp.text
+            _wait_until(lambda: app.state.sweep_job.get("status") == "done")
+
+        assert captured_mechanisms  # BASELINE + "a" both solved (no cache yet)
+        assert all(m == "/resolved/gri30.yaml" for m in captured_mechanisms)
+    finally:
+        _StubConverter.instances.clear()
         client.__exit__(None, None, None)


### PR DESCRIPTION
## Summary
- Run Sweep's in-process worker (introduced in #133) was passing `conv.mechanism` -- the bare, unresolved name/spec a converter was constructed with -- straight to `write_payload`, which calls `ct.Solution(mechanism)` with no resolution of its own. Any host whose bare mechanism names aren't Cantera built-ins fails with `CanteraError: findInputFile` (found running a real model's sweep end-to-end).
- `DualCanteraConverter.__init__` (and any host subclass) resolves the mechanism internally to load its own Cantera Solution, but never updates `.mechanism` itself -- so `conv.mechanism` always stays the original bare string for the converter's lifetime.
- The original disk-based `sweep_runner.run()` already re-resolved (`_resolve(resolved_mech)`) before this exact call; the in-process rewrite dropped that step. Fixed by resolving via `resolve_mechanism(conv.mechanism)` before both scenario-level and root-level HDF5 writes.
- Also source the converter class from `app.state.converter_class` (same place `/api/simulations` reads, set once by the CLI at startup) instead of the separate `get_plugins()` registry, so hosts that only populate one of the two paths stay consistent between single-simulation and sweep runs.

## Why CI didn't catch this
Boulder's existing sweep tests mock `SimulationWorker` entirely, so they never exercise real Cantera mechanism resolution. A host's own converter/mechanism-resolution convention (e.g. a non-builtin mechanism name) is only exercised when running a real solve against a real host-configured GUI server -- which no unit test does. Added a regression test that mocks `write_payload` itself and asserts on the exact mechanism string it receives, which would have caught this.

## Test plan
- [x] New regression test `test_sweep_run_stores_a_resolved_mechanism_not_convs_raw_attribute` -- mocks `write_payload`, asserts the resolved (not raw) mechanism string is passed
- [x] New test `test_sweep_run_uses_app_state_converter_class_for_mechanism_resolution` -- asserts `app.state.converter_class` is used, not silently dropped for `DualCanteraConverter`
- [x] `pytest tests/test_sweep_run_no_cache.py -q` -- 5 passed
- [x] Full backend suite -- 793 passed, 1 skipped, 7 xfailed
- [x] `pre-commit run --files boulder/api/routes/sweep.py tests/test_sweep_run_no_cache.py` -- clean
- [x] Verified live against a real model : sweep now resolves and loads the mechanism correctly instead of raising `CanteraError: findInputFile`

🤖 Generated with [Claude Code](https://claude.com/claude-code)