### PR TITLE
fix: sweep "Calculating…" detail line follows the solver instead of freezing on the scenario switch

### DIFF
--- a/boulder/api/routes/sweep.py
+++ b/boulder/api/routes/sweep.py
@@ -22,6 +22,7 @@ Endpoints (prefix ``/api/sweep``):
 
 from __future__ import annotations
 
+import logging
 import threading
 from pathlib import Path
 from typing import Any, Dict, Optional
@@ -137,6 +138,32 @@ def _run_host_sweep(
     runner(store_dir, **kwargs)
 
 
+class _LastLineHandler(logging.Handler):
+    """Mirror each ``boulder.*`` log record into a sweep job's ``last_line``.
+
+    The status payload's detail line was otherwise written only when a scenario
+    *started*, so a multi-minute solve showed ``scenario 3/4 (…)`` the whole way
+    through while the console narrated stage after stage. Boulder's own INFO
+    logs already say what the solve is doing ("stage 'pfr_stage' finished
+    (3/3)", "Network built successfully, …"), so the newest one is exactly the
+    detail line to show. Only the latest is kept — the frontend polls once a
+    second and the full stream stays on the server console.
+
+    INFO-level by design: ``BOULDER_VERBOSE=1`` puts the package logger at
+    DEBUG, and per-timestep chatter is not what this line is for.
+    """
+
+    def __init__(self, state: Dict[str, Any]) -> None:
+        super().__init__(level=logging.INFO)
+        self._state = state
+
+    def emit(self, record: logging.LogRecord) -> None:
+        try:
+            self._state["last_line"] = record.getMessage()
+        except Exception:  # noqa: BLE001 — a status line must never break a solve
+            pass
+
+
 def _has_run_set(request: Request) -> bool:
     return has_run_set(
         _raw(request), getattr(request.app.state, "preloaded_config_path", None)
@@ -235,6 +262,8 @@ async def sweep_run(
         "scenario_progress": {},
         # Most recent progress line, verbatim — the frontend shows it under
         # the "Calculating…" spinner so a long solve says *what* it is doing.
+        # Written on each scenario transition below, and refreshed in between by
+        # the solver's own INFO logs (see `_LastLineHandler`).
         "last_line": None,
     }
     request.app.state.sweep_job = state
@@ -404,7 +433,23 @@ async def sweep_run(
             state["message"] = str(exc)
             print(f"[sweep] FAILED: {exc}", flush=True)
 
-    threading.Thread(target=_worker, daemon=True).start()
+    def _worker_logging_to_status() -> None:
+        # Live detail line for the "Calculating…" spinner: while this sweep
+        # runs, every boulder INFO log becomes `last_line`. Attached here rather
+        # than inside `_worker` so the detach is one `finally`, whichever way the
+        # sweep ends.
+        # The handler is process-wide, so a *concurrent* single "Run Simulation"
+        # would write this line too — harmless while only one solve runs at a
+        # time; filter on the thread id if that ever stops being true.
+        pkg_logger = logging.getLogger("boulder")
+        handler = _LastLineHandler(state)
+        pkg_logger.addHandler(handler)
+        try:
+            _worker()
+        finally:
+            pkg_logger.removeHandler(handler)
+
+    threading.Thread(target=_worker_logging_to_status, daemon=True).start()
     return {"status": "running", "total": total}
 
 

--- a/tests/test_sweep_status_scenario_progress.py
+++ b/tests/test_sweep_status_scenario_progress.py
@@ -141,6 +141,54 @@ def test_scenario_progress_tracks_stage_then_moves_to_the_next_scenario(
         client.__exit__(None, None, None)
 
 
+def test_last_line_follows_the_solver_s_own_log_lines(tmp_path: Path) -> None:
+    """`last_line` tracks boulder's INFO logs, not just the scenario-start line.
+
+    Written when a scenario *started* only, the detail line under the spinner sat
+    on "scenario 1/2 (BASELINE)" for the whole solve while the console narrated
+    stage after stage. It should say whatever the solver last said.
+    """
+    import logging
+
+    client, app = _client_with_config(tmp_path)
+    workers: List[_FakeWorker] = []
+
+    def _factory() -> _FakeWorker:
+        w = _FakeWorker()
+        workers.append(w)
+        return w
+
+    try:
+        with patch("boulder.simulation_worker.SimulationWorker", side_effect=_factory):
+            resp = client.post("/api/sweep/run", json={"scenarios": {"a": {}}})
+            assert resp.status_code == 200, resp.text
+
+            _wait_until(lambda: len(workers) >= 1)
+            assert app.state.sweep_job["last_line"] == "scenario 1/2 (BASELINE)"
+
+            # Any boulder.* logger, from any module in the solve path.
+            logging.getLogger("boulder.staged_solver").info(
+                "Staged solve: stage '%s' finished (%d/%d)", "pfr_stage", 3, 3
+            )
+            assert (
+                app.state.sweep_job["last_line"]
+                == "Staged solve: stage 'pfr_stage' finished (3/3)"
+            )
+
+            workers[0].progress = SimulationProgress(is_complete=True)
+            _wait_until(lambda: len(workers) >= 2)
+            workers[1].progress = SimulationProgress(is_complete=True)
+            _wait_until(lambda: app.state.sweep_job.get("status") == "done")
+            assert app.state.sweep_job["last_line"] is None
+
+            # Detached once the sweep is over -- a later log must not resurrect
+            # a detail line for a job that finished.
+            logging.getLogger("boulder.staged_solver").info("late straggler")
+            assert app.state.sweep_job["last_line"] is None
+    finally:
+        client.__exit__(None, None, None)
+
+
 def test_scenario_progress_clears_if_a_scenario_errors_mid_solve(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## The bug

The sub-text under `Calculating "<scenario>"… — Stage 3/3` was not the latest
thing the solver said. `sweep_job["last_line"]` — the field that line renders —
was written **only when a scenario started**, so a multi-minute solve showed
`scenario 3/4 (…)` from beginning to end while the server console narrated stage
after stage.

## The fix

Boulder's own INFO logs already say what the solve is doing:

```
boulder.staged_solver - INFO - Staged solve: stage 'pfr_stage' finished (3/3)
boulder.staged_solver - INFO - Staged solve complete – building visualization ReactorNet.
boulder.simulation_worker - INFO - Network built successfully, starting streaming simulation
```

A ~10-line `logging.Handler`, attached to the `boulder` package logger for the
life of the sweep thread and detached in a `finally`, mirrors the newest record
into `last_line`.

Deliberately **not** a log stream to the frontend:

- only the *latest* record is kept — the frontend polls once a second, and the
  full stream stays on the server console;
- INFO-level, so `BOULDER_VERBOSE=1`'s DEBUG chatter never reaches the UI;
- `print()`-based progress (plugin output, warnings) is untouched — logged events only.

No frontend change: `SweepCalculatingCard` already renders whatever `last_line`
carries.

## Verification

- New test in `tests/test_sweep_status_scenario_progress.py`: a `boulder.*` INFO
  record becomes `last_line` mid-solve, and a record logged *after* the job
  finishes cannot resurrect the line (handler detached).
- Real 3-scenario sweep of `configs/cstr_residence_time_scenarios.yaml`: the
  detail line moved through **17** distinct values instead of 3.
- `pytest -k "sweep or logging"` — 68 passed; `mypy` strict clean; `pre-commit`
  clean on the touched files.

## Known limitation

The handler is process-wide, so a *concurrent* single "Run Simulation" would
also write this line. Harmless while only one solve runs at a time; noted in a
comment with the thread-id filter as the upgrade path.

*Extensive AI use — code & PR fully written by Claude Opus 5*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
