### PR TITLE
fix: stop the Properties panel showing the previous scenario's values

### DIFF
--- a/frontend/src/stores/scenarioStore.test.ts
+++ b/frontend/src/stores/scenarioStore.test.ts
@@ -306,4 +306,50 @@ describe("scenarioStore", () => {
 
     expect(useScenarioStore.getState().previewId).toBe("B");
   });
+
+  it("clears the previous preview before awaiting the new one", async () => {
+    // Selecting a scenario used to leave the *previous* scenario's preview in
+    // place until the fetch resolved, so the Properties panel rendered another
+    // scenario's numbers under the new selection, styled as an override with
+    // nothing marking them stale. Measured at ~80 ms against a real model, but
+    // it scales with server load, and a wrong number presented as fact is the
+    // bug regardless of how briefly it shows.
+    mockFetchScenarioPreview.mockResolvedValueOnce({
+      scenario_id: "A",
+      nodes: [{ id: "outlet", type: "OutletSink", properties: { pressure: 200000 } }],
+      connections: [],
+    });
+    await useScenarioStore.getState().setActive("A");
+    expect(useScenarioStore.getState().previewNodes).toEqual([
+      { id: "outlet", type: "OutletSink", properties: { pressure: 200000 } },
+    ]);
+
+    // Now select another scenario whose preview has not resolved yet.
+    let resolveSecond: (v: unknown) => void = () => {};
+    mockFetchScenarioPreview.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveSecond = resolve;
+        }),
+    );
+    const pending = useScenarioStore.getState().setActive("B");
+
+    const midFlight = useScenarioStore.getState();
+    expect(midFlight.previewLoading).toBe(true);
+    expect(midFlight.previewNodes).toBeNull();
+    expect(midFlight.previewConnections).toBeNull();
+    expect(midFlight.previewId).toBeNull();
+
+    resolveSecond({
+      scenario_id: "B",
+      nodes: [{ id: "outlet", type: "OutletSink", properties: { pressure: 300000 } }],
+      connections: [],
+    });
+    await pending;
+
+    expect(useScenarioStore.getState().previewId).toBe("B");
+    expect(useScenarioStore.getState().previewNodes).toEqual([
+      { id: "outlet", type: "OutletSink", properties: { pressure: 300000 } },
+    ]);
+  });
 });

--- a/frontend/src/stores/scenarioStore.ts
+++ b/frontend/src/stores/scenarioStore.ts
@@ -179,7 +179,21 @@ export const useScenarioStore = create<ScenarioState>((set, get) => ({
 
   clearCache: async () => {
     const resp = await apiClearScenarioCache();
-    set({ activeId: null });
+    // Drop the preview with the selection, as `deleteScenario` already does.
+    // Otherwise the Properties panel keeps showing the last-selected
+    // scenario's overrides -- flagged as overrides -- with no scenario
+    // selected any more and nothing left in the store to justify them.
+    //
+    // The *base run's* result deliberately survives: this clears scenario
+    // results only (see the button's tooltip), so the graph's "computed"
+    // node tint still correctly reflects the base simulation still loaded.
+    set({
+      activeId: null,
+      previewId: null,
+      previewNodes: null,
+      previewConnections: null,
+      previewError: null,
+    });
     await get().refresh();
     return { cleared: resp.cleared };
   },
@@ -230,7 +244,20 @@ export const useScenarioStore = create<ScenarioState>((set, get) => ({
 
   loadPreview: async (id) => {
     const seq = get().previewSeq + 1;
-    set({ previewSeq: seq, previewLoading: true, previewError: null });
+    // Drop the previous scenario's preview *before* awaiting. Keeping it would
+    // leave the Properties panel rendering another scenario's numbers under the
+    // newly selected one -- styled as an override, with nothing marking them as
+    // stale, so a value belonging to a different case reads as this one's.
+    // Consumers fall back to the base config's values instead, which are at
+    // least not attributed to the wrong scenario, until the real preview lands.
+    set({
+      previewSeq: seq,
+      previewLoading: true,
+      previewError: null,
+      previewId: null,
+      previewNodes: null,
+      previewConnections: null,
+    });
     const overlay = id === BASELINE_SCENARIO_ID ? {} : get().overlays[id] ?? {};
     try {
       const preview = await fetchScenarioPreview(id, overlay);


### PR DESCRIPTION
## The bug

Selecting a scenario set `previewLoading: true` but left `previewId`/`previewNodes` holding the **previous** scenario's preview until the new fetch resolved. `PropertiesPanel` gates on `previewId`, so it confidently rendered another scenario's numbers under the new selection — styled as overrides, with nothing marking them stale.

Reported against a real multi-scenario model: selecting a low-pressure case showed a reactor's pressure taken from the high-pressure case.

Traced in the browser, switching between two scenarios that override the same outlet pressure:

```
t=0ms     <other scenario's value>   <- wrong
t=78ms    <correct value>
```

**The duration is not the bug — the wrong number is.** 78 ms is easy to miss; under server load it stretches long enough to read a value and believe it.

Worth noting what this is *not*: the preview endpoint is fast (73–86 ms, ~3 KB) and there were **zero** long tasks, so neither the backend nor main-thread blocking was involved. Making it faster would have hidden the bug rather than fixed it.

## The fix

Clear the preview before awaiting, so consumers fall back to the base config — at least not attributed to the wrong scenario. Same trace after:

```
t=1ms     <pre-click state>
t=5ms     <correct value>            <- one React render later
```

The correct value now lands **before** the ~76 ms fetch resolves, because it comes from the base config rather than the response. The residual ~4 ms is a single React render.

`clearCache` gets the same treatment (`deleteScenario` already did it): otherwise the panel keeps showing the last scenario's overrides, flagged as overrides, with no scenario selected any more.

## Not changed, deliberately

A side report that nodes stay **blue** rather than grey after "Clear Cache" is **correct behaviour**. The blue `calc_status='computed'` tint is driven by `useSimulationStore(s => s.results)` — the *base run's* result. That button clears scenario results only (per its own tooltip), and the base result stays loaded, so the tint is accurate. Discarding it would throw away a result the user never asked to clear. Recorded in a comment rather than "fixed".

## Test plan
- [x] New store test `clears the previous preview before awaiting the new one` — **verified to fail without the fix** (`expected [ { id: 'outlet', …(2) } ] to be null`)
- [x] Verified in a browser against a real model, before and after, with a `MutationObserver` trace of the actual DOM transitions (timings above)
- [x] `npx tsc -b` clean; `npx vitest run` **220 passed** (29 files)
- [x] `npm run build` clean; confirmed the served bundle actually changed before trusting the browser result — the first reload served a cached `index.html` and would have tested stale code

🤖 Generated with [Claude Code](https://claude.com/claude-code)