### PR TITLE
fix: guard scenarioStore.refresh() against out-of-order responses

### DIFF
--- a/frontend/src/stores/scenarioStore.test.ts
+++ b/frontend/src/stores/scenarioStore.test.ts
@@ -58,6 +58,7 @@ describe("scenarioStore", () => {
       previewLoading: false,
       previewError: null,
       previewSeq: 0,
+      refreshSeq: 0,
     });
   });
 
@@ -351,5 +352,48 @@ describe("scenarioStore", () => {
     expect(useScenarioStore.getState().previewNodes).toEqual([
       { id: "outlet", type: "OutletSink", properties: { pressure: 300000 } },
     ]);
+  });
+
+  it("an older in-flight refresh() cannot clobber a newer one's result", async () => {
+    // sweepStore calls refresh() from two overlapping places during a sweep:
+    // a progressive mid-sweep refresh every time `current` advances, plus a
+    // final one once the whole job reaches "done". Two in-flight requests
+    // racing is the normal case here, not an edge case -- and nothing
+    // guarantees network order matches call order. If the *older* call's
+    // response happens to resolve *after* the newer one's, it must be
+    // dropped, or the last-finished scenario in a sweep can sit at
+    // "Not computed yet" even though the store already fetched its result.
+    let resolveFirst: (v: unknown) => void = () => {};
+    const firstPromise = new Promise((resolve) => {
+      resolveFirst = resolve;
+    });
+    mockListScenarios.mockImplementationOnce(() => firstPromise); // older call
+    mockListScenarios.mockImplementationOnce(() =>
+      Promise.resolve({
+        // newer call: 2 scenarios, one of them freshly finished
+        available: true,
+        scenarios: [
+          { id: "A", t0_K: 300, label: "A" },
+          { id: "B", t0_K: 310, label: "B" },
+        ],
+        authored_ids: ["BASELINE", "A", "B"],
+        authored_overlays: {},
+      }),
+    );
+
+    const older = useScenarioStore.getState().refresh(); // mid-sweep progressive refresh
+    const newer = useScenarioStore.getState().refresh(); // sweep-done refresh, started later
+    // The older call's response lands last -- e.g. it was issued while the
+    // server was busy solving the final scenario and got queued behind it.
+    resolveFirst({
+      available: true,
+      scenarios: [{ id: "A", t0_K: 300, label: "A" }], // stale: missing "B"
+      authored_ids: ["BASELINE", "A"],
+      authored_overlays: {},
+    });
+    await Promise.all([older, newer]);
+
+    // The newer call's complete list must win, regardless of resolution order.
+    expect(useScenarioStore.getState().scenarios.map((s) => s.id)).toEqual(["A", "B"]);
   });
 });

--- a/frontend/src/stores/scenarioStore.ts
+++ b/frontend/src/stores/scenarioStore.ts
@@ -60,6 +60,18 @@ interface ScenarioState {
   previewError: string | null;
   /** Internal: guards against a stale response landing after a newer selection. */
   previewSeq: number;
+  /**
+   * Internal: guards against a stale `refresh()` response landing after a
+   * newer one. Needed because `refresh()` is called from several overlapping
+   * places during a sweep — the mid-sweep progressive refresh fires on every
+   * `current` advance, on top of the final one when the whole sweep finishes
+   * — so two in-flight requests racing is the normal case here, not an edge
+   * case. Without this, an older request that happens to resolve later wins
+   * and overwrites the newer (more complete) list, which is exactly how the
+   * last-finished scenario in a sweep could sit at "Not computed yet" even
+   * though the store already had its result.
+   */
+  refreshSeq: number;
 
   /** Fetch the scenario list for the active store (no-op-safe if none). */
   refresh: () => Promise<void>;
@@ -111,10 +123,14 @@ export const useScenarioStore = create<ScenarioState>((set, get) => ({
   previewLoading: false,
   previewError: null,
   previewSeq: 0,
+  refreshSeq: 0,
 
   refresh: async () => {
+    const seq = get().refreshSeq + 1;
+    set({ refreshSeq: seq });
     try {
       const resp = await listScenarios();
+      if (get().refreshSeq !== seq) return; // superseded by a newer refresh()
       set((s) => {
         // The server's `authored_overlays` is its startup snapshot -- only
         // the seed for this store's own state, never applied again after
@@ -132,6 +148,7 @@ export const useScenarioStore = create<ScenarioState>((set, get) => ({
         };
       });
     } catch {
+      if (get().refreshSeq !== seq) return;
       // No store / API not ready: the pane simply stays hidden.
       set((s) => ({
         available: false,


### PR DESCRIPTION
## The bug

Reported: after a sweep finished, one scenario (the last one to solve) sat at "Not computed yet" for about a minute, then corrected itself with no user action.

`refresh()` is called from several **overlapping** places during a sweep — `sweepStore` fires a progressive mid-sweep refresh every time `current` advances, on top of the final one when the whole job reaches `"done"`. Two in-flight requests racing is the normal case here, not an edge case.

`refresh()` had no protection against that: whichever response landed last simply won, with no check for whether a newer request had since started. An older request that happened to resolve *after* the final one would silently overwrite the complete list with the stale one it saw when it was issued — and the last-finished scenario is precisely the one most likely to be missing from that stale snapshot, which matches the report exactly.

Same shape of race as #141's `loadPreview` bug, different call site — `loadPreview` already guards against it (`previewSeq`); `refresh()` needed the same `refreshSeq` treatment.

## The fix

```ts
refresh: async () => {
  const seq = get().refreshSeq + 1;
  set({ refreshSeq: seq });
  try {
    const resp = await listScenarios();
    if (get().refreshSeq !== seq) return; // superseded by a newer refresh()
    ...
```

## Verification

**Unit test** — an older call's response, resolved *after* a newer call's, must not overwrite it. Confirmed to fail without the guard (`expected ['A'] to deeply equal ['A', 'B']`) and pass with it.

**Live in the browser**, against a real sweep on a scratch multi-scenario config (not committed — no fixture data in the repo): patched `fetch` to stall the *first* `/api/scenarios` GET by 6 seconds, then ran a real 3-scenario sweep.

- At **t=4s** (before the stalled response had even landed): all 3 scenarios already showed "just now" — the fast, later refresh had already won.
- At **t=8s** (after the stalled response landed): unchanged — the stale response was correctly dropped.

## Test plan
- [x] New test `an older in-flight refresh() cannot clobber a newer one's result` — verified to fail without the fix
- [x] `npx tsc -b` clean; `npx vitest run` **221 passed** (29 files)
- [x] Live browser verification against a real sweep, as above

🤖 Generated with [Claude Code](https://claude.com/claude-code)