### PR TITLE
fix: startup normalize() was corrupting preloaded_raw in place

### DIFF
--- a/boulder/api/main.py
+++ b/boulder/api/main.py
@@ -87,14 +87,37 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     env_config_path = os.environ.get("BOULDER_CONFIG_PATH") or os.environ.get(
         "BOULDER_CONFIG"
     )
-    app.state.preloaded_config = None
+    # ------------------------------------------------------------------
+    # Every ``preloaded_*`` attribute below is a **startup snapshot**: it is
+    # written once, here, from the file named by ``BOULDER_CONFIG_PATH``, and
+    # is then frozen for the process lifetime. Read them as if they were named
+    # ``initial_*``.
+    #
+    # They deliberately do NOT track live edits. Saving the YAML pane calls
+    # ``adopt_live_config``, which **no-ops when a real file was preloaded**
+    # (see ``boulder/api/live_config.py``) -- the browser's own store becomes
+    # the current config instead. That is why ``/api/simulations`` takes the
+    # config from the *request body* rather than from here.
+    #
+    # Consequences to keep in mind when adding a route:
+    #   * Anything served from these attrs reflects the file as it was at
+    #     startup, not what the user currently sees in the editor.
+    #   * ``preloaded_raw`` is additionally the base that every scenario
+    #     overlay is merged onto (Run Sweep, scenario preview), so it must
+    #     stay byte-identical to the file -- never hand it to a function that
+    #     mutates its argument. ``normalize_config`` does exactly that; pass
+    #     it a ``copy.deepcopy`` (see below, and
+    #     ``tests/test_preloaded_raw_snapshot.py``).
+    # ------------------------------------------------------------------
+    app.state.preloaded_config = None  # normalized + validated startup snapshot
     app.state.preloaded_yaml = None
     app.state.preloaded_filename = None
     app.state.preloaded_config_path = None  # full path for script generation
     app.state.preloaded_result = None
     app.state.preloaded_fingerprint = None
     app.state.scenario_store_path = None
-    app.state.preloaded_raw = None  # inheritance-resolved config (keeps sweeps:)
+    # Inheritance-resolved but *un-normalized* startup snapshot (keeps sweeps:).
+    app.state.preloaded_raw = None
     app.state.sweep_job = None
     # ``--sweep`` GUI mode (BOULDER_SWEEP_MODE): default the split button to Run Sweep.
     app.state.sweep_default = bool(os.environ.get("BOULDER_SWEEP_MODE"))

--- a/boulder/api/main.py
+++ b/boulder/api/main.py
@@ -6,6 +6,7 @@ registers all API routes, and serves the React frontend in production.
 
 from __future__ import annotations
 
+import copy
 import logging
 import os
 import time
@@ -130,7 +131,11 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
                 original_yaml = _f.read()
             actual_yaml_path = cleaned
 
-            normalized = runner_cls.normalize(config)
+            # `normalize()` mutates its argument in place (see
+            # `boulder.config.normalize_config`) -- deep-copy first so
+            # `preloaded_raw` above stays the pristine, un-normalized snapshot
+            # its own comment promises (the Run Sweep button's base config).
+            normalized = runner_cls.normalize(copy.deepcopy(config))
             validated = runner_cls.validate(normalized)
 
             app.state.preloaded_config = validated

--- a/tests/test_preloaded_raw_snapshot.py
+++ b/tests/test_preloaded_raw_snapshot.py
@@ -1,0 +1,151 @@
+"""`app.state.preloaded_raw` must stay the pristine, un-normalized snapshot.
+
+The startup lifespan (`boulder.api.main`) stores the freshly loaded config as
+``preloaded_raw`` and then normalizes it to build ``preloaded_config``.
+`normalize_config` mutates its argument in place (unit coercion and process-
+pressure propagation write straight into the nested property dicts), so
+normalizing the *same object* retroactively corrupts the snapshot.
+
+That snapshot is the base every scenario overlay is merged onto -- Run Sweep
+(`boulder.api.routes.sweep._merged_raw`) and the scenario preview route both
+read it. Corrupting it means overlays merge against a config that no longer
+matches the file on disk: sibling nodes carry SI-converted and propagated
+values they never declared, which then *conflict* with an overlay that
+legitimately overrides one boundary node (a spurious STONE v2
+"conflicting process pressures" error).
+"""
+
+from __future__ import annotations
+
+import copy
+import os
+from pathlib import Path
+from typing import Any, Dict
+
+import pytest
+import yaml
+
+pytest.importorskip("fastapi")
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from boulder.api.main import create_app  # noqa: E402
+
+# `outlet` declares its pressure as a *unit string* and `feed` declares none at
+# all -- normalization coerces the former to Pa and propagates it onto the
+# latter, so both are visible tripwires for in-place mutation.
+_BASE_YAML = """\
+metadata:
+  description: "preloaded_raw snapshot test"
+phases:
+  gas:
+    mechanism: gri30.yaml
+network:
+  - id: feed
+    Reservoir:
+      temperature: 300.0
+      composition: "CH4:1"
+  - id: reactor
+    IdealGasReactor:
+      volume: 1.0
+      initial:
+        temperature: 300.0
+        composition: "CH4:1"
+  - id: outlet
+    OutletSink:
+      pressure: "1.05 bar"
+  - id: mfc
+    MassFlowController:
+      mass_flow_rate: 0.01
+    source: feed
+    target: reactor
+  - id: pc
+    PressureController:
+      master: mfc
+    source: reactor
+    target: outlet
+"""
+
+
+def _client_fully_preloaded(cfg_path: Path):
+    """Start the app the way the CLI does, so the lifespan populates state."""
+    os.environ["BOULDER_CONFIG_PATH"] = str(cfg_path)
+    try:
+        app = create_app()
+        client = TestClient(app)
+        client.__enter__()
+    finally:
+        del os.environ["BOULDER_CONFIG_PATH"]
+    return client, app
+
+
+def _network_entry(cfg: Dict[str, Any], node_id: str) -> Dict[str, Any]:
+    return next(item for item in cfg["network"] if item["id"] == node_id)
+
+
+def test_startup_leaves_preloaded_raw_byte_identical_to_the_file(
+    tmp_path: Path,
+) -> None:
+    """The snapshot must equal the on-disk YAML, key for key."""
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(_BASE_YAML, encoding="utf-8")
+    on_disk = yaml.safe_load(cfg.read_text(encoding="utf-8"))
+
+    client, app = _client_fully_preloaded(cfg)
+    try:
+        assert app.state.preloaded_raw == on_disk
+    finally:
+        client.__exit__(None, None, None)
+
+
+def test_startup_normalization_does_not_leak_into_preloaded_raw(
+    tmp_path: Path,
+) -> None:
+    """Spell out the two ways normalization used to leak into the snapshot.
+
+    Also asserts the *normalized* config really did get both transformations --
+    otherwise the snapshot could look pristine simply because normalization
+    never ran, and this test would pass vacuously.
+    """
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(_BASE_YAML, encoding="utf-8")
+
+    client, app = _client_fully_preloaded(cfg)
+    try:
+        raw = app.state.preloaded_raw
+        # 1. Unit strings stay authored -- not coerced to Pa.
+        assert _network_entry(raw, "outlet")["OutletSink"]["pressure"] == "1.05 bar"
+        # 2. A node that declares no pressure still declares none -- the
+        #    propagation pass must not have defaulted one onto it.
+        assert "pressure" not in _network_entry(raw, "feed")["Reservoir"]
+
+        # The normalized config, by contrast, must show both -- proving the
+        # assertions above aren't passing just because nothing happened.
+        nodes = {
+            n["id"]: (n.get("properties") or {})
+            for n in app.state.preloaded_config["nodes"]
+        }
+        assert nodes["outlet"]["pressure"] == pytest.approx(105000.0)
+        assert nodes["feed"]["pressure"] == pytest.approx(105000.0)
+    finally:
+        client.__exit__(None, None, None)
+
+
+def test_preloaded_raw_survives_a_scenario_preview(tmp_path: Path) -> None:
+    """Reading routes must not normalize the shared snapshot either.
+
+    `/preview` deep-merges an overlay onto the base and normalizes the result;
+    if it normalized the snapshot itself rather than a copy, the first preview
+    would corrupt the base for every later merge.
+    """
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(_BASE_YAML, encoding="utf-8")
+
+    client, app = _client_fully_preloaded(cfg)
+    try:
+        before = copy.deepcopy(app.state.preloaded_raw)
+        resp = client.post("/api/scenarios/probe/preview", json={"overlay": {}})
+        assert resp.status_code == 200, resp.text
+        assert app.state.preloaded_raw == before
+    finally:
+        client.__exit__(None, None, None)


### PR DESCRIPTION
## Summary
- `boulder.config.normalize_config` mutates its input dict rather than returning a fresh copy (no `copy.deepcopy` anywhere in `config.py`). Existing callers that need to preserve an unnormalized copy already work around this by deep-copying first (see `sweep_runner.prepare_scenario`).
- `boulder/api/main.py`'s startup lifespan didn't: it assigned the freshly loaded config to `app.state.preloaded_raw`, then called `runner_cls.normalize()` on *that same object* one line later to build `preloaded_config` -- retroactively corrupting `preloaded_raw` with unit-converted values and propagated/defaulted properties, contradicting its own comment that it must stay the pristine, un-normalized snapshot Run Sweep relies on.
- Found while verifying Run Sweep end-to-end against a real host model: a scenario overlay that only overrides one boundary node's process pressure spuriously failed with a STONE v2 "conflicting process pressures" error, because sibling reactor properties had silently picked up SI-converted/propagated pressure values baked into the corrupted base -- values that don't exist in the on-disk config at all. Run Simulation was unaffected since it never reads `preloaded_raw`.
- Fixed by deep-copying before `normalize()`, matching the existing pattern.

## Test plan
- [x] Reproduced live against a real model : before the fix, 2 of 4 scenarios failed with a spurious STONE v2 pressure-conflict error on Run Sweep; after the fix, all 4 scenarios (including both that override boundary pressure) solve successfully.
- [x] Confirmed via a diagnostic dump that `app.state.preloaded_raw`'s nested node properties matched the fix: before, a reactor property showed a baked-in numeric pressure never declared on disk; after, the raw snapshot stays in its authored, pre-normalize form (e.g. unit strings intact).
- [x] `pre-commit run --files boulder/api/main.py` -- clean
- [x] Full backend test suite -- no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)