### PR TITLE
One sweep tail, so the GUI and CLI cannot drift again

### DIFF
--- a/boulder/api/routes/sweep.py
+++ b/boulder/api/routes/sweep.py
@@ -32,14 +32,16 @@ from pydantic import BaseModel, Field
 from ... import scenario_store
 from ...cantera_converter import DualCanteraConverter, get_plugins
 from ...runset import (
-    node_property_attrs,
     resolve_store_dir,
     run_set_size,
-    sweep_point_of,
     sweep_runner_of,
     sweeps_of,
 )
-from ...sweep_runner import prepare_scenario, solve_scenario
+from ...sweep_runner import (
+    prepare_scenario,
+    solve_scenario,
+    store_solved_scenario,
+)
 
 __all__ = ["has_run_set", "router"]
 
@@ -360,85 +362,26 @@ async def sweep_run(
                 # internally to load its own `ct.Solution`, so skipping this
                 # would hand `write_payload` an unresolved name it can't load.
                 stored_mech = resolve_mechanism(conv_mechanism)
-                # Host KPI attrs (`plugins.scenario_attrs`) -- the numbers the
-                # Scenario pane's Sweep Results plot offers as axes. Computed
-                # before the h5 handle opens so a raising hook can't leave the
-                # store open, and best-effort for the same reason `on_solved`
-                # is: a KPI failure must not lose an already-solved scenario.
-                # A declarative sweep's own axis values are the run's inputs;
-                # recording them makes the Sweep Results plot usable with no
-                # host code at all (they are its natural X axis). A host's
-                # `scenario_attrs` may add to or override them.
-                extra_attrs: Dict[str, Any] = {
-                    key: value
-                    for key, value in sweep_point_of(cfg).items()
-                    if isinstance(value, (int, float)) and not isinstance(value, bool)
-                }
-                # Every node/connection's own numeric properties -- generic,
-                # host-agnostic "input" axis candidates for the Sweep Results
-                # plot, keyed ``in.<id>.<prop>`` (see node_property_attrs
-                # docstring). Added on top of whatever extra_attrs already has.
-                extra_attrs.update(node_property_attrs(config))
-                # `update`, not assignment: a host hook *adds to or overrides*
-                # these, as the comment above promises. Assigning discarded the
-                # declarative sweep's own axis values -- the plot's natural X
-                # axis -- for any host that registered the hook. Applied after
-                # `node_property_attrs` so the host wins a key collision, which
-                # is also the CLI runner's order.
-                if plugins.scenario_attrs is not None:
-                    try:
-                        extra_attrs.update(plugins.scenario_attrs(sid, cfg, gui) or {})
-                    except Exception as exc:  # noqa: BLE001
-                        print(
-                            f"[sweep] WARNING: scenario_attrs hook failed for "
-                            f"'{sid}': {exc}",
-                            flush=True,
-                        )
-                # A host may pair a KPI value with its display unit as
-                # (value, unit); the number becomes the attr and the unit is
-                # recorded separately, since HDF5 attrs are flat scalars.
-                entry_units: Dict[str, str] = {}
-                for key, value in list(extra_attrs.items()):
-                    if isinstance(value, tuple):
-                        extra_attrs[key], entry_units[key] = value
-                scenario_store.write_entry(
+                # Attrs, the store write and the host hooks are the same
+                # tail the headless runner uses -- shared so the two cannot
+                # drift again (they had: one assigned the host hook's return
+                # over the sweep's own axis values where the other merged).
+                store_solved_scenario(
                     store_dir,
                     sid,
-                    gui_payload=gui,
-                    mechanism=stored_mech,
+                    cfg,
+                    config,
+                    gui,
+                    conv,
+                    order=i,
+                    label=label,
                     fingerprint=fingerprint,
                     identity=identity,
-                    label=label,
-                    order=i,
-                    units=entry_units or None,
-                    extra_attrs=extra_attrs,
+                    mechanism=stored_mech,
+                    scenario_attrs=plugins.scenario_attrs,
+                    on_solved=plugins.on_scenario_solved,
+                    warn=lambda msg: print(f"[sweep]{msg}", flush=True),
                 )
-
-                # Let the host persist per-scenario artifacts keyed by this
-                # fingerprint -- e.g. the single-run result cache, so a later
-                # "Export" reuses this solve instead of re-solving. Runs on the
-                # in-process path too, not just the out-of-process runner:
-                # otherwise a host that registers it silently gets nothing from
-                # the GUI's Run Sweep button.
-                if plugins.on_scenario_solved is not None:
-                    try:
-                        from ...simulation_result import make_simulation_result
-
-                        plugins.on_scenario_solved(
-                            sid,
-                            config,
-                            conv,
-                            make_simulation_result(conv, config),
-                            fingerprint,
-                            gui,
-                            stored_mech,
-                        )
-                    except Exception as exc:  # noqa: BLE001
-                        print(
-                            f"[sweep] WARNING: on_scenario_solved hook failed "
-                            f"for '{sid}': {exc}",
-                            flush=True,
-                        )
 
             stale = scenario_store.prune_entries(store_dir, run_ids)
             if stale:

--- a/boulder/sweep_runner.py
+++ b/boulder/sweep_runner.py
@@ -255,6 +255,91 @@ def gui_payload_from_progress(progress: Any, started: float) -> Dict[str, Any]:
     }
 
 
+def store_solved_scenario(
+    store_dir: Path,
+    sid: str,
+    cfg: Dict[str, Any],
+    config: Dict[str, Any],
+    gui: Dict[str, Any],
+    conv: Any,
+    *,
+    order: int,
+    label: str,
+    fingerprint: str,
+    identity: str,
+    mechanism: str,
+    scenario_attrs: Optional[Callable[..., Any]] = None,
+    on_solved: Optional[Callable[..., Any]] = None,
+    warn: Optional[Callable[[str], None]] = None,
+) -> None:
+    """Record one freshly solved run-set entry: attrs, the write, the host hook.
+
+    The tail of both sweep loops -- the GUI's (``api/routes/sweep.py``) and this
+    module's headless one. They used to carry a copy each and drifted: one
+    *assigned* the host hook's return over the sweep's own axis values where the
+    other merged them, and they applied ``node_property_attrs`` on opposite
+    sides of the hook. Same config, different stored attrs depending on which
+    button you pressed. One function, so that cannot recur.
+
+    Attr precedence, lowest to highest: the declarative sweep's axis values
+    (the plot's natural X axis), then every node's own numeric properties
+    (``in.<id>.<prop>``), then the host's ``scenario_attrs``. A host may pair a
+    KPI with its display unit as ``(value, unit)``; the number becomes the attr
+    and the unit is recorded separately, since HDF5 attrs are flat scalars.
+
+    Both hooks are best-effort: a KPI or artifact failure must not lose a
+    scenario that already solved. *warn* receives the message; the default
+    prints it.
+    """
+    say = warn or (lambda msg: print(msg, flush=True))
+
+    entry_attrs: Dict[str, Any] = {
+        key: value
+        for key, value in sweep_point_of(cfg).items()
+        if isinstance(value, (int, float)) and not isinstance(value, bool)
+    }
+    entry_attrs.update(node_property_attrs(config))
+    if scenario_attrs is not None:
+        try:
+            entry_attrs.update(scenario_attrs(sid, cfg, gui) or {})
+        except Exception as exc:  # noqa: BLE001
+            say(f"  WARNING: scenario_attrs hook failed for '{sid}': {exc}")
+
+    entry_units: Dict[str, str] = {}
+    for key, value in list(entry_attrs.items()):
+        if isinstance(value, tuple):
+            entry_attrs[key], entry_units[key] = value
+
+    scenario_store.write_entry(
+        store_dir,
+        sid,
+        gui_payload=gui,
+        mechanism=mechanism,
+        fingerprint=fingerprint,
+        identity=identity,
+        label=label,
+        order=order,
+        units=entry_units or None,
+        extra_attrs=entry_attrs,
+    )
+
+    if on_solved is not None:
+        try:
+            from .simulation_result import make_simulation_result  # noqa: PLC0415
+
+            on_solved(
+                sid,
+                config,
+                conv,
+                make_simulation_result(conv, config),
+                fingerprint,
+                gui,
+                mechanism,
+            )
+        except Exception as exc:  # noqa: BLE001
+            say(f"  WARNING: on_solved hook failed for scenario '{sid}': {exc}")
+
+
 def run(
     cfg_path: Path,
     *,
@@ -353,61 +438,21 @@ def run(
         print(f"scenario {i + 1}/{total} ({sid})", flush=True)
         gui, resolved_mech, conv = solve_scenario(config, mech_name)
         stored_mech = _resolve(resolved_mech)
-        # A declarative sweep's axis values are the run's inputs, and the Sweep
-        # Results plot's natural X axis -- recorded so the GUI and CLI stores
-        # carry the same attrs. A host hook may override.
-        entry_attrs: Dict[str, Any] = {
-            key: value
-            for key, value in sweep_point_of(cfg).items()
-            if isinstance(value, (int, float)) and not isinstance(value, bool)
-        }
-        # Every node/connection's own numeric properties -- generic,
-        # host-agnostic "input" axis candidates for the Sweep Results plot,
-        # keyed ``in.<id>.<prop>`` (see node_property_attrs docstring).
-        entry_attrs.update(node_property_attrs(config))
-        if scenario_attrs is not None:
-            entry_attrs.update(scenario_attrs(sid, cfg, gui) or {})
-        # A host may pair a KPI value with its display unit as (value, unit);
-        # the number becomes the attr and the unit is recorded separately.
-        entry_units: Dict[str, str] = {}
-        for key, value in list(entry_attrs.items()):
-            if isinstance(value, tuple):
-                entry_attrs[key], entry_units[key] = value
-        scenario_store.write_entry(
+        store_solved_scenario(
             store_dir,
             sid,
-            gui_payload=gui,
-            mechanism=stored_mech,
+            cfg,
+            config,
+            gui,
+            conv,
+            order=i,
+            label=label,
             fingerprint=fingerprint,
             identity=identity,
-            label=label,
-            order=i,
-            units=entry_units or None,
-            extra_attrs=entry_attrs,
+            mechanism=stored_mech,
+            scenario_attrs=scenario_attrs,
+            on_solved=on_solved,
         )
-        if on_solved is not None:
-            # Give the host a chance to persist per-scenario artifacts (e.g. a
-            # calc-note bundle in the single-run result cache) keyed by this
-            # scenario's fingerprint. Best-effort: a failure here must not abort
-            # the remaining scenarios or the store write.
-            try:
-                from .simulation_result import make_simulation_result  # noqa: PLC0415
-
-                simulation_result = make_simulation_result(conv, config)
-                on_solved(
-                    sid,
-                    config,
-                    conv,
-                    simulation_result,
-                    fingerprint,
-                    gui,
-                    stored_mech,
-                )
-            except Exception as exc:  # noqa: BLE001
-                print(
-                    f"  WARNING: on_solved hook failed for scenario '{sid}': {exc}",
-                    flush=True,
-                )
 
     stale = scenario_store.prune_entries(store_dir, run_ids)
     if stale:


### PR DESCRIPTION
Extracts `store_solved_scenario` — the shared end of both sweep loops (entry attrs → store write → host hooks). `api/routes/sweep.py` and `sweep_runner.run` each carried a copy.

## Why this, and why now

Not tidiness. **The copies had already drifted, twice:**

- The GUI copy **assigned** the host hook's return over the attrs it had just built from the sweep point, where the CLI copy **merged**. Any host registering `scenario_attrs` silently lost the declarative sweep's own axis values — the plot's natural X axis — on the GUI path only.
- They applied `node_property_attrs` on opposite sides of the hook, so a key collision resolved the opposite way on each path.

Same config, different stored attrs depending on which button you pressed. Both were fixed in #148 by editing one copy to match the other, which left the mechanism that produced them fully intact. This removes it.

## After

One definition of attr precedence: the declarative sweep's axis values, then every node's `in.<id>.<prop>`, then the host's `scenario_attrs` on top. Both hooks remain best-effort — a KPI or artifact failure must not lose a scenario that already solved.

The GUI passes a `warn` callback so its warnings keep the `[sweep]` prefix. That prefix is the only behavioural difference left between the two paths.

## Size

Net −12 lines, which understates it: `sweep.py` sheds ~78 lines of duplicated tail; the helper holds that logic once, with the docstring the duplication never had.

## Coverage

No new tests — the behaviour is unchanged and already pinned from both sides. `test_sweep_scenario_hooks.py` reaches the helper through the GUI path (including the merge-not-assign regression test added in #148), and `test_sweep_paths_share_one_solve.py` through the CLI path.

`855 passed, 1 skipped, 7 xfailed` · mypy clean over 163 files · pre-commit clean.