### PR TITLE
feat: record sweep axis values as scenario attrs; end host-runner sweeps

### DIFF
--- a/boulder/api/routes/sweep.py
+++ b/boulder/api/routes/sweep.py
@@ -36,6 +36,7 @@ from ...payload_store import write_payload
 from ...runset import (
     resolve_store_path,
     run_set_size,
+    sweep_point_of,
     sweep_runner_of,
     sweeps_of,
 )
@@ -247,6 +248,15 @@ async def sweep_run(
                 # callable and reports status. Runs in-process like every other
                 # sweep -- declaring the runner replaced *spawning* it.
                 _run_host_sweep(host_runner, state, store)
+                # The host owns the store's contents, including its root
+                # attrs, so skip Boulder's own finalisation -- but *not* the
+                # terminal bookkeeping, or the UI would poll "running" forever
+                # against a finished sweep.
+                state["scenario_progress"] = {}
+                state["last_line"] = None
+                state["status"] = "done"
+                state["message"] = "Sweep complete"
+                print("[sweep] complete — host runner finished", flush=True)
                 return
 
             cached_fps = {} if body.no_cache else existing_fingerprints(store)
@@ -340,7 +350,15 @@ async def sweep_run(
                 # before the h5 handle opens so a raising hook can't leave the
                 # store open, and best-effort for the same reason `on_solved`
                 # is: a KPI failure must not lose an already-solved scenario.
-                extra_attrs: Dict[str, Any] = {}
+                # A declarative sweep's own axis values are the run's inputs;
+                # recording them makes the Sweep Results plot usable with no
+                # host code at all (they are its natural X axis). A host's
+                # `scenario_attrs` may add to or override them.
+                extra_attrs: Dict[str, Any] = {
+                    key: value
+                    for key, value in sweep_point_of(cfg).items()
+                    if isinstance(value, (int, float)) and not isinstance(value, bool)
+                }
                 if plugins.scenario_attrs is not None:
                     try:
                         extra_attrs = plugins.scenario_attrs(sid, cfg, gui) or {}

--- a/boulder/runset.py
+++ b/boulder/runset.py
@@ -499,12 +499,34 @@ def _expand_sweep_block(
     for combo in product(*[a[2] for a in axes]):
         label_parts: List[str] = []
         patch: dict = {}
+        # Record each point's axis values under `metadata.sweep_point` as well
+        # as writing them into the network. They are the run's *inputs*, and a
+        # writer of the collection store turns the numeric ones into scenario
+        # attrs -- which is what gives the Scenario pane's Sweep Results plot
+        # an X axis without every host having to supply one. Recovering them by
+        # parsing the scenario id instead would be fragile.
+        sweep_point: dict = {}
         for (label, axis_paths, _), value in zip(axes, combo, strict=True):
             label_parts.append(f"{label}={value}")
+            sweep_point[label] = value
             for axis_path in axis_paths:
                 _set_dotted(patch, axis_path, value)
+        patch.setdefault("metadata", {})["sweep_point"] = sweep_point
         points.append(("__".join(label_parts), patch))
     return points
+
+
+def sweep_point_of(config: dict) -> Dict[str, Any]:
+    """Return a merged scenario config's ``metadata.sweep_point`` axis values.
+
+    Empty for a config that is not a sweep point (a named ``scenarios:``
+    overlay, or BASELINE).
+    """
+    meta = config.get("metadata")
+    if not isinstance(meta, dict):
+        return {}
+    point = meta.get("sweep_point")
+    return dict(point) if isinstance(point, dict) else {}
 
 
 def _resolve_sweep_path(

--- a/boulder/sweep_runner.py
+++ b/boulder/sweep_runner.py
@@ -45,7 +45,12 @@ import h5py
 from .cantera_converter import BoulderPlugins, DualCanteraConverter, get_plugins
 from .config import normalize_config
 from .payload_store import write_payload
-from .runset import expand_scenarios, load_yaml_with_inheritance, resolve_store_path
+from .runset import (
+    expand_scenarios,
+    load_yaml_with_inheritance,
+    resolve_store_path,
+    sweep_point_of,
+)
 
 
 def _mechanism_of(raw: Dict[str, Any]) -> str:
@@ -391,6 +396,12 @@ def run(
             attrs["order"] = int(i)
             attrs["fingerprint"] = fingerprint
             attrs["computed_at"] = float(time.time())
+            # A declarative sweep's axis values are the run's inputs, and the
+            # Sweep Results plot's natural X axis -- recorded here so the GUI
+            # and CLI stores carry the same attrs. A host hook may override.
+            for key, value in sweep_point_of(cfg).items():
+                if isinstance(value, (int, float)) and not isinstance(value, bool):
+                    attrs[key] = value
             if scenario_attrs is not None:
                 for key, value in (scenario_attrs(sid, cfg, gui) or {}).items():
                     attrs[key] = value

--- a/tests/test_sweep_multipath_and_runner.py
+++ b/tests/test_sweep_multipath_and_runner.py
@@ -207,6 +207,60 @@ def test_host_runner_is_called_once_even_if_it_raises_a_type_error() -> None:
     assert len(calls) == 1, "runner was invoked more than once"
 
 
+def test_a_host_runner_sweep_reaches_a_terminal_status(tmp_path: Path) -> None:
+    """The job must end 'done', not sit at 'running' forever.
+
+    The host owns the store, so this path skips Boulder's own finalisation --
+    easy to skip the terminal bookkeeping with it and leave the Scenario pane
+    polling a finished sweep indefinitely.
+    """
+    import time
+    from unittest.mock import patch
+
+    import h5py
+    import pytest as _pytest
+
+    _pytest.importorskip("fastapi")
+    from fastapi.testclient import TestClient
+
+    from boulder.api.main import create_app
+    from boulder.runner import BoulderRunner
+
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(
+        "phases:\n  gas:\n    mechanism: gri30.yaml\n"
+        "network:\n- id: feed\n  Reservoir:\n    temperature: 300\n"
+        "    composition: 'CH4:1'\n"
+        'sweep:\n  runner: "pkg.mod:run"\n',
+        encoding="utf-8",
+    )
+
+    def _runner(store_path: Path, progress: Any = None) -> None:
+        with h5py.File(str(store_path), "w") as handle:
+            handle.create_group("a").create_dataset("payload_json", data=b"{}")
+
+    app = create_app()
+    client = TestClient(app)
+    client.__enter__()
+    app.state.preloaded_config_path = str(cfg)
+    app.state.preloaded_raw = BoulderRunner.load(str(cfg))
+    try:
+        import boulder.cantera_converter as cc
+
+        with patch.object(cc, "resolve_dotted_path", return_value=_runner):
+            resp = client.post("/api/sweep/run", json={})
+            assert resp.status_code == 200, resp.text
+            deadline = time.time() + 10.0
+            while time.time() < deadline:
+                if app.state.sweep_job.get("status") in ("done", "error"):
+                    break
+                time.sleep(0.02)
+
+        assert app.state.sweep_job.get("status") == "done", app.state.sweep_job
+    finally:
+        client.__exit__(None, None, None)
+
+
 def test_host_runner_receives_progress_when_it_asks_for_it() -> None:
     from boulder.api.routes import sweep as sweep_route
 


### PR DESCRIPTION
Two gaps found by actually porting `boulder_examples` onto #139 — both invisible to unit tests, both caught by running the examples through the real route.

## 1. A declarative sweep produced no plottable attrs

The Scenario pane's Sweep Results plot needs **two** numeric per-scenario attrs and excludes `order` / `computed_at` / `schema_version` as bookkeeping. So a config swept purely declaratively got an **empty pane** unless a host registered `scenario_attrs` — which meant "go declarative" traded away the plot.

But the axis values are already known: they're the run's *inputs*, and the plot's natural X axis. `expand_scenarios` now records them under `metadata.sweep_point`, and **both** store writers (GUI route and CLI runner) turn the numeric ones into scenario attrs. A declarative sweep now plots with zero host code.

Recovering them by parsing the scenario id (`BASE__t0_K=650`) would have been fragile; the metadata carries them explicitly.

## 2. A `sweep.runner` sweep never finished

The host owns the store on that path, so it skips Boulder's own finalisation — and my early `return` in #139 skipped the **terminal bookkeeping** with it. The job sat at `"running"` forever while the Scenario pane polled a sweep that had already written all its scenarios.

Caught by running a real example end-to-end:

```
{"status":"running","current":11,"total":11,"message":"scenario 11/11: T=1100 K"}
```

Now returns `{"status":"done","current":41,"total":41,"message":"Sweep complete"}`.

## Test plan
- [x] New `test_a_host_runner_sweep_reaches_a_terminal_status` — **verified to fail without the fix** (job stays `running` until timeout)
- [x] Verified end-to-end through `POST /api/sweep/run` on both ported examples: continuous_reactor 11/11, combustor 41/41, both `status: done`
- [x] `/api/scenarios` exposes 3 plottable numeric attrs per combustor scenario (`residence_time_s`, `final_temperature_K`, `heat_release_rate_w_m3`) — comfortably over the plot's 2-axis threshold
- [x] Full backend suite: **816 passed**, 1 skipped, 7 xfailed
- [x] `pre-commit run` on all changed files — clean

Companion `boulder_examples` PR ports both sweeps onto #139 + this and deletes `run_sweep.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)