### PR TITLE
docs: distinguish mechanism provenance from cache identity

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -154,6 +154,21 @@ Two **profiles** of this one encoding:
 | Holds | one result (1..n reactors, groups `r0`,`r1`,…) | many single-reactor results, one group per scenario |
 | Producer / reader | `result_cache.save_result` / `load_result*` | `api/routes/sweep.py` (GUI) or `sweep_runner.py` (CLI) / `api/routes/scenarios.py` |
 
+**Mechanism provenance vs. cache identity** — two different things, easily confused:
+
+- The scenario store's per-group **`mechanism_sha256` attr is provenance only**, and is written by
+  `payload_store._resolve_mechanism`, which hashes the file *only when the mechanism resolves to an
+  existing path*. For a **Cantera built-in** (`gri30.yaml`) it stores the bare name and an **empty
+  hash** — so a stored result records *which* built-in it used, but not its exact content.
+- **Cache invalidation does not depend on that attr.** `result_cache._mechanism_identity` keys a
+  built-in as `builtin:<name>@cantera-<version>`, so upgrading Cantera *does* invalidate cached
+  results that used a built-in.
+- **Known, accepted limitation:** a built-in whose content changed *without* a Cantera version bump
+  would not invalidate the cache. Built-in mechanisms are not expected to change within a release, so
+  this is tolerated rather than defended against. Filling in the hash is feasible if provenance ever
+  matters — a built-in is locatable by scanning `cantera.get_data_directories()` for the name — but it
+  would only strengthen the recorded provenance, not cache correctness.
+
 #### Run-set expansion and the sweep runners (GUI in-process, CLI out-of-process)
 
 `runset.py` is the reference implementation of the STONE `scenarios:`/`sweep:` semantics


### PR DESCRIPTION
## Summary
Documents a known limitation raised while auditing "when can the calculated parameters differ from what the GUI shows".

The scenario store's per-group `mechanism_sha256` attr is **empty for Cantera built-ins** (`gri30.yaml`), which looks like a cache-invalidation hole. It isn't — the two things are separate:

- `payload_store._resolve_mechanism` writes `mechanism_sha256` as **provenance only**, and only hashes a mechanism that resolves to an existing file.
- `result_cache._mechanism_identity` — the actual **cache key** — already keys a built-in as `builtin:<name>@cantera-<version>`, so upgrading Cantera *does* invalidate cached results that used one.

The one case genuinely not covered is a built-in whose content changes *without* a Cantera version bump. Built-in mechanisms aren't expected to change within a release, so this is documented as accepted rather than defended against.

Also notes that filling in the hash is feasible (a built-in is locatable by scanning `cantera.get_data_directories()` for the name — verified working on Cantera 3.2.0) but would only strengthen recorded provenance, not cache correctness.

Docs-only, no behavior change.

## Test plan
- [x] `pre-commit run --files ARCHITECTURE.md` -- clean (mdformat included)

🤖 Generated with [Claude Code](https://claude.com/claude-code)