### PR TITLE
feat: multi-target sweep axes and a declarative sweep.runner

### DIFF
--- a/STONE_SPECIFICATIONS.md
+++ b/STONE_SPECIFICATIONS.md
@@ -1384,6 +1384,55 @@ sweep:
 `sweep:` may appear at the top level (expanded on the base) **or inside a `scenarios:` entry**
 (expanded on that scenario only). Ids are suffixed `__<axis>=<value>`.
 
+#### One axis, several targets
+
+`path:` also accepts a **list**, so one swept value is written to every listed target:
+
+```yaml
+sweep:
+  inlet_temperature:
+    path:
+      - "network[id=fuel_air_mixture_tank].Reservoir.temperature"
+      - "network[id=stirred_reactor].IdealGasMoleReactor.initial.temperature"
+    values: [650, 700, 750]
+```
+
+Use this when the targets are the *same physical quantity* on different nodes — above, an inlet
+reservoir's temperature and the initial state of the isothermal (`energy: "off"`) reactor it feeds.
+They must move together: sweeping one alone is physically inconsistent, and giving them separate
+axes would cross-multiply into mostly nonsense combinations. It stays **one** axis — three values
+give three runs, not nine — and the scenario id is unchanged, labelled from the first path.
+
+### `sweep.runner:` — a host-produced run-set
+
+When no declarative axis can express the run-set, name a callable that produces it:
+
+```yaml
+sweep:
+  runner: "my_package.sweeps.combustor:run"
+```
+
+Reach for this only when the points cannot be enumerated up front:
+
+- they must be solved **sequentially**, each warm-started from the previous (continuing along a
+  branch, e.g. down to a combustor's extinction limit), or
+- the run-set's **length is only known at runtime** (stop when a condition is met).
+
+The callable receives the resolved collection-store path and writes the scenarios itself with
+`boulder.payload_store.write_payload`. It may declare an optional `progress` parameter —
+`(done, total, message)` — to drive the same status UI a declarative sweep does:
+
+```python
+def run(store_path, progress=None): ...
+```
+
+`runner` is a reserved key inside the block: it is never interpreted as an axis, and may sit
+alongside real axes. Boulder resolves and calls it **in-process**, like every other sweep.
+
+> **Note** — Boulder previously executed any file literally named `run_sweep.py` next to the config.
+> That is gone: it tied behaviour to a filename, was invisible in the config, and broke silently.
+> Declare `sweep.runner` instead.
+
 ### Run-set semantics (union)
 
 The run set is the **union**: the top-level `sweep:` points **⊎** each `scenarios:` entry (each

--- a/boulder/api/routes/sweep.py
+++ b/boulder/api/routes/sweep.py
@@ -33,7 +33,12 @@ from pydantic import BaseModel, Field
 
 from ...cantera_converter import DualCanteraConverter, get_plugins
 from ...payload_store import write_payload
-from ...runset import resolve_store_path, run_set_size, sweeps_of
+from ...runset import (
+    resolve_store_path,
+    run_set_size,
+    sweep_runner_of,
+    sweeps_of,
+)
 from ...sweep_runner import (
     _mechanism_of,
     existing_fingerprints,
@@ -61,14 +66,58 @@ class SweepRunRequest(BaseModel):
 def has_run_set(raw: Dict[str, Any], config_path: Optional[str]) -> bool:
     """Return whether *raw* (the inheritance-resolved config) declares a run-set.
 
-    True when it has an inline ``scenarios:``/``sweep:``/``sweeps:`` block.
+    True when it declares one **in the config**: an inline
+    ``scenarios:``/``sweep:``/``sweeps:`` block, or a ``sweep.runner`` dotted
+    path naming a host function that produces the run-set itself.
+
     Pure function of ``raw`` so both the request-scoped sweep routes and the
-    app-startup lifespan can share one detection rule. ``config_path`` is
-    accepted for signature compatibility with existing callers; it is not
-    otherwise used (Run Sweep runs in-process now — there is no external
-    runner script to look for next to the config).
+    app-startup lifespan share one detection rule. ``config_path`` is accepted
+    for signature compatibility; it is deliberately *not* consulted — Boulder
+    used to treat any file named ``run_sweep.py`` next to the config as a
+    run-set source, which coupled behaviour to a filename and was invisible in
+    the config itself. Declare ``sweep.runner`` instead.
     """
-    return bool(raw.get("scenarios") or sweeps_of(raw))
+    return bool(raw.get("scenarios") or sweeps_of(raw) or sweep_runner_of(raw))
+
+
+def _run_host_sweep(dotted: str, state: Dict[str, Any], store: Path) -> None:
+    """Resolve and call a ``sweep.runner`` callable, updating *state* around it.
+
+    The callable owns the run-set: it decides the points, solves them and
+    writes them into the collection store (``boulder.payload_store``). It is
+    passed the store path and may accept an optional ``progress`` callable —
+    ``(done, total, message)`` — so a host that knows its point count can drive
+    the same status UI a declarative sweep does.
+    """
+    from ...cantera_converter import resolve_dotted_path
+
+    runner = resolve_dotted_path(dotted)
+    if not callable(runner):
+        raise TypeError(f"sweep.runner {dotted!r} resolved to a non-callable")
+
+    def _progress(done: int, total: int, message: str = "") -> None:
+        state["current"] = int(done)
+        if total:
+            state["total"] = int(total)
+        line = message or f"scenario {done}/{total or '?'}"
+        state["message"] = line
+        state["last_line"] = line
+
+    # Decide by signature, not by catching TypeError: a TypeError raised
+    # *inside* the runner would otherwise look like "wrong arity" and re-run
+    # it, writing the store twice.
+    import inspect
+
+    try:
+        accepts_progress = "progress" in inspect.signature(runner).parameters
+    except (TypeError, ValueError):  # builtins / C callables expose no signature
+        accepts_progress = False
+
+    print(f"[sweep] delegating to host runner {dotted}", flush=True)
+    if accepts_progress:
+        runner(store, progress=_progress)
+    else:
+        runner(store)
 
 
 def _has_run_set(request: Request) -> bool:
@@ -142,8 +191,9 @@ async def sweep_run(
     ``no_cache=true`` forces every scenario to re-solve from scratch.
     """
     raw = _merged_raw(request, body.scenarios)
+    host_runner = sweep_runner_of(raw)
     total = run_set_size(raw)
-    if total == 0:
+    if total == 0 and not host_runner:
         raise HTTPException(
             status_code=400, detail="No runnable run-set for this config"
         )
@@ -188,6 +238,17 @@ async def sweep_run(
             store.parent.mkdir(parents=True, exist_ok=True)
             if body.no_cache and store.exists():
                 store.unlink()
+
+            if host_runner:
+                # A host-produced run-set: points that no declarative axis can
+                # express (solved sequentially, each warm-started from the
+                # last, or of a length not known until extinction). The host
+                # writes the collection store itself; Boulder only resolves the
+                # callable and reports status. Runs in-process like every other
+                # sweep -- declaring the runner replaced *spawning* it.
+                _run_host_sweep(host_runner, state, store)
+                return
+
             cached_fps = {} if body.no_cache else existing_fingerprints(store)
 
             # Bound once: the host's KPI/artifact hooks are read per scenario

--- a/boulder/runset.py
+++ b/boulder/runset.py
@@ -164,9 +164,44 @@ def load_yaml_with_inheritance(path: "str | Path") -> dict:
 # ---------------------------------------------------------------------------
 
 
+#: Keys inside a ``sweep:``/``sweeps:`` block that configure the run-set rather
+#: than declare an axis. Filtered out of every axis-iterating code path.
+SWEEP_RESERVED_KEYS = frozenset({"runner"})
+
+
 def sweeps_of(block: dict) -> dict:
-    """Return the sweep block of a config/overlay, accepting ``sweep:`` or ``sweeps:``."""
-    return block.get("sweeps") or block.get("sweep") or {}
+    """Return a config/overlay's sweep **axes**, accepting ``sweep:`` or ``sweeps:``.
+
+    Reserved keys (:data:`SWEEP_RESERVED_KEYS`) are stripped, so every caller
+    that treats the result as ``{axis_name: axis_spec}`` stays correct as
+    non-axis configuration is added to the block.
+    """
+    raw = block.get("sweeps") or block.get("sweep") or {}
+    if not isinstance(raw, dict):
+        return {}
+    return {k: v for k, v in raw.items() if k not in SWEEP_RESERVED_KEYS}
+
+
+def sweep_runner_of(block: dict) -> Optional[str]:
+    """Return a config's declared host sweep runner, or ``None``.
+
+    ``sweep.runner`` is a dotted ``"package.module:callable"`` reference to a
+    host function that produces the run-set itself, for run-sets that no
+    declarative axis can express — a sweep whose points must be solved
+    *sequentially* (each warm-started from the last, e.g. tracing a combustor's
+    extinction branch), or whose length is not known in advance.
+
+    Declaring it in the config is deliberate: Boulder used to *guess*, running
+    any file literally named ``run_sweep.py`` sitting next to the config. That
+    coupled behaviour to a filename, was invisible in the config, and silently
+    stopped working when Run Sweep moved in-process. An explicit dotted path is
+    resolvable, greppable, and testable.
+    """
+    raw = block.get("sweeps") or block.get("sweep") or {}
+    if not isinstance(raw, dict):
+        return None
+    runner = raw.get("runner")
+    return str(runner) if runner else None
 
 
 def sweep_axis_values(axis_spec: dict) -> list:
@@ -416,33 +451,58 @@ def _expand_sweep_block(
         explicit_symbol = axis_spec.get("symbol")
         if explicit_symbol:
             return str(explicit_symbol)
-        path = str(axis_spec.get("path", ""))
+        # A multi-target axis labels itself from its *first* path, so the
+        # scenario id stays short and stable no matter how many nodes it drives.
+        raw_path = axis_spec.get("path")
+        first = (
+            raw_path[0]
+            if isinstance(raw_path, (list, tuple)) and raw_path
+            else raw_path
+        )
+        path = str(first or "")
         leaf = path.rsplit(".", 1)[-1] if path else axis_name
         return symbols.get(leaf) or symbols.get(axis_name) or axis_name
 
     axes = []
     for axis_name, axis_spec in sweeps_block.items():
-        axis_path = axis_spec.get("path") if isinstance(axis_spec, dict) else None
+        raw_path = axis_spec.get("path") if isinstance(axis_spec, dict) else None
         axis_values = (
             sweep_axis_values(axis_spec) if isinstance(axis_spec, dict) else None
         )
-        if not axis_path or not axis_values:
+        if not raw_path or not axis_values:
             raise ValueError(
                 f"sweep.{axis_name} must be a dict with 'path' and either "
                 f"'values: [...]' or 'min'/'max'/'num'; got {axis_spec!r}"
             )
-        axis_path = _resolve_sweep_path(
-            axis_name, axis_path, base_for_paths, schema_entry
+        # ``path`` may name several targets, so one swept value can drive
+        # parameters that are physically the same quantity but live on
+        # different nodes -- e.g. an inlet reservoir's temperature and the
+        # isothermal reactor's initial temperature fed by it. Solving those as
+        # one axis is the whole point: sweeping only one of them would be
+        # physically inconsistent, and a cross-product of the two would mostly
+        # produce nonsense combinations.
+        raw_paths = (
+            list(raw_path) if isinstance(raw_path, (list, tuple)) else [raw_path]
         )
-        axes.append((_axis_label(axis_name, axis_spec), axis_path, list(axis_values)))
+        if not all(isinstance(p, str) and p for p in raw_paths):
+            raise ValueError(
+                f"sweep.{axis_name}.path must be a dotted string or a list of "
+                f"them; got {raw_path!r}"
+            )
+        axis_paths = tuple(
+            _resolve_sweep_path(axis_name, p, base_for_paths, schema_entry)
+            for p in raw_paths
+        )
+        axes.append((_axis_label(axis_name, axis_spec), axis_paths, list(axis_values)))
 
     points: List[Tuple[str, dict]] = []
     for combo in product(*[a[2] for a in axes]):
         label_parts: List[str] = []
         patch: dict = {}
-        for (label, axis_path, _), value in zip(axes, combo, strict=True):
+        for (label, axis_paths, _), value in zip(axes, combo, strict=True):
             label_parts.append(f"{label}={value}")
-            _set_dotted(patch, axis_path, value)
+            for axis_path in axis_paths:
+                _set_dotted(patch, axis_path, value)
         points.append(("__".join(label_parts), patch))
     return points
 

--- a/tests/test_sweep_multipath_and_runner.py
+++ b/tests/test_sweep_multipath_and_runner.py
@@ -1,0 +1,227 @@
+"""Two ways to declare a run-set that a single-target axis could not express.
+
+Both exist because real sweeps hit limits of the original `sweep:` block:
+
+* **Multi-target axis** — one swept value must reach several config paths at
+  once, because they are the same physical quantity on different nodes (an
+  inlet reservoir's temperature and the isothermal reactor it feeds). Sweeping
+  only one is physically inconsistent; crossing them produces nonsense pairs.
+* **`sweep.runner`** — the points can only be produced by running them: solved
+  sequentially with each warm-started from the last, or continuing until a
+  condition (extinction) that fixes the length only at runtime.
+
+The second replaces Boulder *guessing*: it used to execute any file named
+`run_sweep.py` next to the config. That is deliberately still ignored.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, List
+
+import pytest
+
+from boulder.runset import (  # noqa: E402
+    expand_scenarios,
+    sweep_runner_of,
+    sweeps_of,
+)
+
+_BASE: Dict[str, Any] = {
+    "phases": {"gas": {"mechanism": "gri30.yaml"}},
+    "network": [
+        {"id": "tank", "Reservoir": {"temperature": 925.0, "composition": "CH4:1"}},
+        {
+            "id": "reactor",
+            "IdealGasMoleReactor": {
+                "energy": "off",
+                "initial": {"temperature": 925.0, "composition": "CH4:1"},
+            },
+        },
+    ],
+}
+
+
+def _cfg(**extra: Any) -> Dict[str, Any]:
+    import copy
+
+    cfg = copy.deepcopy(_BASE)
+    cfg.update(extra)
+    return cfg
+
+
+# --------------------------------------------------------------------------- #
+# Multi-target axis
+# --------------------------------------------------------------------------- #
+
+
+def test_one_value_reaches_every_declared_path() -> None:
+    """The point of the feature: both nodes move together, in lockstep."""
+    runs = expand_scenarios(
+        _cfg(
+            sweep={
+                "inlet_temperature": {
+                    "path": [
+                        "network[id=tank].Reservoir.temperature",
+                        "network[id=reactor].IdealGasMoleReactor.initial.temperature",
+                    ],
+                    "values": [650, 1100],
+                }
+            }
+        )
+    )
+
+    assert len(runs) == 2, "two values -> two points, not a cross product"
+    by_value = {}
+    for _sid, cfg in runs:
+        node = {n["id"]: n for n in cfg["network"]}
+        tank_t = node["tank"]["Reservoir"]["temperature"]
+        reactor_t = node["reactor"]["IdealGasMoleReactor"]["initial"]["temperature"]
+        assert tank_t == reactor_t, "paths drifted -- they must move as one"
+        by_value[tank_t] = reactor_t
+    assert sorted(by_value) == [650, 1100]
+
+
+def test_a_single_string_path_still_works() -> None:
+    """Backward compatibility: the overwhelmingly common form is unchanged."""
+    runs = expand_scenarios(
+        _cfg(
+            sweep={
+                "t": {"path": "network[id=tank].Reservoir.temperature", "values": [700]}
+            }
+        )
+    )
+    assert len(runs) == 1
+    node = {n["id"]: n for n in runs[0][1]["network"]}
+    assert node["tank"]["Reservoir"]["temperature"] == 700
+    # The untargeted node keeps the base value.
+    assert node["reactor"]["IdealGasMoleReactor"]["initial"]["temperature"] == 925.0
+
+
+def test_scenario_ids_do_not_grow_with_path_count() -> None:
+    """A 2-path axis must not produce a doubled, unreadable id."""
+    single = expand_scenarios(
+        _cfg(
+            sweep={
+                "t": {"path": "network[id=tank].Reservoir.temperature", "values": [650]}
+            }
+        )
+    )
+    multi = expand_scenarios(
+        _cfg(
+            sweep={
+                "t": {
+                    "path": [
+                        "network[id=tank].Reservoir.temperature",
+                        "network[id=reactor].IdealGasMoleReactor.initial.temperature",
+                    ],
+                    "values": [650],
+                }
+            }
+        )
+    )
+    assert single[0][0] == multi[0][0]
+
+
+def test_a_malformed_path_list_fails_loudly() -> None:
+    with pytest.raises(ValueError, match="dotted string or a list"):
+        expand_scenarios(_cfg(sweep={"t": {"path": [None], "values": [1]}}))
+
+
+# --------------------------------------------------------------------------- #
+# sweep.runner
+# --------------------------------------------------------------------------- #
+
+
+def test_runner_is_read_but_never_treated_as_an_axis() -> None:
+    """`runner` configures the run-set; iterating it as an axis would crash."""
+    cfg = _cfg(sweep={"runner": "pkg.mod:run"})
+    assert sweep_runner_of(cfg) == "pkg.mod:run"
+    assert sweeps_of(cfg) == {}, "reserved key leaked into the axis map"
+
+
+def test_runner_coexists_with_real_axes() -> None:
+    cfg = _cfg(
+        sweep={
+            "runner": "pkg.mod:run",
+            "t": {"path": "network[id=tank].Reservoir.temperature", "values": [1, 2]},
+        }
+    )
+    assert sweep_runner_of(cfg) == "pkg.mod:run"
+    assert list(sweeps_of(cfg)) == ["t"]
+    # A sweep-only config gets no BASELINE entry (that is the `scenarios:`
+    # case); the two axis points are the whole run-set.
+    assert len(expand_scenarios(cfg)) == 2
+
+
+def test_no_runner_declared_reads_as_none() -> None:
+    assert sweep_runner_of(_cfg()) is None
+    assert sweep_runner_of(_cfg(sweep={"t": {"path": "a.b", "values": [1]}})) is None
+
+
+def test_a_config_with_only_a_runner_still_counts_as_a_run_set(tmp_path: Path) -> None:
+    """Without this the Run Sweep button and Scenario pane stay hidden.
+
+    Exactly how boulder_examples' scripted sweeps disappeared: their configs
+    declare no axes at all, so a run-set check based purely on axes reported
+    "nothing to run".
+    """
+    from boulder.api.routes.sweep import has_run_set
+
+    cfg = _cfg(sweep={"runner": "pkg.mod:run"})
+    assert has_run_set(cfg, str(tmp_path / "config.yaml")) is True
+
+
+def test_a_bare_run_sweep_py_is_still_not_a_run_set(tmp_path: Path) -> None:
+    """Filename discovery stays gone -- the runner must be declared."""
+    from boulder.api.routes.sweep import has_run_set
+
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text("metadata: {}\n", encoding="utf-8")
+    (tmp_path / "run_sweep.py").write_text("", encoding="utf-8")
+    assert has_run_set({}, str(cfg)) is False
+
+
+def test_host_runner_is_called_once_even_if_it_raises_a_type_error() -> None:
+    """Arity must be decided by signature, not by catching TypeError.
+
+    A TypeError raised *inside* a runner would otherwise be mistaken for
+    "wrong arity" and re-invoke it, writing the collection store twice.
+    """
+    from boulder.api.routes import sweep as sweep_route
+
+    calls: List[Any] = []
+
+    def _runner(store: Path) -> None:  # no `progress` parameter
+        calls.append(store)
+        raise TypeError("failure from inside the runner")
+
+    from unittest.mock import patch
+
+    import boulder.cantera_converter as cc
+
+    with patch.object(cc, "resolve_dotted_path", return_value=_runner):
+        with pytest.raises(TypeError, match="from inside the runner"):
+            sweep_route._run_host_sweep("pkg.mod:run", {}, Path("store.h5"))
+
+    assert len(calls) == 1, "runner was invoked more than once"
+
+
+def test_host_runner_receives_progress_when_it_asks_for_it() -> None:
+    from boulder.api.routes import sweep as sweep_route
+
+    state: Dict[str, Any] = {}
+
+    def _runner(store: Path, progress: Any = None) -> None:
+        progress(2, 5, "scenario 2/5")
+
+    from unittest.mock import patch
+
+    import boulder.cantera_converter as cc
+
+    with patch.object(cc, "resolve_dotted_path", return_value=_runner):
+        sweep_route._run_host_sweep("pkg.mod:run", state, Path("store.h5"))
+
+    assert state["current"] == 2
+    assert state["total"] == 5
+    assert state["last_line"] == "scenario 2/5"


### PR DESCRIPTION
## Why

`boulder_examples`' two sweep examples (`continuous_reactor`, `combustor`) bypass Boulder entirely with a `run_sweep.py` script, because their run-sets genuinely cannot be written as a `sweep:` block. Boulder used to *discover* that script by filename; #133 removed that, and both examples silently lost Run Sweep **and** their Scenario pane — the committed `*_scenarios.h5` files are fully populated but never shown.

Rather than restore filename discovery, this closes the two capability gaps that made a script necessary.

## 1. One axis, several targets

`path:` now accepts a list:

```yaml
sweep:
  inlet_temperature:
    path:
      - "network[id=fuel_air_mixture_tank].Reservoir.temperature"
      - "network[id=stirred_reactor].IdealGasMoleReactor.initial.temperature"
    values: [650, 700, 750]
```

Use it when the targets are the *same physical quantity* on different nodes — above, an inlet reservoir and the initial state of the isothermal (`energy: "off"`) reactor it feeds. Sweeping one alone is physically inconsistent; separate axes would cross-multiply into mostly nonsense combinations.

Stays **one** axis: 3 values → 3 runs, not 9. Scenario ids are unchanged (labelled from the first path), so a 2-path axis doesn't produce a doubled id.

## 2. `sweep.runner`

```yaml
sweep:
  runner: "my_package.sweeps.combustor:run"
```

For run-sets that can only be produced by running them: points solved **sequentially**, each warm-started from the last (tracing a combustor down to extinction), or whose **length is only known at runtime**. Combustor's continuation is physics, not a numerical convenience — independent per-point solves would find a different branch.

The callable gets the resolved store path and writes scenarios with `write_payload`; it may declare an optional `progress` parameter (`done, total, message`) to drive the normal status UI. Resolved and called **in-process** like every other sweep — declaring the runner replaced *spawning* it.

Details:
- `runner` is a reserved key, stripped by `sweeps_of()` so no axis-iterating path mistakes it for an axis; it may sit alongside real axes.
- `has_run_set()` counts it — without that the button and pane stay hidden, exactly how the scripted examples vanished.
- **Filename discovery stays gone.** A bare `run_sweep.py` next to a config is still not a run-set; a test pins that.
- Arity is decided by `inspect.signature`, not by catching `TypeError` — otherwise a `TypeError` raised *inside* a runner looks like wrong arity and re-invokes it, writing the store twice. Also pinned by a test.

## Test plan
- [x] New `tests/test_sweep_multipath_and_runner.py` (11 tests): lockstep multi-target writes; single-string paths unchanged; ids don't grow with path count; malformed path list fails loudly; `runner` never treated as an axis; coexists with axes; counts as a run-set; bare `run_sweep.py` still ignored; runner invoked exactly once when it raises `TypeError`; `progress` delivered when requested
- [x] Full backend suite: **815 passed**, 1 skipped, 7 xfailed (804 before)
- [x] `pre-commit run` on all changed files — clean
- [x] STONE_SPECIFICATIONS.md §14 documents both, including why filename discovery was dropped

Follow-up: port both boulder_examples sweeps onto these and delete `run_sweep.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)