### PR TITLE
Fix BASELINE cache-busting on every Run Sweep; add scenario-cache-lifecycle test skill

### DIFF
--- a/.cursor/skills/boulder-scenario-cache-lifecycle/SKILL.md
+++ b/.cursor/skills/boulder-scenario-cache-lifecycle/SKILL.md
@@ -1,0 +1,135 @@
+______________________________________________________________________
+
+## name: boulder-scenario-cache-lifecycle description: >- GUI test procedure for Boulder's scenario cache lifecycle: Clear Cache, Run Sweep, Run Simulation, and how the Scenario Pane's "Not computed yet" state and the network graph's node tint (grey/blue) each track (or don't track) those actions. Use when the user asks to verify scenario caching end-to-end, check Run Sweep vs. Run Simulation consistency, or the Clear Cache button's effect on the Scenario Pane and graph tint.
+
+# Boulder scenario cache lifecycle (GUI test procedure)
+
+Step-by-step procedure for verifying Boulder's scenario/sweep cache behaves
+correctly through the GUI. Written against a config with a `scenarios:`
+block, no host plugin required — pure Boulder built-in reactor kinds only.
+
+## Example config
+
+`configs/cstr_residence_time_scenarios.yaml` — the same CSTR as
+`configs/default.yaml`, plus a `scenarios:` block with two named overlays
+(`short_residence_time`, `long_residence_time`) that retune the inlet
+`mass_flow_rate`. Solves in well under a second per scenario. If testing a
+different config, it just needs a `scenarios:` mapping with 2+ entries.
+
+## Procedure
+
+```bash
+conda activate boulder
+cd frontend && npm run build && cd ..
+boulder configs/cstr_residence_time_scenarios.yaml --no-open
+```
+
+1. **Open the config.** Confirm the header shows
+   `cstr_residence_time_scenarios.yaml` (not `untitled.yaml`) and the
+   Scenario Pane lists `BASELINE` + the two named scenarios, each
+   "Not computed yet".
+
+1. **Clear Cache, defensively.** The "Clear cache" button only appears
+   once a sweep has produced a collection store — on a genuinely fresh
+   config (no prior `*_scenarios.h5`), it's simply **absent**; that's
+   correct, not a bug. Skip straight to step 3. If it *is* present (a
+   store already exists from an earlier session), click it and confirm
+   every row still reads "Not computed yet" afterward.
+
+1. **Run Sweep.** Use the dropdown next to "Run Simulation" → "Run Sweep"
+   → click the (now relabeled) primary button. Once it completes:
+
+   - Every Scenario Pane row shows a timestamp ("just now"), not
+     "Not computed yet".
+   - The network graph's nodes turn blue (`rgb(59,130,246)` /
+     Tailwind `blue-500`) — check via
+     `window.__boulderCy.nodes().map(n => n.style('background-color'))`
+     if canvas clicks aren't available to the agent.
+
+1. **Run Sweep again, unchanged.** Re-run it with nothing edited. Every
+   scenario — **including BASELINE** — must be skipped as a cache hit:
+   `computed_at`/`fingerprint` (`GET /api/scenarios`) stay byte-identical
+   to step 3, and the server console prints `cached, skipped` for all
+   three. See "BASELINE re-solves every time" below if this fails —
+   it's a real, previously-shipped bug with a one-line fix.
+
+1. **Select BASELINE, then Run Simulation.** Click the BASELINE row, then
+   the (relabeled) "Run Simulation" primary button. **Expect a real
+   (fast) re-solve, not a cache hit** — confirm via network inspection
+   that `POST /api/simulations/check-cache` returns `{"cached": false}`.
+   This is not a bug: Run Sweep's collection store and Run Simulation's
+   single-run result cache (`.boulder-cache/`) are separate stores in
+   plain Boulder. A host can unify them by registering
+   `plugins.on_scenario_solved` (see
+   `boulder.cantera_converter.BoulderPlugins.on_scenario_solved`'s
+   docstring) — without one, expect independent caches. The model solves
+   fast enough that this can *look* like a cache hit; don't rely on
+   wall-clock time as the check, use the network request.
+
+1. **Clear Cache from the Scenario Pane.** Every row reverts to
+   "Not computed yet". **The graph's nodes do *not* turn grey** if a
+   result is still loaded/displayed (e.g. right after step 5) — that's
+   deliberate (see `scenarioStore.ts::clearCache`'s comment: "the *base
+   run's* result deliberately survives... so the graph's 'computed' node
+   tint still correctly reflects the base simulation still loaded").
+   Assert the Scenario Pane rows, not node color, for this step.
+
+1. **Run Simulation for BASELINE again.** **Known limitation, not
+   verified by this step as written:** the Scenario Pane's BASELINE row
+   does **not** update after a plain Run Simulation — it stays
+   "Not computed yet" indefinitely, because Run Simulation never writes
+   into the sweep's collection store (the Scenario Pane's only data
+   source). Only **Run Sweep** updates Scenario Pane rows. If you need
+   BASELINE's row to reflect a fresh solve, use Run Sweep (step 3), not
+   Run Simulation. (Tracked as a follow-up: unifying BASELINE's status
+   across both actions needs a design decision, not a one-line fix.)
+
+## Known issues found while writing this procedure
+
+### BASELINE re-solves every time, even unchanged (fixed)
+
+**Symptom:** step 4 shows `BASELINE` re-solving (a new `computed_at`/
+`fingerprint`) on *every* Run Sweep, while named scenarios correctly
+cache-hit. Only reproduces when the config's own collection store
+(`<stem>_scenarios.h5`, written next to the config) lands **inside a git
+working tree that also contains Boulder's own installed source** — e.g.
+testing from Boulder's own `configs/` directory with an editable
+(`pip install -e .`) install, exactly as this procedure does.
+
+**Root cause:** Boulder's cache fingerprint includes a "source identity"
+that hashes `git status --porcelain` + `git diff HEAD` for wherever the
+`boulder` package is installed from (`result_cache._source_identity`) —
+by design, so a code change busts the cache. The very first scenario ever
+solved for a new config is fingerprinted *before* its own collection
+store file exists on disk; every fingerprint computed afterward (store
+file now present as an untracked change) reflects a different git-dirty
+state. Whichever scenario solves first (always BASELINE) gets a
+fingerprint that can never match again — a permanent, self-inflicted,
+one-time cache-bust baked in by the very act of writing the store.
+
+**Fix:** `*_scenarios.h5` is now in `.gitignore` (this file's own commit)
+— the store never appears in `git status`, so it can never perturb its
+own fingerprint. Reproduce the bug pre-fix by removing that `.gitignore`
+line and re-running steps 3-4 from a clean git checkout.
+
+### Native `confirm()` dialogs block headless/agent clicks
+
+"Clear cache" and scenario deletion both guard on `window.confirm(...)`.
+An agent driving the browser via `javascript_exec`/DOM `.click()` (no real
+dialog to answer) gets a silent no-op — `window.confirm` returns `false`
+by default with nothing to interact with, and the handler's
+`if (!window.confirm(...)) return;` aborts before any network call.
+**Stub it first:** `window.confirm = () => true;` before clicking, in the
+same page context.
+
+## Further reading
+
+- [boulder-gui/SKILL.md](../boulder-gui/SKILL.md) — general GUI driving,
+  canvas node selection, results tabs
+- [boulder-scenario-editing/SKILL.md](../boulder-scenario-editing/SKILL.md)
+  — editing a scenario's parameters via Properties panel / YAML pane
+- `boulder/result_cache.py` — `compute_fingerprint`/`_source_identity`/
+  `_git_dirty_token`
+- `boulder/sweep_runner.py` — `prepare_scenario`, the shared
+  normalize→resolve-mechanism→fingerprint pipeline both the GUI's
+  in-process sweep and the CLI runner use

--- a/.gitignore
+++ b/.gitignore
@@ -557,6 +557,12 @@ alembic/versions/*.pyc
 /configs/.boulder-cache
 # On-disk simulation result cache (sidecar next to any YAML)
 .boulder-cache/
+# Run Sweep's collection store (boulder.runset.resolve_store_path's default
+# "<config-stem>_scenarios.h5" next to any YAML). Regenerable, and untracked
+# here on purpose: a tracked/dirty store file would flip the cache
+# fingerprint's git-dirty token (see result_cache._git_dirty_token) on every
+# write, permanently invalidating the very entry it just wrote.
+*_scenarios.h5
 piston.csv
 configs/cantera_examples/nanosecond_pulse_discharge_stone.yaml
 configs/cantera_examples/combustor_stone.yaml

--- a/configs/README.md
+++ b/configs/README.md
@@ -137,6 +137,7 @@ Numeric values may carry explicit units:
 | `grouped_nodes.yaml` | Grouped reactors in one stage |
 | `staged_psr_pfr.yaml` | Two-stage PSR → PFR chain |
 | `surf_pfr.yaml` | `FlowReactor` + `FlowReactorSurface`: catalytic plug-flow, `solver.axis: distance` |
+| `cstr_residence_time_scenarios.yaml` | Same CSTR as `default.yaml`, plus a `scenarios:` block (short/long residence time) for exercising the Scenario Pane / Run Sweep |
 
 ## Cantera Python examples (in `docs/cantera_examples/`)
 

--- a/configs/cstr_residence_time_scenarios.yaml
+++ b/configs/cstr_residence_time_scenarios.yaml
@@ -1,0 +1,73 @@
+metadata:
+  title: Lean methane/air combustor (CSTR) — residence-time scenarios
+  description: >-
+    Same CSTR as default.yaml/cstr_methane_air.yaml, with a `scenarios:`
+    block demonstrating Boulder's Scenario Pane / Run Sweep: two named
+    overlays retune `mass_flow_rate` on the inlet MFC to a shorter and a
+    longer residence time than the base case, alongside the base
+    (BASELINE) run itself.
+  remarks:
+    phi: 0.5
+    fuel: CH4
+    oxidizer: "air (O2:N2 = 1:3.76)"
+
+phases:
+  gas:
+    mechanism: gri30.yaml
+
+network:
+- id: feed
+  Reservoir:
+    temperature: 300 K
+    pressure: 101325 Pa
+    composition: "CH4:0.5,O2:1.0,N2:3.76"
+
+- id: combustor
+  IdealGasConstPressureMoleReactor:
+    volume: 1.0e-3 m**3
+    initial:
+      temperature: 1475 K
+      pressure: 101325 Pa
+      composition: "CO2:0.04476,H2O:0.08951,N2:0.86573"
+
+- id: exhaust
+  OutletSink: {}
+
+- id: feed_to_combustor
+  MassFlowController:
+    mass_flow_rate: 1.0e-4 kg/s
+  source: feed
+  target: combustor
+
+- id: combustor_to_exhaust
+  PressureController:
+    pressure_coeff: 0.0
+    master: feed_to_combustor
+  source: combustor
+  target: exhaust
+
+settings:
+  end_time: 0.5
+  dt: 5.0e-3
+
+output:
+  combustor:
+  - "temperature, K"
+  - "pressure, Pa"
+
+scenarios:
+  short_residence_time:
+    metadata:
+      description: Higher inlet flow -> shorter residence time, closer to blowout.
+    network:
+    - id: feed_to_combustor
+      MassFlowController:
+        mass_flow_rate: 5.0e-4 kg/s
+
+  long_residence_time:
+    metadata:
+      description: Lower inlet flow -> longer residence time, further from blowout.
+    network:
+    - id: feed_to_combustor
+      MassFlowController:
+        mass_flow_rate: 2.0e-5 kg/s


### PR DESCRIPTION
## Summary

Found while writing a GUI test procedure for the scenario cache lifecycle (Clear Cache → Run Sweep → Run Simulation → Clear Cache → Run Simulation), against a new host-agnostic example config with a `scenarios:` block.

**Bug fixed:** `<config-stem>_scenarios.h5` (Run Sweep's collection store) was untracked but not `.gitignore`'d. When it lands inside the same git working tree as Boulder's own installed source (e.g. testing from `configs/` with an editable install — exactly how this new example config is meant to be used), writing it changes `git status`, which feeds straight into the cache fingerprint's git-dirty token (`result_cache._source_identity`, by design: a code change should bust the cache). The very first scenario ever solved for a new config — always `BASELINE` — gets fingerprinted *before* its own store file exists; every fingerprint computed afterward reflects a different git-dirty state, so `BASELINE` silently re-solves on *every* Run Sweep instead of cache-hitting, while named scenarios correctly cache-hit. Root-caused and reproduced via a `TestClient`-based script that spies on `compute_fingerprint`'s exact inputs across two consecutive sweeps — full narrative in the new skill's "Known issues" section.

**Fix:** add `*_scenarios.h5` to `.gitignore`. Verified the exact repro now cache-hits correctly on the second sweep (`computed_at`/`fingerprint` unchanged, server logs `cached, skipped` for all three scenarios including BASELINE).

**New:** `configs/cstr_residence_time_scenarios.yaml` — the existing `default.yaml` CSTR plus a `scenarios:` block (two named overlays retuning residence time), for exercising the Scenario Pane / Run Sweep without any host plugin.

**New:** `.cursor/skills/boulder-scenario-cache-lifecycle/SKILL.md` — the step-by-step GUI verification procedure, live-tested end to end. Also documents two behaviors that look like bugs on first read but are deliberate (confirmed against existing code comments/design):
- Run Simulation and Run Sweep use separate caches in plain Boulder (no cache hit going from one to the other unless a host registers `plugins.on_scenario_solved`).
- Clear Cache doesn't retint an already-displayed result's graph nodes (only clears the Scenario Pane's own store).

Also flagged as a follow-up (not fixed here, needs a design decision): Run Simulation never updates the Scenario Pane's BASELINE row, since it doesn't write into the collection store at all.

## Test plan
- [x] Reproduced the BASELINE cache-bust bug via a `TestClient` script spying on `compute_fingerprint`'s exact `(config, mechanism)` inputs across two consecutive `/api/sweep/run` calls — identical inputs, different outputs, isolated to the git-dirty token
- [x] Confirmed fixed: re-ran the identical repro after the `.gitignore` change — `cached, skipped` for all three scenarios (including BASELINE) on the second sweep
- [x] `pytest tests/test_runset.py tests/test_sweep_scenario_hooks.py tests/test_sweep_runner_store.py` — 33 passed
- [x] `pre-commit run --files <changed>` clean
- [x] Live browser walkthrough of the full 7-step procedure against the new example config (steps 1-4 confirm the fix; steps 5-7 confirm the two by-design behaviors and the known limitation, all documented in the skill)