### PR TITLE
GUI: Clear Cache greys the graph, the sweep card follows the solver, derived inputs hidden

### DIFF
--- a/.cursor/skills/boulder-scenario-cache-lifecycle/SKILL.md
+++ b/.cursor/skills/boulder-scenario-cache-lifecycle/SKILL.md
@@ -87,12 +87,18 @@ boulder configs/cstr_residence_time_scenarios.yaml --no-open
    `computed_at` is unchanged from step 3. This is the single store doing
    its job — Run Simulation reuses the sweep's solve.
 
-1. **Clear Cache from the Scenario Pane.** Every row reverts to
-   "Not computed yet" and `GET /api/scenarios` reports zero entries.
-   **The graph's nodes do *not* turn grey** if a result is still
-   loaded/displayed — that's deliberate (see `scenarioStore.ts::clearCache`:
-   the base run's result survives, so the tint still reflects the
-   simulation still on screen). Assert the pane rows, not node colour.
+1. **Clear Cache from the Scenario Pane.** In that one click: every row
+   reverts to "Not computed yet", `GET /api/scenarios` reports zero entries,
+   the results area empties, and the graph's nodes go **grey**.
+
+   It is an **icon button with no text** — find it by
+   `button[title^="Clear cache"]`, not by text content.
+
+   Older notes here said the nodes deliberately stay blue, because clearing
+   removed only *scenario* results while the base run survived in a second,
+   separate cache. With one store, `clear-cache` removes the whole directory
+   including the base entry, so a still-tinted graph would be backed by
+   nothing.
 
 1. **Run Simulation again.** The **BASELINE row updates to "just now"**
    within a couple of seconds, and `GET /api/scenarios` shows exactly one
@@ -119,6 +125,13 @@ worker could not know either the base's name *or* a declared
 
 **Fix:** `runset.base_entry_id` is the one place the naming rule lives, and
 `POST /api/simulations` always hands the worker the raw config.
+
+### Clear Cache left the graph blue (fixed)
+
+`clearCache` kept the displayed results on purpose, justified by the base run
+surviving in the *other* cache. Unifying the stores deleted that other cache
+without anyone re-reading the justification, so the graph stayed "computed"
+while nothing was stored. It now clears the results in the same click.
 
 ### The pane did not refresh after a single run (fixed)
 

--- a/boulder/config.py
+++ b/boulder/config.py
@@ -1702,6 +1702,13 @@ def synthesize_default_group(config: Dict[str, Any]) -> None:
             conn["group"] = "default"
 
 
+#: ``metadata`` key holding ``{property_name: source_node_id}`` for properties a
+#: normalisation pass filled in rather than the author declaring them. The GUI
+#: hides these from the node's inputs — see
+#: :func:`propagate_terminal_pressure_defaults`.
+DERIVED_PROPERTIES_KEY = "derived_properties"
+
+
 def propagate_terminal_pressure_defaults(config: Dict[str, Any]) -> None:
     """Propagate a declared process pressure from terminal nodes to their flow-connected peers.
 
@@ -1796,6 +1803,7 @@ def propagate_terminal_pressure_defaults(config: Dict[str, Any]) -> None:
 
         if len(distinct) == 1:
             process_pressure = next(iter(declared.values()))
+            source_id = next(iter(declared))
             for nid in component:
                 node = id_to_node[nid]
                 ntype = node.get("type", "")
@@ -1804,6 +1812,21 @@ def propagate_terminal_pressure_defaults(config: Dict[str, Any]) -> None:
                 props = node.setdefault("properties", {})
                 if props.get("pressure") is None:
                     props["pressure"] = process_pressure
+                    # Record that this value was derived, not authored. The
+                    # solver needs it materialised, but the GUI must not offer
+                    # it as an input: shown plainly it reads as a pin the user
+                    # set, it invites an edit that would either be re-derived
+                    # on the next normalise or create the very conflict this
+                    # pass raises for, and it changes between scenarios with no
+                    # visible cause because the overlay moved a *different*
+                    # node. `metadata` carries it because it is free-form on
+                    # NodeModel -- no schema change, and it reaches the browser
+                    # with the config.
+                    meta = node.setdefault("metadata", {})
+                    if isinstance(meta, dict):
+                        derived = meta.setdefault(DERIVED_PROPERTIES_KEY, {})
+                        if isinstance(derived, dict):
+                            derived["pressure"] = source_id
 
 
 def validate_config(config: Dict[str, Any]) -> Dict[str, Any]:

--- a/frontend/src/components/panels/PropertiesPanel.tsx
+++ b/frontend/src/components/panels/PropertiesPanel.tsx
@@ -260,7 +260,17 @@ export function PropertiesPanel() {
   // sibling holds the required value (e.g. nb_reflections only for the
   // "series" reflection model). Evaluated against the live edit values while
   // editing so toggling the controlling field reveals its dependents.
+  // Properties a normalisation pass filled in rather than the author declaring
+  // them -- e.g. the process pressure propagated from a downstream OutletSink
+  // (see `boulder.config.propagate_terminal_pressure_defaults`). The solver
+  // needs them materialised on the node; the user must not see them here,
+  // where they are indistinguishable from a value that was typed and invite an
+  // edit that cannot hold.
+  const derivedProperties = ((entity?.metadata as Record<string, unknown> | undefined)
+    ?.derived_properties ?? {}) as Record<string, string>;
+
   const isFieldVisible = (key: string): boolean => {
+    if (key in derivedProperties) return false;
     const cond = schemaMeta?.[key]?.visibleWhen;
     if (!cond) return true;
     return Object.entries(cond).every(([dep, expected]) => {

--- a/frontend/src/components/results/ResultsTabs.tsx
+++ b/frontend/src/components/results/ResultsTabs.tsx
@@ -40,6 +40,7 @@ export function ResultsTabs() {
   const activeScenarioId = useScenarioStore((s) => s.activeId);
   const scenarioProgress = useSweepRunStore((s) => s.scenarioProgress);
   const sweepLastLine = useSweepRunStore((s) => s.lastLine);
+  const sweepPinnedId = useSweepRunStore((s) => s.pinnedId);
   const defaultResultsTab = results && hasSankeyData(results) ? "Sankey" : "Plots";
   /** Resolved tab for UI: explicit choice, else Sankey/Plots per available data. */
   const displayTab = activeTab ?? defaultResultsTab;
@@ -192,11 +193,23 @@ export function ResultsTabs() {
   // results/progress a previously-viewed scenario left behind — non-blocking
   // (this just occupies the results card's own slot), so the Scenario Pane
   // and the rest of the layout stay fully visible and usable.
-  if (activeScenarioId != null && activeScenarioId in scenarioProgress) {
+  // Which scenario the results area is showing while a sweep runs. By default
+  // it follows the solver, so the card appears without the user having to click
+  // anything and moves on with the sweep. A mid-sweep selection pins it (see
+  // `sweepStore.pinnedId`); if that pinned scenario is itself the one solving,
+  // the card comes back and resumes following.
+  //
+  // Previously this read `activeScenarioId` alone. Nothing is selected when a
+  // sweep starts, so the condition was false and no card ever appeared -- it
+  // only showed if you happened to click the scenario being solved right then.
+  const solvingId = Object.keys(scenarioProgress).at(-1) ?? null;
+  const followedId = sweepPinnedId ?? solvingId;
+
+  if (followedId != null && followedId in scenarioProgress) {
     return (
       <SweepCalculatingCard
-        scenarioId={activeScenarioId}
-        stage={scenarioProgress[activeScenarioId]}
+        scenarioId={followedId}
+        stage={scenarioProgress[followedId]}
         lastLine={sweepLastLine}
       />
     );

--- a/frontend/src/stores/scenarioStore.test.ts
+++ b/frontend/src/stores/scenarioStore.test.ts
@@ -195,6 +195,24 @@ describe("scenarioStore", () => {
     expect(useScenarioStore.getState().activeId).toBeNull();
   });
 
+  it("clearCache also drops the displayed results", async () => {
+    // Otherwise the graph stays tinted "computed" and the results tabs keep
+    // showing a run whose store entry has just been deleted -- `clear-cache`
+    // removes the whole store directory, base entry included.
+    const { useSimulationStore } = await import("./simulationStore");
+    useSimulationStore.setState({
+      results: { status: "complete" } as never,
+      pythonCode: "# code",
+    });
+    mockClearScenarioCache.mockResolvedValue({ ok: true, cleared: true });
+    mockListScenarios.mockResolvedValue({ available: false, scenarios: [], authored_ids: [] });
+
+    await useScenarioStore.getState().clearCache();
+
+    expect(useSimulationStore.getState().results).toBeNull();
+    expect(useSimulationStore.getState().pythonCode).toBe("");
+  });
+
   it("setActive on an id not yet computed just selects it, without fetching", async () => {
     useScenarioStore.setState({ scenarios: [{ id: "A", t0_K: 300, label: "A" }] });
 

--- a/frontend/src/stores/scenarioStore.ts
+++ b/frontend/src/stores/scenarioStore.ts
@@ -207,9 +207,14 @@ export const useScenarioStore = create<ScenarioState>((set, get) => ({
     // scenario's overrides -- flagged as overrides -- with no scenario
     // selected any more and nothing left in the store to justify them.
     //
-    // The *base run's* result deliberately survives: this clears scenario
-    // results only (see the button's tooltip), so the graph's "computed"
-    // node tint still correctly reflects the base simulation still loaded.
+    // Drop the displayed results too, so the graph greys out in the same click.
+    // This used to deliberately keep them, on the grounds that clearing touched
+    // only *scenario* results and the base run survived in a second, separate
+    // cache -- so the "computed" node tint still reflected something real. There
+    // is one store now and `clear-cache` removes the whole directory, base entry
+    // included, so keeping the display would leave a computed-looking graph
+    // backed by nothing on disk.
+    useSimulationStore.getState().clearResults();
     set({
       activeId: null,
       previewId: null,

--- a/frontend/src/stores/scenarioStore.ts
+++ b/frontend/src/stores/scenarioStore.ts
@@ -15,6 +15,7 @@ import {
 import type { ConfigConnection, ConfigNode } from "@/types/config";
 import { useSimulationStore } from "./simulationStore";
 import { useSelectionStore } from "./selectionStore";
+import { useSweepRunStore } from "./sweepStore";
 
 function idsFromOverlays(overlays: Record<string, ScenarioOverlay>): string[] {
   const ids = Object.keys(overlays);
@@ -227,6 +228,12 @@ export const useScenarioStore = create<ScenarioState>((set, get) => ({
   },
 
   setActive: async (id) => {
+    // Selecting a scenario mid-sweep is the user taking the wheel: the results
+    // pane must stop following the solver and stay where they put it. Recorded
+    // on the sweep store because that is what auto-follow reads, and only while
+    // a sweep is running -- outside one there is nothing to follow.
+    const sweep = useSweepRunStore.getState();
+    if (sweep.sweeping) sweep.pin(id);
     set({ activeId: id, error: null });
     // Always preview the scenario's effective properties, computed or not —
     // this is what lets the Inputs pane show an authored-but-unswept

--- a/frontend/src/stores/sweepFollow.test.ts
+++ b/frontend/src/stores/sweepFollow.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Who the results pane follows during a sweep.
+ *
+ * By default the solver: the "Calculating …" card must appear without the user
+ * clicking anything, and move on with the sweep. A mid-sweep selection pins it
+ * instead — the user has taken the wheel — and selecting the scenario that is
+ * itself solving hands control back.
+ *
+ * Regression: the pane used to key off the *selected* scenario alone. Nothing
+ * is selected when a sweep starts, so no card ever appeared unless you happened
+ * to click the scenario being solved right then.
+ */
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { useScenarioStore } from "./scenarioStore";
+import { useSweepRunStore } from "./sweepStore";
+
+/** The gate `ResultsTabs` applies, kept in step with it. */
+function followedId(
+  pinnedId: string | null,
+  scenarioProgress: Record<string, unknown>,
+): string | null {
+  const solvingId = Object.keys(scenarioProgress).at(-1) ?? null;
+  const followed = pinnedId ?? solvingId;
+  return followed != null && followed in scenarioProgress ? followed : null;
+}
+
+describe("sweep follow", () => {
+  beforeEach(() => {
+    useSweepRunStore.setState({ sweeping: false, pinnedId: null, scenarioProgress: {} });
+    useScenarioStore.setState({ activeId: null, scenarios: [] });
+  });
+
+  it("follows the solving scenario when the user has not chosen one", () => {
+    expect(followedId(null, { hot: { stage: 1 } })).toBe("hot");
+  });
+
+  it("moves on with the sweep", () => {
+    expect(followedId(null, { hot: { stage: 3 } })).toBe("hot");
+    expect(followedId(null, { cold: { stage: 1 } })).toBe("cold");
+  });
+
+  it("stops following once the user selects another scenario mid-sweep", async () => {
+    useSweepRunStore.setState({ sweeping: true });
+    await useScenarioStore.getState().setActive("already_done");
+
+    const pinned = useSweepRunStore.getState().pinnedId;
+    expect(pinned).toBe("already_done");
+    // Not in progress -> no card, so the pane shows that scenario's results.
+    expect(followedId(pinned, { hot: { stage: 2 } })).toBeNull();
+  });
+
+  it("resumes following when the user selects the scenario being solved", async () => {
+    useSweepRunStore.setState({ sweeping: true });
+    await useScenarioStore.getState().setActive("hot");
+
+    expect(followedId(useSweepRunStore.getState().pinnedId, { hot: { stage: 2 } })).toBe("hot");
+  });
+
+  it("does not pin a selection made outside a sweep", async () => {
+    useSweepRunStore.setState({ sweeping: false });
+    await useScenarioStore.getState().setActive("whatever");
+
+    expect(useSweepRunStore.getState().pinnedId).toBeNull();
+  });
+});

--- a/frontend/src/stores/sweepStore.ts
+++ b/frontend/src/stores/sweepStore.ts
@@ -20,6 +20,18 @@ interface SweepRunState {
    */
   lastLine: string | null;
   /**
+   * A scenario the user explicitly selected *while a sweep was running*, which
+   * stops the results pane auto-following the solver. `null` means "follow the
+   * sweep". Reset when a sweep starts, so each run begins by following again.
+   *
+   * Needed because auto-follow cannot otherwise tell a user click apart from
+   * its own selection: without it, either the pane never follows (what shipped)
+   * or it yanks the view away from a scenario the user chose to look at.
+   */
+  pinnedId: string | null;
+  /** Record an explicit user selection; call only while `sweeping`. */
+  pin: (id: string) => void;
+  /**
    * Start a sweep job and poll it to completion, toasting the outcome and
    * refreshing the Scenario Pane. Backs RunControl's "Run Sweep" — a single
    * shared job so any other caller can't disagree about whether a sweep is
@@ -86,7 +98,7 @@ export const useSweepRunStore = create<SweepRunState>((set, get) => {
       return;
     }
     stopPolling();
-    set({ sweeping: false, scenarioProgress: {}, lastLine: null });
+    set({ sweeping: false, scenarioProgress: {}, lastLine: null, pinnedId: null });
     if (st.status === "done") {
       toast.success("Sweep complete — scenarios updated");
       void (async () => {
@@ -128,13 +140,21 @@ export const useSweepRunStore = create<SweepRunState>((set, get) => {
     progress: { current: 0, total: 0 },
     scenarioProgress: {},
     lastLine: null,
+    pinnedId: null,
+    pin: (id: string) => set({ pinnedId: id }),
 
     run: (options) => {
       if (get().sweeping) {
         toast.error("A sweep is already running");
         return;
       }
-      set({ sweeping: true, progress: { current: 0, total: options?.total ?? 0 } });
+      // A new sweep starts by following the solver again, whatever the user
+      // had pinned during the last one.
+      set({
+        sweeping: true,
+        pinnedId: null,
+        progress: { current: 0, total: options?.total ?? 0 },
+      });
       const scenarios = useScenarioStore.getState().overlays;
       startSweep({ scenarios, noCache: options?.noCache })
         .then(() => startPolling())

--- a/tests/test_config_pressure_propagation.py
+++ b/tests/test_config_pressure_propagation.py
@@ -1,0 +1,72 @@
+"""A propagated process pressure is marked derived, so the GUI can hide it.
+
+`propagate_terminal_pressure_defaults` materialises the component's pressure
+onto every pressure-bearing node because the solver needs it there. That makes
+it indistinguishable from an authored value in the Properties panel, where it
+reads as a pin the user set and invites an edit that would either be re-derived
+on the next normalise or create the very conflict the pass raises for.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from boulder.config import DERIVED_PROPERTIES_KEY, normalize_config
+
+
+def _cfg() -> Dict[str, Any]:
+    return {
+        "nodes": [
+            {
+                "id": "feed",
+                "type": "Reservoir",
+                "properties": {"temperature": 300, "composition": "CH4:1"},
+            },
+            {"id": "down", "type": "OutletSink", "properties": {"pressure": 130000.0}},
+        ],
+        "connections": [
+            {
+                "id": "c",
+                "type": "MassFlowController",
+                "source": "feed",
+                "target": "down",
+                "properties": {},
+            }
+        ],
+        "phases": {"gas": {"mechanism": "gri30.yaml"}},
+    }
+
+
+def _node(config: Dict[str, Any], node_id: str) -> Dict[str, Any]:
+    return next(n for n in config["nodes"] if n["id"] == node_id)
+
+
+def test_a_propagated_pressure_records_the_node_it_came_from() -> None:
+    normalized = normalize_config(_cfg())
+    feed = _node(normalized, "feed")
+
+    # Still materialised -- the solver reads it off the node.
+    assert feed["properties"]["pressure"] == 130000.0
+    # ...and marked, so the panel knows not to offer it as an input.
+    assert feed["metadata"][DERIVED_PROPERTIES_KEY] == {"pressure": "down"}
+
+
+def test_the_node_that_declared_the_pressure_is_not_marked() -> None:
+    """Only filled-in values are derived; an authored one stays an input."""
+    normalized = normalize_config(_cfg())
+    down = _node(normalized, "down")
+
+    assert down["properties"]["pressure"] == 130000.0
+    assert (down.get("metadata") or {}).get(DERIVED_PROPERTIES_KEY) is None
+
+
+def test_an_explicitly_declared_matching_pressure_is_not_marked() -> None:
+    """The pass leaves it alone, so it is the author's value, not a derived one."""
+    config = _cfg()
+    _node(config, "feed")["properties"]["pressure"] = 130000.0
+
+    normalized = normalize_config(config)
+    feed = _node(normalized, "feed")
+
+    assert feed["properties"]["pressure"] == 130000.0
+    assert (feed.get("metadata") or {}).get(DERIVED_PROPERTIES_KEY) is None


### PR DESCRIPTION
Three GUI defects found by running the SPRING-class sweep procedure. Each is one focused commit.

## 1. Clear Cache left the graph blue — my regression from #147

`scenarioStore.clearCache` kept the displayed results on purpose:

> The *base run's* result deliberately survives … so the graph's "computed" node tint still correctly reflects the base simulation still loaded.

True under two stores. #147 unified them and made `clear-cache` remove the **whole directory**, base entry included — the justification died, the code it justified did not. Nodes stayed blue and the results tabs kept showing a run with no entry on disk. I changed what the endpoint deletes without re-reading the comment that depended on it.

| | entries | node tint | results |
|---|---|---|---|
| after sweep | 3 | `rgb(59,130,246)` | shown |
| after Clear Cache | 0 | `rgb(91,100,114)` | empty |

The cache-lifecycle SKILL told readers to **expect** blue nodes on the same dead rationale — corrected, and the episode recorded in its known-issues section.

Fixes spark-cleantech-l3/bloc#368.

## 2. The sweep progress card never appeared

`ResultsTabs` gated the card on the *selected* scenario. Nothing is selected when a sweep starts, so it only showed if you happened to click the scenario being solved right then — and `sweepStore` sets a selection only *after* the sweep finishes.

The card now follows the solver by default. A selection made **while a sweep runs** pins it — the user has taken the wheel — and selecting the scenario that is itself solving resumes following. A new sweep resets the pin.

The flag is load-bearing: auto-follow cannot otherwise distinguish a user click from its own selection, so without it you get either a pane that never follows or one that yanks the view away from a scenario the user opened deliberately.

Verified live: a sweep with nothing selected now shows "Calculating …" on its own, where before no card appeared at all.

Fixes spark-cleantech-l3/bloc#367.

## 3. Derived properties shown as node inputs

A mixing reactor listed `pressure 130,000 Pa` under Initial conditions that its author never declared — the process pressure propagated from a downstream OutletSink.

The solver needs it materialised, so it stays. What was wrong is presenting it like a typed value: it reads as a pin on that node, it is offered as editable (an edit is either re-derived on the next normalise or creates the very conflict the pass raises for), and it changes between scenarios with no visible cause because the overlay moved a *different* node.

`propagate_terminal_pressure_defaults` now records `metadata.derived_properties = {property: source_node_id}` for what it fills in, and the panel omits those keys. Only filled-in values are marked — a node declaring its own pressure, and the node the pressure came from, still show it as the input it is. `metadata` is already free-form on `NodeModel`, so no schema change.

Fixes spark-cleantech-l3/bloc#370.

## Verification

`855 passed, 1 skipped, 7 xfailed` · 234 frontend across 31 files · mypy clean over 163 files · pre-commit clean · all three behaviours confirmed in the browser.