### PR TITLE
fix(sweep plot): put the swept input on X and the KPI on Y

### DIFF
--- a/frontend/src/api/scenarios.ts
+++ b/frontend/src/api/scenarios.ts
@@ -15,7 +15,11 @@ export type ScenarioOverlay = Record<string, unknown>;
 /** One precomputed scenario (trajectory) in the active store. */
 export interface ScenarioMeta {
   id: string;
-  t0_K: number;
+  /** Initial temperature -- present only when the sweep actually varies it.
+   * A sweep over any other axis (a pressure, a flow rate, ...) serves rows
+   * with no `t0_K` at all, so requiring it here did not match any guarantee
+   * the API makes. */
+  t0_K?: number;
   label: string;
   reactor_mode?: string;
   n_points?: number;

--- a/frontend/src/components/panels/SweepResultsPlot.test.tsx
+++ b/frontend/src/components/panels/SweepResultsPlot.test.tsx
@@ -198,4 +198,77 @@ describe("SweepResultsPlot", () => {
       ).toHaveTextContent("Efficiency (output)");
     });
   });
+
+  describe("default axis orientation", () => {
+    /** No `t0_K`: the swept knob is an input attr, the KPI is an output.
+     * `carbon_yield` sorts before `in.downstream.pressure` (`c` < `i`), which
+     * is exactly the case the old first-key-alphabetically default got wrong. */
+    const kpiVsInput: ScenarioMeta[] = [
+      {
+        id: "s-1",
+        label: "1",
+        carbon_yield: 75.1,
+        "in.downstream.pressure": 1.05e5,
+      },
+      {
+        id: "s-2",
+        label: "2",
+        carbon_yield: 77.4,
+        "in.downstream.pressure": 1.3e5,
+      },
+    ];
+
+    it("puts the swept input on X and the KPI on Y, not the reverse", () => {
+      render(<SweepResultsPlot scenarios={kpiVsInput} />);
+
+      const xSelect = screen.getByTestId("x-axis-select") as HTMLSelectElement;
+      expect(xSelect.value).toBe("in.downstream.pressure");
+      expect(
+        screen.getByTestId("active-series-chip-carbon_yield"),
+      ).toBeInTheDocument();
+
+      // The plotted X values must be the pressures, ascending.
+      expect(plotCalls.at(-1)?.data[0]?.x).toEqual([1.05e5, 1.3e5]);
+      expect(plotCalls.at(-1)?.data[0]?.y).toEqual([75.1, 77.4]);
+    });
+
+    it("still prefers t0_K for X when present, so existing sweeps are unchanged", () => {
+      const withT0: ScenarioMeta[] = kpiVsInput.map((s, i) => ({
+        ...s,
+        t0_K: 800 + 100 * i,
+      }));
+      render(<SweepResultsPlot scenarios={withT0} />);
+
+      const xSelect = screen.getByTestId("x-axis-select") as HTMLSelectElement;
+      expect(xSelect.value).toBe("t0_K");
+    });
+
+    it("keeps a KPI on Y even when another input sorts ahead of it", () => {
+      const twoInputs: ScenarioMeta[] = [
+        {
+          id: "s-1",
+          label: "1",
+          "in.a.pressure": 1e5,
+          "in.b.temperature": 300,
+          yield_pct: 40,
+        },
+        {
+          id: "s-2",
+          label: "2",
+          "in.a.pressure": 2e5,
+          "in.b.temperature": 400,
+          yield_pct: 60,
+        },
+      ];
+      render(<SweepResultsPlot scenarios={twoInputs} />);
+
+      const xSelect = screen.getByTestId("x-axis-select") as HTMLSelectElement;
+      expect(xSelect.value).toBe("in.a.pressure");
+      // "in.b.temperature" sorts before "yield_pct", but it is an input:
+      // the KPI must still be what gets plotted.
+      expect(
+        screen.getByTestId("active-series-chip-yield_pct"),
+      ).toBeInTheDocument();
+    });
+  });
 });

--- a/frontend/src/components/panels/SweepResultsPlot.tsx
+++ b/frontend/src/components/panels/SweepResultsPlot.tsx
@@ -104,6 +104,21 @@ function numericKeys(scenarios: ScenarioMeta[], nonKpiKeys?: string[]): string[]
   return Array.from(keys).sort();
 }
 
+/** Default X axis: the swept parameter, never a KPI.
+ *
+ * A sweep answers "what does this KPI do as I vary this knob", so the knob
+ * belongs on X. Falling back to the first key alphabetically got this backwards
+ * whenever a KPI happened to sort before the swept input (e.g. a carbon-yield
+ * KPI vs. an `in.*` pressure: `c` < `i`), producing a plot of the input as a
+ * function of the output.
+ *
+ * `t0_K` stays first: it is the classic swept initial temperature, and preferring
+ * it keeps every existing sweep store rendering exactly as before. */
+function defaultXKey(keys: string[]): string | undefined {
+  if (keys.includes("t0_K")) return "t0_K";
+  return keys.find((k) => inputKeyParts(k) !== null) ?? keys[0];
+}
+
 /** Group numeric keys (minus the chosen X key) into Y-axis choices: species sharing
  * a "final_X_"/"final_Y_" prefix are grouped as one Mole/Mass Fractions choice with
  * one trace per species; everything else is its own single-trace choice. */
@@ -195,7 +210,7 @@ export function SweepResultsPlot({ scenarios, units, nonKpiKeys }: Props) {
    * first available series) is used instead. */
   const [activeKeys, setActiveKeys] = useState<string[] | null>(null);
 
-  const effectiveXKey = xKey && keys.includes(xKey) ? xKey : (keys.includes("t0_K") ? "t0_K" : keys[0]);
+  const effectiveXKey = xKey && keys.includes(xKey) ? xKey : defaultXKey(keys);
   const yGroups = useMemo(
     () => (effectiveXKey ? buildYGroups(keys, effectiveXKey, units) : []),
     [keys, effectiveXKey, units],
@@ -209,7 +224,11 @@ export function SweepResultsPlot({ scenarios, units, nonKpiKeys }: Props) {
   const effectiveActiveKeys = useMemo(() => {
     if (activeKeys !== null) return activeKeys.filter((k) => validKeys.has(k));
     if (families.length > 0) return families[0].keys;
-    if (options.length > 0) return [options[0].key];
+    // Mirror of defaultXKey: an output (KPI) belongs on Y. Without this, a
+    // second input attr sorting before the KPI would take the Y axis and the
+    // plot would show one knob against another, with the KPI nowhere.
+    const output = options.find((o) => inputKeyParts(o.key) === null);
+    if (options.length > 0) return [(output ?? options[0]).key];
     return [];
   }, [activeKeys, validKeys, families, options]);
 
@@ -270,6 +289,7 @@ export function SweepResultsPlot({ scenarios, units, nonKpiKeys }: Props) {
           <select
             className={`${selectClass} flex-1`}
             value={effectiveXKey}
+            data-testid="x-axis-select"
             onChange={(e) => setXKey(e.target.value)}
           >
             {keys.map((k) => (


### PR DESCRIPTION
## Problem

The Sweep results chart could default to backwards axes — plotting the knob as a function of the result:

> **downstream.pressure (Pa, input)** on Y, as a function of **Carbon Yield (%, output)** on X

The X default fell back to the first numeric key alphabetically:

```ts
const effectiveXKey = xKey && keys.includes(xKey) ? xKey : (keys.includes("t0_K") ? "t0_K" : keys[0]);
```

`keys` is sorted, so any KPI sorting ahead of the swept input takes the X axis — here a carbon-yield KPI beats an `in.*` pressure on `c` < `i`. Nothing but alphabetical luck was keeping this right for other stores.

A sweep answers *"what does this KPI do as I vary this knob"*, so the knob belongs on X. The component docstring already said so — "pick an X axis (the swept parameter, e.g. temperature)"; the default just never honoured it.

## Change

**X default** now prefers `t0_K`, then any declared input attr (`in.<node>.<property>`), then whatever is available. Keeping `t0_K` first means **every existing sweep store renders exactly as before** — only stores with no `t0_K` change.

**Y default** gets the mirror rule: prefer an output. Without it, a second input attr sorting ahead of the KPI would take the Y axis and the KPI would go unplotted — the same class of bug, one axis over.

Both reuse the existing `inputKeyParts` helper, which is already the single source of truth for input/output provenance in this file (it backs the `(…, input)` / `(…, output)` labels).

Also adds a `data-testid` to the X select so the choice is assertable.

## Tests

Three tests in the existing `SweepResultsPlot.test.tsx`:

- the swept input lands on X and the KPI on Y — including asserting the plotted `x`/`y` arrays, not just the select value — using exactly the `carbon_yield` vs. `in.downstream.pressure` pair that sorts wrong
- `t0_K` still wins X when present (guards the no-regression claim above)
- a KPI stays on Y even when another input sorts ahead of it

**Verified these fail without the fix**: stashing the component change makes all 3 fail, restoring it makes them pass.

`SweepResultsPlot.test.tsx`: 12 passed. Full frontend unit suite: **239 passed, 31 files**. `tsc --noEmit` and `eslint` both clean.

Not verified in a running browser — the change is in frontend source and the served bundle is prebuilt, so seeing it live needs a `npm run build` + redeploy. The tests render the real component and assert the real plot data, and I confirmed the before/after behaviour through them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)