### PR TITLE
feat: full-width scenario rows, with hover actions over the timestamp

### DIFF
--- a/.cursor/skills/boulder-scenario-cache-lifecycle/SKILL.md
+++ b/.cursor/skills/boulder-scenario-cache-lifecycle/SKILL.md
@@ -30,6 +30,13 @@ the staleness check. Two consequences this procedure exists to verify:
   is a hit; going *back* to a previous value re-solves. Keeping a value
   around is what authoring a scenario is for.
 
+Two scopes clear it: the pane header's eraser
+(`POST /api/scenarios/clear-cache`, `button[title^="Clear cache"]`) removes
+the whole store directory, and a row's own eraser
+(`POST /api/scenarios/<id>/clear-cache`,
+`button[title^="Clear this scenario"]`) drops that one entry so the next
+Run Sweep re-solves it alone. Neither touches a scenario's definition.
+
 Historically these were two separate stores (a content-addressed
 `.boulder-cache/<fingerprint>/` for single runs, a name-addressed
 `<stem>_scenarios.h5` for run-sets) which disagreed permanently about

--- a/boulder/api/routes/scenarios.py
+++ b/boulder/api/routes/scenarios.py
@@ -387,6 +387,27 @@ async def clear_scenario_cache(request: Request) -> Dict[str, Any]:
     return {"ok": True, "cleared": scenario_store.clear(_store_dir(request))}
 
 
+@router.post("/{scenario_id}/clear-cache")
+async def clear_scenario_entry_cache(
+    scenario_id: str, request: Request
+) -> Dict[str, Any]:
+    """Drop one scenario's cached result, keeping its definition.
+
+    The per-row counterpart of :func:`clear_scenario_cache`: the next Run Sweep
+    re-solves this scenario alone instead of the whole run-set. ``cleared``
+    reports whether there was actually a cached result to remove.
+    """
+    from ... import scenario_store
+
+    store_dir = _store_dir(request)
+    cleared = (
+        scenario_store.delete_entry(store_dir, scenario_id)
+        if store_dir is not None
+        else False
+    )
+    return {"ok": True, "scenario_id": scenario_id, "cleared": cleared}
+
+
 @router.delete("/{scenario_id}")
 async def delete_scenario(
     scenario_id: str, body: DeleteScenarioRequest, request: Request

--- a/frontend/src/api/scenarios.ts
+++ b/frontend/src/api/scenarios.ts
@@ -252,3 +252,15 @@ export function clearScenarioCache() {
     method: "POST",
   });
 }
+
+/**
+ * Clear one scenario's cached trajectory, leaving its definition alone — the
+ * per-row counterpart of `clearScenarioCache`. `cleared` reports whether there
+ * was actually a cached result to remove.
+ */
+export function clearScenarioEntryCache(id: string) {
+  return apiFetch<{ ok: boolean; scenario_id: string; cleared: boolean }>(
+    `/scenarios/${encodeURIComponent(id)}/clear-cache`,
+    { method: "POST" },
+  );
+}

--- a/frontend/src/components/panels/ScenarioPane.test.tsx
+++ b/frontend/src/components/panels/ScenarioPane.test.tsx
@@ -29,6 +29,7 @@ const mockRefresh = vi.fn();
 const mockSetActive = vi.fn();
 const mockDeleteScenario = vi.fn();
 const mockClearCache = vi.fn();
+const mockClearEntryCache = vi.fn();
 let mockAvailable = true;
 let mockScenarios: Array<{ id: string; label: string; t0_K: number }> = [
   { id: "A", label: "Scenario A", t0_K: 300 },
@@ -48,6 +49,7 @@ vi.mock("@/stores/scenarioStore", () => ({
     setActive: mockSetActive,
     deleteScenario: mockDeleteScenario,
     clearCache: mockClearCache,
+    clearEntryCache: mockClearEntryCache,
   }),
 }));
 
@@ -83,6 +85,7 @@ describe("ScenarioPane", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockClearCache.mockResolvedValue({ cleared: true });
+    mockClearEntryCache.mockResolvedValue({ cleared: true });
     mockAvailable = true;
     mockScenarios = [{ id: "A", label: "Scenario A", t0_K: 300 }];
     mockAuthoredIds = [];
@@ -134,6 +137,26 @@ describe("ScenarioPane", () => {
 
     expect(mockClearCache).not.toHaveBeenCalled();
     confirmSpy.mockRestore();
+  });
+
+  it("a row's eraser confirms, then clears that scenario's cache only", async () => {
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
+    render(<ScenarioPane />);
+
+    fireEvent.click(screen.getByTitle(/Clear this scenario's cached result/));
+    await Promise.resolve();
+
+    expect(mockClearEntryCache).toHaveBeenCalledWith("A");
+    expect(mockClearCache).not.toHaveBeenCalled();
+    confirmSpy.mockRestore();
+  });
+
+  it("an uncomputed row has no eraser — there is no cached result to clear", () => {
+    mockScenarios = [];
+    mockAuthoredIds = ["pending_a"];
+    render(<ScenarioPane />);
+
+    expect(screen.queryByTitle(/Clear this scenario's cached result/)).toBeNull();
   });
 
   it("opens the scoped overlay editor for a regular scenario's pencil", () => {

--- a/frontend/src/components/panels/ScenarioPane.tsx
+++ b/frontend/src/components/panels/ScenarioPane.tsx
@@ -61,6 +61,7 @@ export function ScenarioPane() {
     setActive,
     deleteScenario,
     clearCache,
+    clearEntryCache,
   } = useScenarioStore();
   const scenarioProgress = useSweepRunStore((s) => s.scenarioProgress);
   const openYamlPane = useLayoutStore((s) => s.openYamlPane);
@@ -118,6 +119,27 @@ export function ScenarioPane() {
     } catch (err) {
       toast.error(
         `Could not delete scenario: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  };
+
+  const handleClearRowCache = async (id: string) => {
+    if (
+      !window.confirm(
+        `Clear the cached result for "${id}"? Its definition is untouched — ` +
+          "Run Sweep will recompute it next time.",
+      )
+    ) {
+      return;
+    }
+    try {
+      const { cleared } = await clearEntryCache(id);
+      toast.success(
+        cleared ? `Cached result for "${id}" cleared` : `No cached result for "${id}"`,
+      );
+    } catch (err) {
+      toast.error(
+        `Could not clear cache: ${err instanceof Error ? err.message : String(err)}`,
       );
     }
   };
@@ -246,7 +268,12 @@ export function ScenarioPane() {
             const s = row.computed;
             const ago = s ? timeAgo(s.computed_at ?? createdAt, now) : "";
             return (
-              <li key={row.id} className="group flex items-center gap-1">
+              // The action icons are an overlay (below), not siblings in a
+              // flex row: as siblings they permanently reserved an icon column
+              // even while hidden, so no row ever reached the pane's full
+              // width. They now sit on top of the status label instead, which
+              // fades out on hover.
+              <li key={row.id} className="group relative">
                 <button
                   id={`scenario-${row.id}`}
                   type="button"
@@ -261,7 +288,7 @@ export function ScenarioPane() {
                       : undefined
                   }
                   className={[
-                    "flex-1 min-w-0 text-left rounded-md px-2 py-1.5 text-xs transition-colors border",
+                    "w-full min-w-0 text-left rounded-md px-2 py-1.5 text-xs transition-colors border",
                     "focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400",
                     isActive
                       ? "border-blue-500 bg-blue-500/20 text-foreground"
@@ -270,18 +297,19 @@ export function ScenarioPane() {
                 >
                   <div className="flex items-center justify-between gap-2">
                     <span className="font-medium truncate">{row.id}</span>
+                    {/* Hidden on hover -- the action icons take this spot. */}
                     {isCalculating ? (
-                      <span className="shrink-0 text-[10px] text-primary animate-pulse">
+                      <span className="shrink-0 text-[10px] text-primary animate-pulse group-hover:opacity-0">
                         Calculating…
                       </span>
                     ) : s ? (
                       ago && (
-                        <span className="shrink-0 text-[10px] text-muted-foreground">
+                        <span className="shrink-0 text-[10px] text-muted-foreground group-hover:opacity-0">
                           {ago}
                         </span>
                       )
                     ) : (
-                      <span className="shrink-0 text-[10px] text-muted-foreground">
+                      <span className="shrink-0 text-[10px] text-muted-foreground group-hover:opacity-0">
                         Not computed yet
                       </span>
                     )}
@@ -301,38 +329,54 @@ export function ScenarioPane() {
                     </div>
                   )}
                 </button>
-                <button
-                  type="button"
-                  onClick={() => handleEditRow(row.id)}
-                  title={
-                    row.id === BASELINE_SCENARIO_ID
-                      ? "Edit YAML (the base config BASELINE runs unmodified)"
-                      : "Edit scenario YAML"
-                  }
-                  className="shrink-0 p-1 rounded text-muted-foreground opacity-0 group-hover:opacity-100 hover:text-foreground hover:bg-muted"
-                >
-                  <Pencil size={12} />
-                </button>
-                {row.id === BASELINE_SCENARIO_ID ? (
-                  // Same slot as the delete button below (kept present, not
-                  // removed, so every row's icon column stays aligned) --
-                  // BASELINE has no overlay of its own to delete.
-                  <span
-                    title="BASELINE cannot be deleted (it's the base config's own unmodified run, not an authored scenario)"
-                    className="shrink-0 p-1 rounded text-muted-foreground opacity-0 group-hover:opacity-100 cursor-not-allowed"
-                  >
-                    <Ban size={12} />
-                  </span>
-                ) : (
+                {/* `pointer-events-none` while hidden: the overlay covers part
+                    of the row button, so without it an invisible icon would
+                    swallow clicks meant to select the scenario. */}
+                <div className="absolute right-1 top-1 flex items-center gap-0.5 opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto group-focus-within:opacity-100 group-focus-within:pointer-events-auto">
                   <button
                     type="button"
-                    onClick={() => void handleDelete(row.id, s !== null)}
-                    title="Delete scenario"
-                    className="shrink-0 p-1 rounded text-muted-foreground opacity-0 group-hover:opacity-100 hover:text-destructive hover:bg-muted"
+                    onClick={() => handleEditRow(row.id)}
+                    title={
+                      row.id === BASELINE_SCENARIO_ID
+                        ? "Edit YAML (the base config BASELINE runs unmodified)"
+                        : "Edit scenario YAML"
+                    }
+                    className="p-1 rounded text-muted-foreground hover:text-foreground hover:bg-muted"
                   >
-                    <Trash2 size={12} />
+                    <Pencil size={12} />
                   </button>
-                )}
+                  {/* Only a computed row has a cached trajectory to drop. */}
+                  {s && (
+                    <button
+                      type="button"
+                      onClick={() => void handleClearRowCache(row.id)}
+                      title="Clear this scenario's cached result (keeps its definition)"
+                      className="p-1 rounded text-muted-foreground hover:text-foreground hover:bg-muted"
+                    >
+                      <Eraser size={12} />
+                    </button>
+                  )}
+                  {row.id === BASELINE_SCENARIO_ID ? (
+                    // Same slot as the delete button below (kept present, not
+                    // removed, so every row's icon column stays aligned) --
+                    // BASELINE has no overlay of its own to delete.
+                    <span
+                      title="BASELINE cannot be deleted (it's the base config's own unmodified run, not an authored scenario)"
+                      className="p-1 rounded text-muted-foreground cursor-not-allowed"
+                    >
+                      <Ban size={12} />
+                    </span>
+                  ) : (
+                    <button
+                      type="button"
+                      onClick={() => void handleDelete(row.id, s !== null)}
+                      title="Delete scenario"
+                      className="p-1 rounded text-muted-foreground hover:text-destructive hover:bg-muted"
+                    >
+                      <Trash2 size={12} />
+                    </button>
+                  )}
+                </div>
               </li>
             );
           })}

--- a/frontend/src/stores/scenarioStore.ts
+++ b/frontend/src/stores/scenarioStore.ts
@@ -2,6 +2,7 @@ import { create } from "zustand";
 import {
   BASELINE_SCENARIO_ID,
   clearScenarioCache as apiClearScenarioCache,
+  clearScenarioEntryCache as apiClearScenarioEntryCache,
   createScenario as apiCreateScenario,
   deleteScenario as apiDeleteScenario,
   fetchScenario,
@@ -109,6 +110,8 @@ interface ScenarioState {
   deleteScenario: (id: string) => Promise<{ cachePurged: boolean }>;
   /** Clear every scenario's cached trajectory; resolves with whether there was a store to clear. */
   clearCache: () => Promise<{ cleared: boolean }>;
+  /** Clear one scenario's cached trajectory, keeping its definition. */
+  clearEntryCache: (id: string) => Promise<{ cleared: boolean }>;
 }
 
 export const useScenarioStore = create<ScenarioState>((set, get) => ({
@@ -217,6 +220,18 @@ export const useScenarioStore = create<ScenarioState>((set, get) => ({
       previewConnections: null,
       previewError: null,
     });
+    await get().refresh();
+    return { cleared: resp.cleared };
+  },
+
+  clearEntryCache: async (id) => {
+    const resp = await apiClearScenarioEntryCache(id);
+    // Its trajectory is gone -- stop rendering it as if still cached (same
+    // reasoning as `clearCache`, scoped to the one row).
+    if (get().activeId === id) {
+      useSimulationStore.getState().clearResults();
+      set({ activeId: null });
+    }
     await get().refresh();
     return { cleared: resp.cleared };
   },

--- a/tests/test_scenario_editing.py
+++ b/tests/test_scenario_editing.py
@@ -635,6 +635,35 @@ def test_clear_scenario_cache_without_a_store_reports_false(tmp_path: Path) -> N
         client.__exit__(None, None, None)
 
 
+def test_clear_one_entry_cache_keeps_the_definition(tmp_path: Path) -> None:
+    """The per-row eraser drops one entry only; the scenario stays authored."""
+    pytest.importorskip("h5py")
+    from boulder.scenario_store import store_entry_path
+
+    cfg = _write_config(tmp_path)
+    client, _app = _client_with_config(cfg)
+    try:
+        store_dir = _seed_entry(cfg, "base_case")
+        _seed_entry(cfg, "other")
+
+        resp = client.post("/api/scenarios/base_case/clear-cache")
+        assert resp.status_code == 200, resp.text
+        assert resp.json() == {
+            "ok": True,
+            "scenario_id": "base_case",
+            "cleared": True,
+        }
+        assert not store_entry_path(store_dir, "base_case").exists()
+        assert store_entry_path(store_dir, "other").is_file(), "cleared too much"
+        assert _authored_ids(client) == ["BASELINE", "base_case"]
+
+        # Nothing left to clear the second time round.
+        resp = client.post("/api/scenarios/base_case/clear-cache")
+        assert resp.json()["cleared"] is False
+    finally:
+        client.__exit__(None, None, None)
+
+
 def test_list_scenarios_includes_authored_ids_without_a_store(tmp_path: Path) -> None:
     """authored_ids/authored_overlays reflect the YAML directly, even with no HDF5 store.
 


### PR DESCRIPTION
## What

Scenario Pane rows now span the pane's full width, and their actions appear on hover in place of the `x min ago` label.

- **Root cause of the missing width:** the edit/delete icons were flex siblings of the row button (`flex-1` + two `opacity-0` icon buttons), so an icon column was permanently reserved and no row could reach 100%. They are now one absolutely positioned overlay (`opacity-0` → `group-hover`/`group-focus-within`), and the row button is `w-full`.
- The status label (`x min ago` / `Not computed yet` / `Calculating…`) fades out on hover so the icons take that spot.
- `pointer-events-none` while hidden — the overlay sits on top of the row button, so without it an invisible icon would swallow clicks meant to select the scenario.
- **New per-row eraser between edit and delete:** clears just that scenario's cached result, keeping its definition, so the next Run Sweep re-solves that one entry. Backed by `POST /api/scenarios/<id>/clear-cache`, which reuses the `scenario_store.delete_entry` the delete route already called. Only rendered for rows that actually have a cached result.

## Verification

- `make qa` (pre-commit, all files), `make type-check` (mypy strict), `npm run type-check` — clean.
- `pytest tests/test_scenario_editing.py` — 33 passed, including a new test that the per-row clear drops one entry only, keeps the scenario authored, and reports `cleared: false` the second time.
- `npm run test:unit` — 230 passed, including new cases for the row eraser (confirm → `clearEntryCache(id)`, and no eraser on an uncomputed row).
- Live in the dev server: measured the row button at the full list width (193px of 193px, previously 160px), and on hover the row's overlay goes to `opacity: 1` / `pointer-events: auto` while its timestamp goes to `opacity: 0` — neighbouring rows unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
