### PR TITLE
Sweep axis picker: show every node's inputs/outputs with unit+provenance

### DIFF
--- a/boulder/api/routes/scenarios.py
+++ b/boulder/api/routes/scenarios.py
@@ -130,12 +130,19 @@ async def list_scenarios(request: Request) -> Dict[str, Any]:
             "authored_overlays": authored_overlays,
         }
     root = _root_attrs(store)
+    units_raw = root.get("units")
     return {
         "available": True,
         "store": store.name,
         "mechanism": root.get("mechanism_name"),
         "reactor_mode": root.get("reactor_mode"),
         "created_at": root.get("created_at"),
+        # Display units for host-supplied KPI attrs (e.g. scenario_attrs
+        # returning ``(value, "%")``) -- see boulder.sweep_runner.run's
+        # scenario_attrs docstring. Auto-walked node/connection inputs
+        # (``in.<id>.<prop>`` keys) resolve their unit on the frontend
+        # instead, via the same property-name lookup the Properties panel uses.
+        "units": json.loads(units_raw) if units_raw else None,
         "scenarios": _scenario_entries(store),
         "authored_ids": authored_ids,
         "authored_overlays": authored_overlays,

--- a/boulder/api/routes/sweep.py
+++ b/boulder/api/routes/sweep.py
@@ -22,6 +22,7 @@ Endpoints (prefix ``/api/sweep``):
 
 from __future__ import annotations
 
+import json
 import threading
 import time
 from pathlib import Path
@@ -34,6 +35,7 @@ from pydantic import BaseModel, Field
 from ...cantera_converter import DualCanteraConverter, get_plugins
 from ...payload_store import write_payload
 from ...runset import (
+    node_property_attrs,
     resolve_store_path,
     run_set_size,
     sweep_point_of,
@@ -269,6 +271,7 @@ async def sweep_run(
             run_ids = {sid for sid, _ in runs}
             mechanism = _mechanism_of(raw)
             n_cached = 0
+            store_units: Dict[str, str] = {}
             # The active converter class -- e.g. a host's own subclass with
             # its own mechanism search convention -- lives on `app.state`
             # (set once by the CLI at startup; see `boulder/api/main.py`),
@@ -368,6 +371,11 @@ async def sweep_run(
                             f"'{sid}': {exc}",
                             flush=True,
                         )
+                # Every node/connection's own numeric properties -- generic,
+                # host-agnostic "input" axis candidates for the Sweep Results
+                # plot, keyed ``in.<id>.<prop>`` (see node_property_attrs
+                # docstring). Added on top of whatever extra_attrs already has.
+                extra_attrs.update(node_property_attrs(config))
                 with h5py.File(str(store), "a") as handle:
                     attrs = handle[sid].attrs
                     attrs["label"] = label
@@ -375,6 +383,13 @@ async def sweep_run(
                     attrs["fingerprint"] = fingerprint
                     attrs["computed_at"] = float(time.time())
                     for key, value in extra_attrs.items():
+                        # A host may pair a KPI value with its display unit as
+                        # (value, unit); the unit rides in a store-level attr
+                        # (written once after the loop) since HDF5 per-group
+                        # attrs are flat scalars.
+                        if isinstance(value, tuple):
+                            value, unit = value
+                            store_units[key] = unit
                         attrs[key] = value
 
                 # Let the host persist per-scenario artifacts keyed by this
@@ -422,6 +437,8 @@ async def sweep_run(
                     Path(mechanism).name if mechanism else ""
                 )
                 handle.attrs["created_at"] = float(time.time())
+                if store_units:
+                    handle.attrs["units"] = json.dumps(store_units)
 
             state["scenario_progress"] = {}
             state["last_line"] = None

--- a/boulder/cantera_converter.py
+++ b/boulder/cantera_converter.py
@@ -102,7 +102,13 @@ class BoulderPlugins:
     #: become selectable plot axes; the plot stays hidden until at least two
     #: exist. Conventional names it renders nicely: ``t0_K`` (default X axis),
     #: ``final_temperature_K``, ``final_X_<species>`` (grouped as Mole
-    #: Fractions), ``final_Y_<species>`` (Mass Fractions).
+    #: Fractions), ``final_Y_<species>`` (Mass Fractions). A value may also be
+    #: a ``(value, unit)`` tuple to label the KPI's display unit in the plot's
+    #: axis picker; units are collected into a store-level ``units`` JSON attr
+    #: (flat scalar values only go into each scenario's own HDF5 attrs).
+    #: Every node/connection's own numeric properties are recorded separately
+    #: and automatically, with no host hook needed — see
+    #: :func:`boulder.runset.node_property_attrs`.
     #:
     #: Same contract as :func:`boulder.sweep_runner.run`'s ``scenario_attrs``
     #: argument, which defaults to this when not passed explicitly, so the GUI

--- a/boulder/runset.py
+++ b/boulder/runset.py
@@ -529,6 +529,56 @@ def sweep_point_of(config: dict) -> Dict[str, Any]:
     return dict(point) if isinstance(point, dict) else {}
 
 
+#: Keys on a node/connection dict that are never a scalar property to record.
+_ELEMENT_META_KEYS = {"id", "description", "source", "target"}
+
+
+def _numeric_props(props: dict) -> Dict[str, Any]:
+    return {
+        k: v
+        for k, v in props.items()
+        if k not in _ELEMENT_META_KEYS
+        and not isinstance(v, bool)
+        and isinstance(v, (int, float))
+    }
+
+
+def node_property_attrs(config: dict) -> Dict[str, Any]:
+    """Flatten every numeric top-level property of every node/connection.
+
+    Walks the normalized STONE ``nodes:``/``connections:`` lists, emitting
+    ``f"in.{id}.{prop}": val`` for every numeric, non-bool leaf. Host-agnostic
+    and kind-agnostic — no schema/variable-map registration required — so the
+    Sweep Results plot's axis picker can offer every node's declared inputs
+    without a host having to enumerate them one at a time via
+    :attr:`~boulder.cantera_converter.BoulderPlugins.scenario_attrs`.
+
+    Handles both element shapes a STONE config may use: the type-keyed style
+    (``{id, TypeName: {prop: val, ...}}``) and the legacy explicit
+    ``properties:`` sub-dict style. Nested dicts/lists (e.g. per-layer
+    insulation properties) are skipped: there's no natural single scalar to
+    record for them.
+    """
+    attrs: Dict[str, Any] = {}
+    for key in ("nodes", "connections"):
+        for element in config.get(key) or []:
+            if not isinstance(element, dict):
+                continue
+            eid = element.get("id")
+            if not eid:
+                continue
+            if "properties" in element and isinstance(element["properties"], dict):
+                for prop, value in _numeric_props(element["properties"]).items():
+                    attrs[f"in.{eid}.{prop}"] = value
+                continue
+            for type_key, props in element.items():
+                if type_key in _ELEMENT_META_KEYS or not isinstance(props, dict):
+                    continue
+                for prop, value in _numeric_props(props).items():
+                    attrs[f"in.{eid}.{prop}"] = value
+    return attrs
+
+
 def _resolve_sweep_path(
     axis_name: str,
     axis_path: str,

--- a/boulder/sweep_runner.py
+++ b/boulder/sweep_runner.py
@@ -35,6 +35,7 @@ from __future__ import annotations
 
 import argparse
 import copy
+import json
 import os
 import time
 from pathlib import Path
@@ -48,6 +49,7 @@ from .payload_store import write_payload
 from .runset import (
     expand_scenarios,
     load_yaml_with_inheritance,
+    node_property_attrs,
     resolve_store_path,
     sweep_point_of,
 )
@@ -325,7 +327,11 @@ def run(
         ``(scenario_id, merged_config, gui_payload) -> dict`` of extra scalar
         attributes written onto the scenario's HDF5 group after each solve —
         the per-run KPIs the Sweep Results plot reads (``t0_K``,
-        ``final_X_<species>``, …).
+        ``final_X_<species>``, …). A value may be a bare number, or a
+        ``(value, unit)`` tuple to also label the KPI's display unit; units
+        are collected into a store-level ``units`` JSON attr (see
+        :func:`~boulder.runset.node_property_attrs` for the input-side
+        counterpart, recorded automatically without a host hook).
     on_solved : callable, optional
         ``(scenario_id, config, converter, simulation_result, fingerprint,
         gui_payload, mechanism) -> None`` called once per *freshly solved*
@@ -373,6 +379,7 @@ def run(
     run_ids = {sid for sid, _ in runs}
     mechanism = _mechanism_of(raw)
     n_cached = 0
+    store_units: Dict[str, str] = {}
     for i, (sid, cfg) in enumerate(runs):
         config, mech_name, fingerprint = prepare_scenario(cfg, resolve_mechanism)
         label = str((cfg.get("metadata") or {}).get("scenario_name") or sid)
@@ -402,8 +409,19 @@ def run(
             for key, value in sweep_point_of(cfg).items():
                 if isinstance(value, (int, float)) and not isinstance(value, bool):
                     attrs[key] = value
+            # Every node/connection's own numeric properties -- generic,
+            # host-agnostic "input" axis candidates for the Sweep Results plot,
+            # keyed ``in.<id>.<prop>`` (see node_property_attrs docstring).
+            for key, value in node_property_attrs(config).items():
+                attrs[key] = value
             if scenario_attrs is not None:
                 for key, value in (scenario_attrs(sid, cfg, gui) or {}).items():
+                    # A host may pair a KPI value with its display unit as
+                    # (value, unit); the unit rides in a store-level attr
+                    # (below) since HDF5 attrs are flat scalars.
+                    if isinstance(value, tuple):
+                        value, unit = value
+                        store_units[key] = unit
                     attrs[key] = value
         if on_solved is not None:
             # Give the host a chance to persist per-scenario artifacts (e.g. a
@@ -438,6 +456,8 @@ def run(
         handle.attrs["mechanism"] = _resolve(mechanism)
         handle.attrs["mechanism_name"] = Path(mechanism).name if mechanism else ""
         handle.attrs["created_at"] = float(time.time())
+        if store_units:
+            handle.attrs["units"] = json.dumps(store_units)
     print(
         f"Wrote {store} ({total} scenarios; {n_cached} cached, "
         f"{total - n_cached} solved)",

--- a/frontend/src/api/scenarios.ts
+++ b/frontend/src/api/scenarios.ts
@@ -34,6 +34,14 @@ export interface ScenarioListResponse {
   reactor_mode?: string | null;
   /** Unix seconds when the store (sweep) was written (fallback for all rows). */
   created_at?: number | null;
+  /**
+   * Display unit per host-supplied KPI attr key (e.g. `{ efficiency: "%" }`),
+   * for `scenario_attrs` values returned as `(value, unit)` — see
+   * `boulder.sweep_runner.run`'s docstring. Auto-walked node/connection input
+   * attrs (`in.<id>.<prop>` keys) aren't in here; their unit is resolved on
+   * the frontend from the property name (see `SweepResultsPlot.tsx`).
+   */
+  units?: Record<string, string> | null;
   scenarios: ScenarioMeta[];
   /**
    * Every scenario id in the config's `scenario:` mapping, regardless of

--- a/frontend/src/components/panels/ScenarioPane.tsx
+++ b/frontend/src/components/panels/ScenarioPane.tsx
@@ -52,6 +52,7 @@ export function ScenarioPane() {
     scenarios,
     authoredIds,
     createdAt,
+    units,
     activeId,
     loading,
     error,
@@ -336,7 +337,7 @@ export function ScenarioPane() {
           })}
         </ul>
       </div>
-      <SweepResultsPlot scenarios={scenarios} />
+      <SweepResultsPlot scenarios={scenarios} units={units} />
       <AddScenarioModal
         open={addModalOpen}
         onClose={() => setAddModalOpen(false)}

--- a/frontend/src/components/panels/SweepResultsPlot.test.tsx
+++ b/frontend/src/components/panels/SweepResultsPlot.test.tsx
@@ -154,4 +154,48 @@ describe("SweepResultsPlot", () => {
     expect(screen.getByTestId("y-axis-add-select")).toBeInTheDocument();
     expect(plotCalls.at(-1)?.data).toEqual([]);
   });
+
+  describe("input/output labeling", () => {
+    function makeKpiScenario(
+      t0_K: number,
+      extra: Record<string, number>,
+    ): ScenarioMeta {
+      return { id: `s-${t0_K}`, t0_K, label: `${t0_K} K`, ...extra };
+    }
+
+    const kpiScenarios: ScenarioMeta[] = [
+      makeKpiScenario(800, { efficiency: 75.0, "in.downstream.pressure": 1.05e5 }),
+      makeKpiScenario(900, { efficiency: 77.5, "in.downstream.pressure": 1.3e5 }),
+    ];
+
+    it("labels an auto-walked node.property key as input with its unit", () => {
+      render(<SweepResultsPlot scenarios={kpiScenarios} />);
+
+      const select = screen.getByTestId("y-axis-add-select") as HTMLSelectElement;
+      const optionValues = Array.from(select.options).map((o) => o.value);
+      // efficiency is active by default (first available series); pressure
+      // is still offered in the "add series" dropdown.
+      expect(optionValues).toContain("k:in.downstream.pressure");
+      const pressureOption = Array.from(select.options).find(
+        (o) => o.value === "k:in.downstream.pressure",
+      );
+      expect(pressureOption?.textContent).toBe("downstream.pressure (Pa, input)");
+    });
+
+    it("labels a host KPI attr as output, with its unit when supplied", () => {
+      render(<SweepResultsPlot scenarios={kpiScenarios} units={{ efficiency: "%" }} />);
+
+      expect(
+        screen.getByTestId("active-series-chip-efficiency"),
+      ).toHaveTextContent("Efficiency (%, output)");
+    });
+
+    it("omits an empty unit parenthetical when no unit is known", () => {
+      render(<SweepResultsPlot scenarios={kpiScenarios} />);
+
+      expect(
+        screen.getByTestId("active-series-chip-efficiency"),
+      ).toHaveTextContent("Efficiency (output)");
+    });
+  });
 });

--- a/frontend/src/components/panels/SweepResultsPlot.tsx
+++ b/frontend/src/components/panels/SweepResultsPlot.tsx
@@ -2,11 +2,14 @@ import { useMemo, useState } from "react";
 import Plot from "react-plotly.js";
 import { useThemeStore } from "@/stores/themeStore";
 import type { ScenarioMeta } from "@/api/scenarios";
+import { propertyDisplayUnit } from "@/lib/units";
 
 // TODO: overlay experimental/reference data points on this chart (planned future enhancement).
 
 interface Props {
   scenarios: ScenarioMeta[];
+  /** Display unit per host-supplied KPI attr key -- see `ScenarioListResponse.units`. */
+  units?: Record<string, string>;
 }
 
 interface YGroup {
@@ -45,6 +48,42 @@ function friendlyLabel(key: string): string {
     .replace(/\b\w/g, (c) => c.toUpperCase());
 }
 
+/** Auto-walked node/connection input attrs are always keyed `in.<node_id>.<property>`
+ * (see `boulder.runset.node_property_attrs`) -- split back into its parts. */
+function inputKeyParts(key: string): { nodeId: string; property: string } | null {
+  if (!key.startsWith("in.")) return null;
+  const rest = key.slice(3);
+  const dot = rest.indexOf(".");
+  if (dot === -1) return null;
+  return { nodeId: rest.slice(0, dot), property: rest.slice(dot + 1) };
+}
+
+/** Human label, unit, and input/output provenance for an axis-candidate key.
+ * Input attrs (`in.<node>.<property>`) are auto-walked by Boulder with no host
+ * hook needed; everything else came from a host's `scenario_attrs`/the
+ * declarative sweep axis -- both conventionally "output" (a KPI or the swept
+ * value itself). */
+function describeKey(
+  key: string,
+  units: Record<string, string> | undefined,
+): { label: string; unit?: string; kind: "input" | "output" } {
+  const input = inputKeyParts(key);
+  if (input) {
+    return {
+      label: `${input.nodeId}.${input.property}`,
+      unit: propertyDisplayUnit(input.property),
+      kind: "input",
+    };
+  }
+  return { label: friendlyLabel(key), unit: units?.[key], kind: "output" };
+}
+
+/** `describeKey` rendered as one string, e.g. "downstream.pressure (Pa, input)". */
+function displayLabel(key: string, units: Record<string, string> | undefined): string {
+  const { label, unit, kind } = describeKey(key, units);
+  return unit ? `${label} (${unit}, ${kind})` : `${label} (${kind})`;
+}
+
 /** Numeric attr keys present on at least one scenario, excluding bookkeeping fields. */
 function numericKeys(scenarios: ScenarioMeta[]): string[] {
   const keys = new Set<string>();
@@ -59,7 +98,11 @@ function numericKeys(scenarios: ScenarioMeta[]): string[] {
 /** Group numeric keys (minus the chosen X key) into Y-axis choices: species sharing
  * a "final_X_"/"final_Y_" prefix are grouped as one Mole/Mass Fractions choice with
  * one trace per species; everything else is its own single-trace choice. */
-function buildYGroups(keys: string[], xKey: string): YGroup[] {
+function buildYGroups(
+  keys: string[],
+  xKey: string,
+  units: Record<string, string> | undefined,
+): YGroup[] {
   const moleSpecies: { key: string; traceName: string }[] = [];
   const massSpecies: { key: string; traceName: string }[] = [];
   const singles: YGroup[] = [];
@@ -73,7 +116,8 @@ function buildYGroups(keys: string[], xKey: string): YGroup[] {
     } else if (mass) {
       massSpecies.push({ key, traceName: mass[1] });
     } else {
-      singles.push({ id: key, label: friendlyLabel(key), keys: [{ key, traceName: friendlyLabel(key) }] });
+      const label = displayLabel(key, units);
+      singles.push({ id: key, label, keys: [{ key, traceName: label }] });
     }
   }
 
@@ -129,7 +173,7 @@ function buildSeriesOptions(groups: YGroup[]): {
  * Renders nothing when the store has fewer than two numeric attrs to plot
  * against each other (e.g. a plain multi-case store with no sweep KPIs).
  */
-export function SweepResultsPlot({ scenarios }: Props) {
+export function SweepResultsPlot({ scenarios, units }: Props) {
   const theme = useThemeStore((s) => s.theme);
 
   const keys = useMemo(() => numericKeys(scenarios), [scenarios]);
@@ -141,8 +185,8 @@ export function SweepResultsPlot({ scenarios }: Props) {
 
   const effectiveXKey = xKey && keys.includes(xKey) ? xKey : (keys.includes("t0_K") ? "t0_K" : keys[0]);
   const yGroups = useMemo(
-    () => (effectiveXKey ? buildYGroups(keys, effectiveXKey) : []),
-    [keys, effectiveXKey],
+    () => (effectiveXKey ? buildYGroups(keys, effectiveXKey, units) : []),
+    [keys, effectiveXKey, units],
   );
   const { options, families, labelByKey, groupLabelByKey } = useMemo(
     () => buildSeriesOptions(yGroups),
@@ -218,7 +262,7 @@ export function SweepResultsPlot({ scenarios }: Props) {
           >
             {keys.map((k) => (
               <option key={k} value={k}>
-                {friendlyLabel(k)}
+                {displayLabel(k, units)}
               </option>
             ))}
           </select>
@@ -303,7 +347,7 @@ export function SweepResultsPlot({ scenarios }: Props) {
           showlegend: true,
           legend: { x: 1, xanchor: "right" as const, y: 1 },
           xaxis: {
-            title: { text: friendlyLabel(effectiveXKey) },
+            title: { text: displayLabel(effectiveXKey, units) },
             gridcolor: theme === "dark" ? "#333" : "#e0e0e0",
           },
           yaxis: {

--- a/frontend/src/lib/units.ts
+++ b/frontend/src/lib/units.ts
@@ -89,6 +89,11 @@ export function labelWithUnit(label: string, unit?: string): string {
   return u ? `${label} [${u}]` : label;
 }
 
+/** Look up a property's canonical display unit by name, e.g. "pressure" -> "Pa". */
+export function propertyDisplayUnit(name: string): string | undefined {
+  return PROPERTY_DISPLAY_UNIT[name];
+}
+
 /**
  * Convert Pascal to bar.
  */

--- a/frontend/src/stores/scenarioStore.ts
+++ b/frontend/src/stores/scenarioStore.ts
@@ -37,6 +37,8 @@ interface ScenarioState {
   overlaysSeeded: boolean;
   /** Unix seconds the store was written; drives the "computed X ago" label. */
   createdAt?: number;
+  /** Display unit per host-supplied KPI attr key -- see `ScenarioListResponse.units`. */
+  units?: Record<string, string>;
   activeId: string | null;
   loading: boolean;
   error: string | null;
@@ -144,6 +146,7 @@ export const useScenarioStore = create<ScenarioState>((set, get) => ({
           overlaysSeeded: true,
           authoredIds: idsFromOverlays(overlays),
           createdAt: resp.created_at ?? undefined,
+          units: resp.units ?? undefined,
           revision: s.revision + 1,
         };
       });

--- a/tests/test_runset.py
+++ b/tests/test_runset.py
@@ -14,6 +14,7 @@ from boulder.runset import (
     deep_merge,
     expand_scenarios,
     load_yaml_with_inheritance,
+    node_property_attrs,
     run_set_size,
     sweep_axis_values,
 )
@@ -329,3 +330,57 @@ def test_load_yaml_with_inheritance_sweeps_inherited_scenario_not(tmp_path: Path
     assert cfg["metadata"]["scenario_id"] == "CHILD"
     assert "scenarios" not in cfg
     assert cfg["sweep"]["T"]["values"] == [1, 2]
+
+
+# ---------------------------------------------------------------------------
+# node_property_attrs
+# ---------------------------------------------------------------------------
+
+
+def test_node_property_attrs_type_keyed_style():
+    cfg = {
+        "nodes": [
+            {"id": "tank", "Reservoir": {"temperature": 300.0, "pressure": 1e5}},
+        ],
+        "connections": [
+            {
+                "id": "feed",
+                "source": "tank",
+                "target": "reactor",
+                "MassFlowController": {"mass_flow_rate": 0.01},
+            },
+        ],
+    }
+    assert node_property_attrs(cfg) == {
+        "in.tank.temperature": 300.0,
+        "in.tank.pressure": 1e5,
+        "in.feed.mass_flow_rate": 0.01,
+    }
+
+
+def test_node_property_attrs_legacy_properties_style():
+    cfg = {"nodes": [{"id": "tank", "properties": {"temperature": 300.0}}]}
+    assert node_property_attrs(cfg) == {"in.tank.temperature": 300.0}
+
+
+def test_node_property_attrs_skips_meta_keys_bools_and_nested_dicts():
+    cfg = {
+        "nodes": [
+            {
+                "id": "pfr",
+                "description": "a reactor",
+                "RefractoryReactor": {
+                    "length": 10.0,
+                    "energy": True,
+                    "insulation": {"e_insul": {"1": 0.1}},
+                },
+            },
+            {"description": "no id at all -- skipped"},
+        ]
+    }
+    assert node_property_attrs(cfg) == {"in.pfr.length": 10.0}
+
+
+def test_node_property_attrs_no_nodes_or_connections():
+    assert node_property_attrs({}) == {}
+    assert node_property_attrs({"nodes": [], "connections": []}) == {}

--- a/tests/test_sweep_scenario_hooks.py
+++ b/tests/test_sweep_scenario_hooks.py
@@ -17,6 +17,7 @@ Both now live on `BoulderPlugins` and fire on the in-process path too.
 
 from __future__ import annotations
 
+import json
 import time
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Tuple
@@ -174,6 +175,61 @@ def test_on_scenario_solved_hook_fires_per_scenario(tmp_path: Path) -> None:
                 assert handle[sid].attrs["fingerprint"] == fp
     finally:
         plugins.on_scenario_solved = None
+        client.__exit__(None, None, None)
+
+
+def test_node_property_attrs_are_recorded_with_no_host_hook(tmp_path: Path) -> None:
+    """Every node's numeric properties land as `in.<id>.<prop>` with no host code."""
+    client, app = _client_with_config(tmp_path)
+    try:
+        _run_sweep(client, app)
+
+        store = Path(app.state.scenario_store_path)
+        with h5py.File(str(store), "r") as handle:
+            for sid in ("BASELINE", "a"):
+                attrs = handle[sid].attrs
+                assert attrs["in.feed.temperature"] == pytest.approx(298.15)
+                assert attrs["in.feed.pressure"] == pytest.approx(101325)
+    finally:
+        client.__exit__(None, None, None)
+
+
+def test_scenario_attrs_tuple_value_carries_a_unit(tmp_path: Path) -> None:
+    """A `(value, unit)` return records the number as usual plus a store-level unit."""
+    client, app = _client_with_config(tmp_path)
+    plugins = get_plugins()
+
+    def _attrs(sid: str, cfg: Dict[str, Any], gui: Dict[str, Any]) -> Dict[str, Any]:
+        return {"efficiency": (75.0, "%"), "t0_K": 1200.0}
+
+    plugins.scenario_attrs = _attrs
+    try:
+        _run_sweep(client, app)
+
+        store = Path(app.state.scenario_store_path)
+        with h5py.File(str(store), "r") as handle:
+            for sid in ("BASELINE", "a"):
+                attrs = handle[sid].attrs
+                # The tuple's numeric part, not the tuple itself, is the stored attr.
+                assert attrs["efficiency"] == pytest.approx(75.0)
+                assert attrs["t0_K"] == pytest.approx(1200.0)
+            units = json.loads(handle.attrs["units"])
+            assert units == {"efficiency": "%"}
+            # A bare-float attr in the same dict must not appear in `units`.
+            assert "t0_K" not in units
+    finally:
+        plugins.scenario_attrs = None
+        client.__exit__(None, None, None)
+
+
+def test_no_units_attr_written_when_no_hook_supplies_a_unit(tmp_path: Path) -> None:
+    client, app = _client_with_config(tmp_path)
+    try:
+        _run_sweep(client, app)
+        store = Path(app.state.scenario_store_path)
+        with h5py.File(str(store), "r") as handle:
+            assert "units" not in handle.attrs
+    finally:
         client.__exit__(None, None, None)
 
 


### PR DESCRIPTION
## Summary
- `boulder.runset.node_property_attrs` walks every node/connection's numeric properties (host-agnostic, no schema registration needed) and records them as scenario attrs keyed `in.<id>.<prop>`, alongside whatever a host's `scenario_attrs` hook already supplies.
- `scenario_attrs` may now pair a value with a display unit as `(value, unit)`; units are collected into a store-level `units` JSON attr on the sweep's HDF5 store.
- The Sweep Results plot's axis picker labels every option `node.property (unit, input)` for auto-walked properties, or `label (unit, output)` for host-supplied KPIs — reusing the frontend's existing `PROPERTY_DISPLAY_UNIT` map for input units instead of a second registry.
- Both the in-process GUI sweep route and the CLI `boulder.sweep_runner.run()` get the same treatment, so the picker's behavior is identical either way.

## Test plan
- [x] `pytest tests/` — 823 passed, 1 skipped, 7 xfailed (full suite, no regressions)
- [x] `npx tsc -b && npx vitest run` — 224 passed (full frontend suite)
- [x] `make qa` clean (pre-commit on all files)
- [x] Live browser verification against a real multi-node, multi-stage sweep: axis picker offered ~24 auto-walked input properties plus a host KPI, correctly labeled with unit + provenance (e.g. `downstream.pressure (Pa, input)`), plot rendered correctly for both axes