### PR TITLE
Delete scenario_store.is_current, which nothing called

### DIFF
--- a/boulder/scenario_store.py
+++ b/boulder/scenario_store.py
@@ -300,27 +300,6 @@ def fingerprints(store_dir: Optional[Path], identity: str = "") -> Dict[str, str
     return found
 
 
-def is_current(
-    store_dir: Optional[Path],
-    scenario_id: str,
-    candidate_fingerprint: str,
-    identity: str = "",
-) -> bool:
-    """Whether *scenario_id*'s stored result already matches *candidate_fingerprint*.
-
-    The one staleness question the whole store exists to answer: solve, or reuse?
-    Matches the canonical fingerprint or any recorded alternate (see
-    :data:`_ATTR_ALT_FINGERPRINTS`), so the same entry answers to both the
-    pre-build config a sweep derives and the post-build config the browser holds.
-    """
-    if store_dir is None or not candidate_fingerprint:
-        return False
-    attrs = entry_attrs(store_dir, scenario_id, identity)
-    if attrs is None:
-        return False
-    return _answers_to(attrs, candidate_fingerprint)
-
-
 def _answers_to(attrs: Dict[str, Any], candidate_fingerprint: str) -> bool:
     """Whether an entry's attrs match *candidate_fingerprint*, canonical or alternate."""
     if str(attrs.get(_ATTR_FINGERPRINT, "")) == candidate_fingerprint:

--- a/tests/test_scenario_store.py
+++ b/tests/test_scenario_store.py
@@ -260,14 +260,16 @@ def test_clear_removes_entries_and_artifacts(tmp_path: Path) -> None:
 # --------------------------------------------------------------------------- #
 
 
-def test_is_current_only_for_the_matching_fingerprint(tmp_path: Path) -> None:
+def test_find_entry_matches_only_the_current_fingerprint(tmp_path: Path) -> None:
+    """Solve, or reuse? -- asked by fingerprint, since the caller has no id."""
     d = tmp_path / "store"
     _write(d, "hot", "id", fingerprint="fp-now")
 
-    assert store.is_current(d, "hot", "fp-now", "id") is True
-    assert store.is_current(d, "hot", "fp-edited", "id") is False
-    assert store.is_current(d, "absent", "fp-now", "id") is False
-    assert store.is_current(None, "hot", "fp-now", "id") is False
+    found = store.find_entry(d, "fp-now", "id")
+    assert found is not None and found["id"] == "hot"
+    assert store.find_entry(d, "fp-edited", "id") is None
+    assert store.find_entry(d, "", "id") is None
+    assert store.find_entry(None, "fp-now", "id") is None
 
 
 def test_the_same_entry_answers_to_its_post_build_fingerprint_too(
@@ -283,9 +285,9 @@ def test_the_same_entry_answers_to_its_post_build_fingerprint_too(
     d = tmp_path / "store"
     _write(d, "hot", "id", fingerprint="fp-pre", alt_fingerprints=("fp-post",))
 
-    assert store.is_current(d, "hot", "fp-pre", "id") is True
-    assert store.is_current(d, "hot", "fp-post", "id") is True
-    assert store.is_current(d, "hot", "fp-unrelated", "id") is False
+    assert (store.find_entry(d, "fp-pre", "id") or {}).get("id") == "hot"
+    assert (store.find_entry(d, "fp-post", "id") or {}).get("id") == "hot"
+    assert store.find_entry(d, "fp-unrelated", "id") is None
     # The canonical fingerprint is what a sweep compares against.
     assert store.fingerprints(d, "id") == {"hot": "fp-pre"}
 
@@ -304,7 +306,7 @@ def test_a_foreign_config_is_never_current(tmp_path: Path) -> None:
     d = tmp_path / "store"
     _write(d, "hot", store.config_identity(tmp_path / "a.yaml"), fingerprint="fp")
     other = store.config_identity(tmp_path / "b.yaml")
-    assert store.is_current(d, "hot", "fp", other) is False
+    assert store.find_entry(d, "fp", other) is None
 
 
 # --------------------------------------------------------------------------- #
@@ -469,4 +471,4 @@ def test_a_half_written_entry_reads_as_absent_not_as_an_error(tmp_path: Path) ->
     assert st.entry_attrs(store_dir, "crashed", identity) is None
     assert st.read_entry(store_dir, "crashed", identity) is None
     assert st.list_entries(store_dir, identity) == []
-    assert st.is_current(store_dir, "crashed", "any-fingerprint", identity) is False
+    assert st.find_entry(store_dir, "any-fingerprint", identity) is None

--- a/tests/test_worker_persists_to_store.py
+++ b/tests/test_worker_persists_to_store.py
@@ -127,8 +127,12 @@ def test_the_entry_answers_to_the_post_build_fingerprint_too(cfg: Path) -> None:
     post_fp = compute_fingerprint(enriched, mechanism="gri30.yaml")
     assert pre_fp != post_fp, "fixture no longer exercises the pre/post difference"
 
-    assert store.is_current(store_dir, BASE_SCENARIO_ID, pre_fp, identity) is True
-    assert store.is_current(store_dir, BASE_SCENARIO_ID, post_fp, identity) is True
+    assert (store.find_entry(store_dir, pre_fp, identity) or {}).get(
+        "id"
+    ) == BASE_SCENARIO_ID
+    assert (store.find_entry(store_dir, post_fp, identity) or {}).get(
+        "id"
+    ) == BASE_SCENARIO_ID
     # The canonical fingerprint -- the one a sweep compares -- is the pre-build one.
     assert store.fingerprints(store_dir, identity) == {BASE_SCENARIO_ID: pre_fp}
 


### PR DESCRIPTION
The last follow-up recorded in #147.

`is_current` has had **zero production callers** since the store landed. Both sweep loops answer "solve or reuse?" with a single bulk `fingerprints()` read plus a dict compare — the right shape for a loop, since `is_current` would mean one file open per entry. It was never going to acquire a caller.

Its tests were the only thing keeping it alive. What they actually pin is **alt-fingerprint matching** — that one solve answers both to the pre-build fingerprint a sweep derives and the post-build one the browser holds after the staged solver enriches the network. That behaviour lives in `_answers_to`, which `find_entry` also uses, and `find_entry` has three real callers: the startup check, `_build_context`, and `check-cache`.

So the tests now exercise `find_entry`. The coverage moves onto the path that actually ships, instead of guarding a function nobody runs.

`855 passed, 1 skipped, 7 xfailed` · mypy clean over 163 files · pre-commit clean.

With this, every follow-up listed in #147 is closed.