### PR TITLE
feat: cooperative Stop for a running simulation and a running sweep

### DIFF
--- a/boulder/api/routes/simulations.py
+++ b/boulder/api/routes/simulations.py
@@ -347,16 +347,22 @@ async def get_simulation_results(sim_id: str, cleanup: bool = False) -> Dict[str
 
 @router.delete("/{sim_id}")
 async def stop_simulation(sim_id: str) -> Dict[str, Any]:
-    """Stop a running simulation and remove it from memory."""
+    """Request that a running simulation stop.
+
+    Cooperative, not immediate: ``worker.stop_simulation()`` returns right
+    away without waiting for the solve thread to actually exit (it used to
+    block the request for up to 5 s). The registry entry is deliberately
+    *not* removed here -- the open SSE stream (or a late ``/results`` poll)
+    still needs to reach it to report the wind-down; it's reaped once the
+    thread has actually exited, by :func:`cleanup_completed_simulations`.
+    """
     entry = _simulations.get(sim_id)
     if entry is None:
         raise HTTPException(status_code=404, detail=f"Simulation {sim_id} not found")
 
     worker, _ = entry
     worker.stop_simulation()
-    # Remove the worker from the dictionary to free memory
-    del _simulations[sim_id]
-    return {"stopped": True, "simulation_id": sim_id}
+    return {"stopping": True, "simulation_id": sim_id}
 
 
 @router.post("/check-cache")
@@ -511,8 +517,12 @@ async def cleanup_completed_simulations(
 
     for sim_id, (worker, created_at) in _simulations.items():
         progress = worker.get_progress()
-        # Only clean up if completed or errored
-        if progress.is_complete or progress.error_message:
+        # Only clean up a simulation that has actually reached a terminal
+        # state: completed, errored, or stopped (is_stopping and no longer
+        # running -- not just "not running", which a worker whose thread
+        # hasn't started yet would also match).
+        stopped = progress.is_stopping and not progress.is_running
+        if progress.is_complete or progress.error_message or stopped:
             # Check age if specified
             if max_age_seconds is None or (current_time - created_at) > max_age_seconds:
                 to_remove.append(sim_id)

--- a/boulder/api/routes/sweep.py
+++ b/boulder/api/routes/sweep.py
@@ -17,7 +17,9 @@ store — are written to disk here, same as before.
 Endpoints (prefix ``/api/sweep``):
   GET  ""        -> availability / scenario count / can_run / running
   POST "/run"    -> start the sweep (409 if one is already running)
-  GET  "/status" -> current job status (idle | running | done | error)
+  POST "/stop"   -> request the running sweep stop (cooperative, non-blocking)
+  GET  "/status" -> current job status (idle | running | stopping | done |
+                    error | cancelled)
 """
 
 from __future__ import annotations
@@ -82,13 +84,18 @@ def _run_host_sweep(
     state: Dict[str, Any],
     store_dir: Path,
     config_path: Optional[str] = None,
+    stop_event: Optional[threading.Event] = None,
 ) -> None:
     """Resolve and call a ``sweep.runner`` callable, updating *state* around it.
 
     The callable owns the run-set: it decides the points, solves them and writes
     them into the result store. It may accept an optional ``progress`` callable
     — ``(done, total, message)`` — so a host that knows its point count can
-    drive the same status UI a declarative sweep does.
+    drive the same status UI a declarative sweep does. It may also accept
+    ``stop_event`` (a ``threading.Event``) to cooperate with Stop; a runner
+    that doesn't declare it simply can't be interrupted early -- "Stopping…"
+    then waits out the whole host sweep, same honesty as a single-stage
+    single run with no checkpoint of its own.
 
     .. versionchanged:: (store unification)
        The first argument is now the store **directory**, not a single HDF5
@@ -133,6 +140,8 @@ def _run_host_sweep(
         kwargs["progress"] = _progress
     if "config_path" in declared:
         kwargs["config_path"] = config_path
+    if "stop_event" in declared:
+        kwargs["stop_event"] = stop_event
 
     print(f"[sweep] delegating to host runner {dotted}", flush=True)
     runner(store_dir, **kwargs)
@@ -236,7 +245,7 @@ async def sweep_run(
         )
 
     job = getattr(request.app.state, "sweep_job", None)
-    if job and job.get("status") == "running":
+    if job and job.get("status") in ("running", "stopping"):
         raise HTTPException(status_code=409, detail="A sweep is already running")
 
     # The one place results live: the same directory `/api/scenarios` reads, so
@@ -267,6 +276,13 @@ async def sweep_run(
         "last_line": None,
     }
     request.app.state.sweep_job = state
+    # A fresh Event per launch, reachable from POST /stop (below) without
+    # living inside `state` -- GET /status returns `dict(job)` and must stay
+    # JSON-serialisable. Cooperative, not a subprocess handle: setting it is
+    # exactly the same primitive SimulationWorker.stop_simulation() uses, via
+    # `solve_scenario`'s `stop_event` param (see boulder.sweep_runner).
+    stop_event = threading.Event()
+    request.app.state.sweep_stop_event = stop_event
     print(f"[sweep] starting {total} run(s)", flush=True)
 
     def _worker() -> None:
@@ -290,7 +306,9 @@ async def sweep_run(
                 # writes the collection store itself; Boulder only resolves the
                 # callable and reports status. Runs in-process like every other
                 # sweep -- declaring the runner replaced *spawning* it.
-                _run_host_sweep(host_runner, state, store_dir, cfg_path)
+                _run_host_sweep(
+                    host_runner, state, store_dir, cfg_path, stop_event=stop_event
+                )
                 # The host owns the store's contents, including its root
                 # attrs, so skip Boulder's own finalisation -- but *not* the
                 # terminal bookkeeping, or the UI would poll "running" forever
@@ -330,6 +348,14 @@ async def sweep_run(
             # reference -- same trick `_default_resolve_mechanism` uses.
             resolve_mechanism = converter_cls.__new__(converter_cls).resolve_mechanism
             for i, (sid, cfg) in enumerate(runs):
+                if stop_event.is_set():
+                    # A stop was requested while the previous scenario was
+                    # in flight (or between scenarios) -- don't start
+                    # another one. The scenario that *was* solving raises
+                    # out of `solve_scenario` below and is handled there;
+                    # this only guards the ones that haven't started yet.
+                    break
+
                 config, mech_name, fingerprint = prepare_scenario(
                     cfg, resolve_mechanism
                 )
@@ -383,6 +409,7 @@ async def sweep_run(
                     mech_name,
                     converter_cls=converter_cls,
                     progress_cb=_publish,
+                    stop_event=stop_event,
                 )
                 # `conv.mechanism` is whatever bare name/spec the converter was
                 # constructed with -- resolving it (again) to a real, absolute
@@ -412,6 +439,8 @@ async def sweep_run(
                     warn=lambda msg: print(f"[sweep]{msg}", flush=True),
                 )
 
+            # run_ids is the full intended set regardless of how far the loop
+            # got, so pruning stays correct even for a stopped sweep.
             stale = scenario_store.prune_entries(store_dir, run_ids)
             if stale:
                 print(
@@ -423,15 +452,32 @@ async def sweep_run(
 
             state["scenario_progress"] = {}
             state["last_line"] = None
-            state["status"] = "done"
-            state["message"] = "Sweep complete"
-            print(f"[sweep] complete — {total} run(s)", flush=True)
+            if stop_event.is_set():
+                # The loop above broke on the stop check before starting the
+                # next scenario -- the in-flight one (if any) is handled by
+                # the except branch below, which raises out of solve_scenario.
+                state["status"] = "cancelled"
+                state["message"] = "Sweep stopped"
+                print("[sweep] cancelled", flush=True)
+            else:
+                state["status"] = "done"
+                state["message"] = "Sweep complete"
+                print(f"[sweep] complete — {total} run(s)", flush=True)
         except Exception as exc:  # noqa: BLE001
             state["scenario_progress"] = {}
             state["last_line"] = None
-            state["status"] = "error"
-            state["message"] = str(exc)
-            print(f"[sweep] FAILED: {exc}", flush=True)
+            if stop_event.is_set():
+                # solve_scenario raises RuntimeError when its own poll loop
+                # sees the stop flag (see boulder.sweep_runner) -- same
+                # exception shape as a genuine failure, distinguished here by
+                # whether *this* route asked for the stop.
+                state["status"] = "cancelled"
+                state["message"] = "Sweep stopped"
+                print("[sweep] cancelled", flush=True)
+            else:
+                state["status"] = "error"
+                state["message"] = str(exc)
+                print(f"[sweep] FAILED: {exc}", flush=True)
 
     def _worker_logging_to_status() -> None:
         # Live detail line for the "Calculating…" spinner: while this sweep
@@ -451,6 +497,28 @@ async def sweep_run(
 
     threading.Thread(target=_worker_logging_to_status, daemon=True).start()
     return {"status": "running", "total": total}
+
+
+@router.post("/stop")
+async def sweep_stop(request: Request) -> Dict[str, Any]:
+    """Request that the running sweep stop, without blocking.
+
+    Cooperative, same mechanism a single "Run Simulation" uses: setting
+    ``sweep_stop_event`` is instant, so this returns right away rather than
+    waiting for the in-flight scenario (or, for a host ``sweep.runner`` that
+    doesn't declare a ``stop_event`` parameter, the whole sweep) to actually
+    stop. The job's ``status`` becomes ``"cancelled"`` once it does -- poll
+    ``GET /status``, the same way completion is already observed.
+    """
+    job = getattr(request.app.state, "sweep_job", None)
+    if not job or job.get("status") != "running":
+        raise HTTPException(status_code=404, detail="No sweep is currently running")
+
+    job["status"] = "stopping"
+    stop_event = getattr(request.app.state, "sweep_stop_event", None)
+    if stop_event is not None:
+        stop_event.set()
+    return {"stopping": True}
 
 
 @router.get("/status")

--- a/boulder/api/sse.py
+++ b/boulder/api/sse.py
@@ -38,6 +38,7 @@ async def simulation_event_stream(
         snapshot: Dict[str, Any] = {
             "is_running": progress.is_running,
             "is_complete": progress.is_complete,
+            "is_stopping": progress.is_stopping,
             "error_message": progress.error_message,
             "stages_done": progress.stages_done,
             "n_stages": progress.n_stages,
@@ -48,6 +49,15 @@ async def simulation_event_stream(
             "connection_reports": progress.connection_reports.copy(),
             "total_time": progress.total_time,
         }
+
+        # A stopped run: is_stopping was set by stop_simulation() and the
+        # solve thread has since exited without completing or erroring.
+        # Checked before the error/complete branches below since without a
+        # terminal event of its own here, this state matches neither of
+        # them and the loop would otherwise poll "progress" forever.
+        if progress.is_stopping and not progress.is_running:
+            yield _sse_event("stopped", snapshot)
+            return
 
         if progress.error_message and not progress.is_running:
             yield _sse_event("error", {"message": progress.error_message})

--- a/boulder/cantera_converter.py
+++ b/boulder/cantera_converter.py
@@ -29,7 +29,7 @@ from .reactor_energy import (
 )
 from .sankey import generate_sankey_input_from_sim, sankey_links_for_api
 from .spatial_inference import try_infer_spatial_reactor_series
-from .staged_solver import _order_stage_nodes_for_flow
+from .staged_solver import SolveCancelled, _order_stage_nodes_for_flow
 from .verbose_utils import get_verbose_logger, is_verbose_mode
 
 logger = get_verbose_logger(__name__)
@@ -1980,7 +1980,10 @@ class DualCanteraConverter:
                 times = [float(t) for t in np.arange(start + dt, stop + dt / 2, dt)]
             else:
                 times = [float(t) for t in grid_spec]
+            cancel_token = getattr(self, "cancel_token", None)
             for t in times:
+                if cancel_token is not None and cancel_token.is_set():
+                    raise SolveCancelled(f"cancelled during stage '{stage_id}'")
                 network.advance(float(t))
                 if _scope_recorder is not None:
                     _scope_recorder.record(float(t), axis=axis)
@@ -1990,7 +1993,10 @@ class DualCanteraConverter:
             max_dt = float(solver.get("max_dt", chunk_dt / 10))
             reinit = bool(solver.get("reinitialize_between_chunks", False))
             t = float(solver.get("start", 0.0))
+            cancel_token = getattr(self, "cancel_token", None)
             while t < t_total:
+                if cancel_token is not None and cancel_token.is_set():
+                    raise SolveCancelled(f"cancelled during stage '{stage_id}'")
                 t_end = min(t + chunk_dt, t_total)
                 # Fire any schedule callbacks before each chunk, then
                 # reinitialize *immediately* -- CVODES caches the RHS's

--- a/boulder/simulation_worker.py
+++ b/boulder/simulation_worker.py
@@ -205,6 +205,11 @@ class SimulationProgress:
     is_running: bool = False
     is_complete: bool = False
     error_message: Optional[str] = None
+    #: A stop has been requested (``stop_simulation()`` was called) but the
+    #: worker thread hasn't exited yet -- cooperative, so it can lag behind
+    #: the request by up to one stage. "Stopped" (as opposed to "stopping")
+    #: is derived, not tracked separately: ``is_stopping and not is_running``.
+    is_stopping: bool = False
 
     # Timing information
     start_time: Optional[float] = None
@@ -294,16 +299,23 @@ class SimulationWorker:
         logger.info("Background simulation started")
 
     def stop_simulation(self) -> None:
-        """Stop the current simulation."""
-        self._stop_event.set()
-        if self._worker_thread:
-            self._worker_thread.join(timeout=5.0)
-            if self._worker_thread.is_alive():
-                logger.warning("Worker thread did not stop gracefully")
+        """Request that the current simulation stop, without blocking.
 
+        Cooperative, not immediate: it sets the flag ``_run_simulation``'s
+        cancellation checkpoints (via ``cancel_token``) and its own finalize
+        guard check, then returns right away. The caller learns the worker
+        thread actually exited from ``is_running`` turning ``False`` in a
+        later :meth:`get_progress` poll -- never by blocking here, which used
+        to stall the FastAPI event loop for up to 5 s per stop request.
+        """
+        self._stop_event.set()
         with self._lock:
-            self.progress.is_running = False
-        logger.info("Simulation stopped")
+            # Only meaningful for a run that's actually in flight -- guards
+            # against a late/duplicate stop request marking an already
+            # finished (or already-stopped) run as "stopping" again.
+            if self.progress.is_running:
+                self.progress.is_stopping = True
+        logger.info("Simulation stop requested")
 
     def get_progress(self) -> SimulationProgress:
         """Get current simulation progress (thread-safe copy)."""
@@ -337,6 +349,7 @@ class SimulationWorker:
                 is_running=self.progress.is_running,
                 is_complete=self.progress.is_complete,
                 error_message=self.progress.error_message,
+                is_stopping=self.progress.is_stopping,
                 start_time=self.progress.start_time,
                 end_time=self.progress.end_time,
                 total_time=self.progress.total_time,
@@ -386,6 +399,13 @@ class SimulationWorker:
                     self.progress.stages_done = n_done
                     self.progress.n_stages = n_total
                     self.progress.completed_stage_ids.append(stage_id)
+
+            # Cooperative-cancellation token: staged_solver/cantera_converter
+            # check this at each stage/transient-step boundary and raise
+            # SolveCancelled if it's set. An attribute, not a build_network
+            # kwarg, so a host converter subclass that overrides build_network
+            # doesn't need to know about it to keep working.
+            converter.cancel_token = self._stop_event
 
             # Build the network first
             network = converter.build_network(
@@ -480,6 +500,26 @@ class SimulationWorker:
                 config=config,
             )
 
+            # Finalize results -- skipped entirely if a stop was requested,
+            # checked once here regardless of whether a SolveCancelled
+            # checkpoint actually fired. A single-stage steady solve has no
+            # checkpoint before this point (see staged_solver.py), so without
+            # this explicit check a stop would silently do nothing for that
+            # common case: the solve would run to completion and this whole
+            # block -- the cache write and is_complete=True -- would fire
+            # anyway. Also covers a SolveCancelled that *did* fire mid-stage
+            # and unwound straight past this point into the except block below.
+            if self._stop_event.is_set():
+                with self._lock:
+                    self.progress.is_running = False
+                    # Set unconditionally here too (not just by
+                    # stop_simulation()): that call and the background thread
+                    # reaching this point race, so is_stopping could otherwise
+                    # still read False for a run that very much did stop.
+                    self.progress.is_stopping = True
+                logger.info("Simulation stopped before finalizing results")
+                return
+
             # Finalize results
             logger.info(f"Simulation completed: {len(results['time'])} time points")
             reactor_reports = generate_reactor_reports(converter, results)
@@ -520,6 +560,17 @@ class SimulationWorker:
                     self.progress.error_message = results.get("error_message")
 
         except Exception as e:
+            if self._stop_event.is_set():
+                # A cancellation checkpoint raised SolveCancelled (or some
+                # other exception surfaced while a stop was in flight) --
+                # either way this is an intentional stop, not a failure: no
+                # error_message, no is_complete.
+                logger.info("Simulation stopped: %s", e)
+                with self._lock:
+                    self.progress.is_running = False
+                    self.progress.is_stopping = True
+                    self.progress.end_time = time.time()
+                return
             logger.error(f"Simulation failed: {e}", exc_info=True)
             with self._lock:
                 self.progress.error_message = str(e)

--- a/boulder/staged_solver.py
+++ b/boulder/staged_solver.py
@@ -533,6 +533,16 @@ def alias_inter_connection_mfcs(
 # ---------------------------------------------------------------------------
 
 
+class SolveCancelled(Exception):
+    """Raised to unwind a staged solve when a stop was requested mid-run.
+
+    Checked cooperatively — Cantera's own solver calls cannot be interrupted,
+    so this can only take effect at a stage boundary (or, for transient runs,
+    inside the per-step loops in :mod:`boulder.cantera_converter`) rather than
+    immediately.
+    """
+
+
 def solve_staged(
     converter: "DualCanteraConverter",
     plan: StageExecutionPlan,
@@ -609,7 +619,12 @@ def solve_staged(
 
     n_stages = len(plan.ordered_stages)
 
+    cancel_token = getattr(converter, "cancel_token", None)
+
     for stage_idx, stage in enumerate(plan.ordered_stages):
+        if cancel_token is not None and cancel_token.is_set():
+            raise SolveCancelled(f"cancelled before stage '{stage.id}'")
+
         logger.info(
             "Staged solve: stage '%s' (%d/%d, %d reactors)",
             stage.id,

--- a/boulder/sweep_runner.py
+++ b/boulder/sweep_runner.py
@@ -36,6 +36,7 @@ from __future__ import annotations
 import argparse
 import copy
 import os
+import threading
 import time
 from pathlib import Path
 from typing import Any, Callable, Dict, Optional, Tuple, Type
@@ -169,6 +170,7 @@ def solve_scenario(
     converter_cls: Optional[Type[Any]] = None,
     progress_cb: Optional[Callable[[Any], None]] = None,
     poll_interval: float = 0.05,
+    stop_event: Optional[threading.Event] = None,
 ) -> Tuple[Dict[str, Any], str, DualCanteraConverter]:
     """Solve one normalized scenario config → (gui_payload, mechanism, converter).
 
@@ -198,6 +200,13 @@ def solve_scenario(
     passes nothing. The solved ``converter`` is returned (not discarded) so
     callers can build a :class:`~boulder.simulation_result.SimulationResult`
     from it or hand it to cache contributors — see :func:`run`'s ``on_solved``.
+
+    ``stop_event``, when set mid-poll, requests that this scenario's solve
+    stop -- the same :class:`~boulder.simulation_worker.SimulationWorker`
+    cooperative-cancellation mechanism a plain "Run Simulation" uses (see
+    ``SimulationWorker.stop_simulation``), not a second cancellation design.
+    Raises, same as a genuine solve failure: the caller (the GUI sweep route)
+    distinguishes the two by checking whether it itself requested the stop.
     """
     from .simulation_worker import SimulationWorker  # noqa: PLC0415 — cycle
 
@@ -213,6 +222,9 @@ def solve_scenario(
         progress = worker.get_progress()
         if progress_cb is not None:
             progress_cb(progress)
+        if stop_event is not None and stop_event.is_set():
+            worker.stop_simulation()
+            break
         if progress.is_complete or progress.error_message:
             break
         time.sleep(poll_interval)

--- a/frontend/src/api/simulations.ts
+++ b/frontend/src/api/simulations.ts
@@ -24,8 +24,14 @@ export function fetchSimulationResults(simId: string) {
   return apiFetch<SimulationResults>(`/simulations/${simId}/results`);
 }
 
+/**
+ * Request that a running simulation stop. Cooperative, not immediate: the
+ * request returns right away; the actual wind-down is observed via the SSE
+ * stream's "stopped" event (see useSimulationSSE.ts).
+ */
 export function stopSimulation(simId: string) {
-  return apiFetch<{ stopped: boolean }>(`/simulations/${simId}`, {
-    method: "DELETE",
-  });
+  return apiFetch<{ stopping: boolean; simulation_id: string }>(
+    `/simulations/${simId}`,
+    { method: "DELETE" },
+  );
 }

--- a/frontend/src/api/sweep.ts
+++ b/frontend/src/api/sweep.ts
@@ -14,7 +14,7 @@ export interface SweepInfo {
 }
 
 export interface SweepStatus {
-  status: "idle" | "running" | "done" | "error";
+  status: "idle" | "running" | "stopping" | "cancelled" | "done" | "error";
   current?: number;
   total?: number;
   message?: string;
@@ -65,4 +65,13 @@ export function startSweep(options?: {
 /** Poll the running/last sweep job's status. */
 export function getSweepStatus() {
   return apiFetch<SweepStatus>("/sweep/status");
+}
+
+/**
+ * Request that the running sweep stop. Cooperative, not immediate: returns
+ * right away; the job's status becomes "cancelled" once the in-flight
+ * scenario actually stops — observed via the existing status poll.
+ */
+export function stopSweep() {
+  return apiFetch<{ stopping: boolean }>("/sweep/stop", { method: "POST" });
 }

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -160,7 +160,12 @@ export function AppShell() {
 
   // Keyboard shortcut: Ctrl+Enter
   const handleRunSimulation = useCallback(async () => {
-    if (isRunning || config.nodes.length === 0) return;
+    // `sweeping`: a plain run and a sweep share the same solve path and must
+    // not overlap (see SimulateCard.tsx's runDisabled for the click-path
+    // equivalent of this guard).
+    if (isRunning || useSweepRunStore.getState().sweeping || config.nodes.length === 0) {
+      return;
+    }
     beginSimulationRun();
     try {
       const resp = await startSimulation(config);
@@ -172,7 +177,9 @@ export function AppShell() {
     }
   }, [isRunning, config, beginSimulationRun, setStarted, setError]);
 
-  // Ctrl+Enter runs the simulation from anywhere in the app.
+  // Ctrl+Enter runs the simulation from anywhere in the app. Deliberately
+  // stays a no-op while busy rather than becoming a stop shortcut — too easy
+  // to fire by reflex; Stop is a click-only action (see RunControl.tsx).
   useEffect(() => {
     function handler(e: KeyboardEvent) {
       if (e.ctrlKey && e.key === "Enter") {

--- a/frontend/src/components/panels/RunControl.test.tsx
+++ b/frontend/src/components/panels/RunControl.test.tsx
@@ -3,10 +3,11 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { RunControl } from "./RunControl";
 import { useSweepRunStore } from "@/stores/sweepStore";
+import { useSimulationStore } from "@/stores/simulationStore";
 
 const mockGetSweepInfo = vi
   .fn()
@@ -44,13 +45,19 @@ vi.mock("@/stores/scenarioStore", () => {
 
 describe("RunControl", () => {
   const onRunSimulation = vi.fn();
+  const onStopSimulation = vi.fn();
 
   beforeEach(() => {
     vi.clearAllMocks();
     mockGetSweepInfo.mockResolvedValue({ can_run: false, reason: "No sweep" });
     mockScenarioRevision = 0;
     mockAuthoredIdsLength = 0;
-    useSweepRunStore.setState({ sweeping: false, progress: { current: 0, total: 0 } });
+    useSweepRunStore.setState({
+      sweeping: false,
+      stopping: false,
+      progress: { current: 0, total: 0 },
+    });
+    useSimulationStore.setState({ isRunning: false, progress: null });
   });
 
   afterEach(() => {
@@ -61,6 +68,7 @@ describe("RunControl", () => {
     render(
       <RunControl
         onRunSimulation={onRunSimulation}
+        onStopSimulation={onStopSimulation}
         isRunning={false}
         runDisabled={false}
       />,
@@ -79,6 +87,7 @@ describe("RunControl", () => {
     render(
       <RunControl
         onRunSimulation={onRunSimulation}
+        onStopSimulation={onStopSimulation}
         isRunning={false}
         runDisabled={false}
       />,
@@ -96,6 +105,7 @@ describe("RunControl", () => {
     render(
       <RunControl
         onRunSimulation={onRunSimulation}
+        onStopSimulation={onStopSimulation}
         isRunning={false}
         runDisabled={false}
       />,
@@ -109,6 +119,7 @@ describe("RunControl", () => {
     render(
       <RunControl
         onRunSimulation={onRunSimulation}
+        onStopSimulation={onStopSimulation}
         isRunning={false}
         runDisabled={false}
       />,
@@ -128,6 +139,7 @@ describe("RunControl", () => {
     render(
       <RunControl
         onRunSimulation={onRunSimulation}
+        onStopSimulation={onStopSimulation}
         isRunning={false}
         runDisabled={false}
       />,
@@ -150,7 +162,7 @@ describe("RunControl", () => {
       reason: "Run 2 scenarios",
     });
     render(
-      <RunControl onRunSimulation={onRunSimulation} isRunning={false} runDisabled={false} />,
+      <RunControl onRunSimulation={onRunSimulation} onStopSimulation={onStopSimulation} isRunning={false} runDisabled={false} />,
     );
     await waitFor(() => expect(mockGetSweepInfo).toHaveBeenCalled());
 
@@ -180,7 +192,7 @@ describe("RunControl", () => {
     mockGetSweepInfo.mockResolvedValue({ can_run: false, reason: "No sweep" });
     mockAuthoredIdsLength = 2; // BASELINE + one session-created scenario
     render(
-      <RunControl onRunSimulation={onRunSimulation} isRunning={false} runDisabled={false} />,
+      <RunControl onRunSimulation={onRunSimulation} onStopSimulation={onStopSimulation} isRunning={false} runDisabled={false} />,
     );
     await waitFor(() => expect(mockGetSweepInfo).toHaveBeenCalled());
 
@@ -190,16 +202,168 @@ describe("RunControl", () => {
 
   it("re-fetches sweep info when a scenario is added/edited/renamed/deleted elsewhere", async () => {
     const { rerender } = render(
-      <RunControl onRunSimulation={onRunSimulation} isRunning={false} runDisabled={false} />,
+      <RunControl onRunSimulation={onRunSimulation} onStopSimulation={onStopSimulation} isRunning={false} runDisabled={false} />,
     );
     await waitFor(() => expect(mockGetSweepInfo).toHaveBeenCalledOnce());
 
     mockGetSweepInfo.mockResolvedValue({ can_run: true, n_scenarios: 3, reason: "Run 3 scenarios" });
     mockScenarioRevision += 1;
     rerender(
-      <RunControl onRunSimulation={onRunSimulation} isRunning={false} runDisabled={false} />,
+      <RunControl onRunSimulation={onRunSimulation} onStopSimulation={onStopSimulation} isRunning={false} runDisabled={false} />,
     );
 
     await waitFor(() => expect(mockGetSweepInfo).toHaveBeenCalledTimes(2));
+  });
+
+  describe("Stop / Stopping", () => {
+    it("shows Stop Simulation (destructive) while a single run is active", () => {
+      useSimulationStore.setState({ isRunning: true, progress: null });
+      render(
+        <RunControl
+          onRunSimulation={onRunSimulation}
+          onStopSimulation={onStopSimulation}
+          isRunning={true}
+          runDisabled={true}
+        />,
+      );
+
+      const button = screen.getByRole("button", { name: "Stop Simulation" });
+      expect(button).not.toBeDisabled();
+    });
+
+    it("clicking Stop Simulation while running calls onStopSimulation, not onRunSimulation", () => {
+      useSimulationStore.setState({ isRunning: true, progress: null });
+      render(
+        <RunControl
+          onRunSimulation={onRunSimulation}
+          onStopSimulation={onStopSimulation}
+          isRunning={true}
+          runDisabled={true}
+        />,
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: "Stop Simulation" }));
+
+      expect(onStopSimulation).toHaveBeenCalledOnce();
+      expect(onRunSimulation).not.toHaveBeenCalled();
+    });
+
+    it("shows a disabled Stopping Simulation… once is_stopping is set, with a checkpoint tooltip", () => {
+      useSimulationStore.setState({
+        isRunning: true,
+        // @ts-expect-error -- partial SimulationProgress is fine for this test
+        progress: { is_stopping: true },
+      });
+      render(
+        <RunControl
+          onRunSimulation={onRunSimulation}
+          onStopSimulation={onStopSimulation}
+          isRunning={true}
+          runDisabled={true}
+        />,
+      );
+
+      const button = screen.getByRole("button", { name: "Stopping Simulation…" });
+      expect(button).toBeDisabled();
+      expect(button).toHaveAttribute("title", "Will stop at the next checkpoint");
+    });
+
+    it("regression: disables the primary button while stopping even if the caller's runDisabled prop is false", () => {
+      // RunControl must not rely on the caller to compute this correctly --
+      // is_stopping alone must be enough to keep the button inert.
+      useSimulationStore.setState({
+        isRunning: true,
+        // @ts-expect-error -- partial SimulationProgress is fine for this test
+        progress: { is_stopping: true },
+      });
+      render(
+        <RunControl
+          onRunSimulation={onRunSimulation}
+          onStopSimulation={onStopSimulation}
+          isRunning={true}
+          runDisabled={false}
+        />,
+      );
+
+      expect(screen.getByRole("button", { name: "Stopping Simulation…" })).toBeDisabled();
+    });
+
+    // The caret (used to switch to "Run Sweep" mode) is disabled once
+    // `sweeping` is true, so each test below selects sweep mode first --
+    // while idle -- and only then mutates the store to simulate the sweep
+    // having started; RunControl's own `runMode` state stays "sweep" across
+    // that later store update, no further menu interaction needed.
+    async function renderInSweepMode() {
+      mockGetSweepInfo.mockResolvedValue({
+        can_run: true,
+        n_scenarios: 3,
+        reason: "Run 3 scenarios",
+      });
+      render(
+        <RunControl
+          onRunSimulation={onRunSimulation}
+          onStopSimulation={onStopSimulation}
+          isRunning={false}
+          runDisabled={false}
+        />,
+      );
+      await waitFor(() => expect(mockGetSweepInfo).toHaveBeenCalled());
+      fireEvent.click(screen.getByLabelText("Choose run action"));
+      // getSweepInfo resolves asynchronously -- `canSweep` (and so the menu
+      // item's disabled state) may not have caught up yet even though the
+      // call itself already happened; a click on a still-disabled item is a
+      // silent no-op, so wait for it to actually be enabled first.
+      await waitFor(() =>
+        expect(screen.getByRole("menuitemradio", { name: /run sweep/i })).not.toBeDisabled(),
+      );
+      fireEvent.click(screen.getByRole("menuitemradio", { name: /run sweep/i }));
+      await waitFor(() =>
+        expect(screen.getByRole("button", { name: "Run Sweep (3 scenarios)" })).toBeInTheDocument(),
+      );
+    }
+
+    it("shows Stop Sweep (n/total) while a sweep is running", async () => {
+      await renderInSweepMode();
+      act(() => {
+        useSweepRunStore.setState({
+          sweeping: true,
+          stopping: false,
+          progress: { current: 1, total: 3 },
+        });
+      });
+
+      expect(screen.getByRole("button", { name: "Stop Sweep (1/3)" })).not.toBeDisabled();
+    });
+
+    it("clicking Stop Sweep calls the sweep store's stop(), not onRunSimulation", async () => {
+      await renderInSweepMode();
+      const mockStop = vi.fn();
+      act(() => {
+        useSweepRunStore.setState({
+          sweeping: true,
+          stopping: false,
+          progress: { current: 1, total: 3 },
+          stop: mockStop,
+        });
+      });
+
+      fireEvent.click(screen.getByRole("button", { name: "Stop Sweep (1/3)" }));
+
+      expect(mockStop).toHaveBeenCalledOnce();
+      expect(onRunSimulation).not.toHaveBeenCalled();
+    });
+
+    it("shows a disabled Stopping Sweep… once the sweep store reports stopping", async () => {
+      await renderInSweepMode();
+      act(() => {
+        useSweepRunStore.setState({
+          sweeping: true,
+          stopping: true,
+          progress: { current: 1, total: 3 },
+        });
+      });
+
+      expect(screen.getByRole("button", { name: "Stopping Sweep…" })).toBeDisabled();
+    });
   });
 });

--- a/frontend/src/components/panels/RunControl.tsx
+++ b/frontend/src/components/panels/RunControl.tsx
@@ -7,12 +7,15 @@ import { useScenarioStore } from "@/stores/scenarioStore";
 import { useSweepRunStore } from "@/stores/sweepStore";
 import { useLayoutStore } from "@/stores/layoutStore";
 import { useShortcutNudge } from "@/hooks/useShortcutNudge";
+import { useSimulationRunPhase, useSweepRunPhase } from "@/hooks/useRunStatus";
 import { AddScenarioModal } from "@/components/modals/AddScenarioModal";
 
 type RunMode = "sim" | "force_sim" | "sweep";
 
 interface RunControlProps {
   onRunSimulation: (force?: boolean) => void;
+  /** Request that the in-flight single run stop (see api/simulations.ts's stopSimulation). */
+  onStopSimulation: () => void;
   isRunning: boolean;
   runDisabled: boolean;
 }
@@ -24,7 +27,12 @@ interface RunControlProps {
  * is shown in the menu and on the button). Running a sweep streams progress and
  * refreshes the Scenario Pane on completion.
  */
-export function RunControl({ onRunSimulation, isRunning, runDisabled }: RunControlProps) {
+export function RunControl({
+  onRunSimulation,
+  onStopSimulation,
+  isRunning,
+  runDisabled,
+}: RunControlProps) {
   const [runMode, setRunMode] = useState<RunMode>("sim");
   const [menuOpen, setMenuOpen] = useState(false);
   // The menu portals to `document.body` (see below) so the sidebar's
@@ -36,6 +44,9 @@ export function RunControl({ onRunSimulation, isRunning, runDisabled }: RunContr
   const sweeping = useSweepRunStore((s) => s.sweeping);
   const progress = useSweepRunStore((s) => s.progress);
   const runSweepJob = useSweepRunStore((s) => s.run);
+  const stopSweepJob = useSweepRunStore((s) => s.stop);
+  const simPhase = useSimulationRunPhase();
+  const sweepPhase = useSweepRunPhase();
   const appliedDefault = useRef(false);
   const appliedAutorun = useRef(false);
   const scenarioRevision = useScenarioStore((s) => s.revision);
@@ -139,24 +150,52 @@ export function RunControl({ onRunSimulation, isRunning, runDisabled }: RunContr
     onRunSimulation,
   ]);
 
+  // Which phase governs the primary button depends on which action it
+  // currently performs -- "sweep" mode tracks the sweep job, "sim"/
+  // "force_sim" track the plain single-run store, regardless of which one
+  // is actually in flight (the two are mutually exclusive by the disabled
+  // guards below).
+  const phase = effectiveMode === "sweep" ? sweepPhase : simPhase;
+
   const primaryLabel =
     effectiveMode === "sweep"
-      ? sweeping
-        ? `Sweeping… ${progress.current}/${progress.total}`
-        : `Run Sweep (${nScenarios} scenarios)`
-      : effectiveMode === "force_sim"
-        ? isRunning
-          ? "Running…"
-          : "Force Run"
-        : isRunning
-          ? "Running…"
-          : "Run Simulation (Ctrl+Enter)";
+      ? phase === "idle"
+        ? `Run Sweep (${nScenarios} scenarios)`
+        : phase === "stopping"
+          ? "Stopping Sweep…"
+          : `Stop Sweep (${progress.current}/${progress.total})`
+      : phase === "idle"
+        ? effectiveMode === "force_sim"
+          ? "Force Run"
+          : "Run Simulation (Ctrl+Enter)"
+        : phase === "stopping"
+          ? "Stopping Simulation…"
+          : "Stop Simulation";
+
+  // Stopping is cooperative and can only take effect at the next checkpoint
+  // (a stage boundary for a single run, a scenario boundary for a sweep) --
+  // this doesn't change the disabled state (the button already shows
+  // "Stopping…" and is inert), it just explains the wait instead of letting
+  // it read as a hang.
+  const primaryTitle = phase === "stopping" ? "Will stop at the next checkpoint" : undefined;
 
   const primaryDisabled =
-    effectiveMode === "sweep" ? sweeping || isRunning || !canSweep : runDisabled;
-  const variant = primaryDisabled ? "muted" : "success";
+    phase === "stopping"
+      ? true
+      : phase === "running"
+        ? false
+        : effectiveMode === "sweep"
+          ? sweeping || isRunning || !canSweep
+          : runDisabled;
+  const variant =
+    phase === "stopping" ? "warning" : phase === "running" ? "destructive" : primaryDisabled ? "muted" : "success";
 
   const onPrimary = () => {
+    if (phase === "running") {
+      if (effectiveMode === "sweep") stopSweepJob();
+      else onStopSimulation();
+      return;
+    }
     if (effectiveMode === "sweep") handleRunSweep();
     else {
       // Ctrl+Enter (see AppShell's keydown handler) always runs the plain
@@ -174,6 +213,7 @@ export function RunControl({ onRunSimulation, isRunning, runDisabled }: RunContr
           id="run-primary"
           onClick={onPrimary}
           disabled={primaryDisabled}
+          title={primaryTitle}
           variant={variant}
           className="flex-1 rounded-r-none"
         >

--- a/frontend/src/components/panels/SimulateCard.test.tsx
+++ b/frontend/src/components/panels/SimulateCard.test.tsx
@@ -17,6 +17,7 @@ import { render, screen, fireEvent, act } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { SimulateCard } from "./SimulateCard";
 import { useSolverStore } from "@/stores/solverStore";
+import { useSweepRunStore } from "@/stores/sweepStore";
 
 // ---------------------------------------------------------------------------
 // Mock dependencies that reach out to the network or zustand stores
@@ -34,8 +35,14 @@ vi.mock("@/api/guiActions", () => ({
 }));
 
 vi.mock("@/api/resultCache", () => ({
+  // Not cached by default, so the Run-button tests exercise the real
+  // startSimulation path rather than the early-return cache hit. Previously
+  // this resolved `cached: true` unconditionally, and the tests only passed
+  // because the old useSimulationStore mock omitted `setResults` -- calling
+  // it in the cache-hit branch threw, was swallowed by handleRun's own
+  // try/catch, and fell through to startSimulation by accident.
   checkSimulationCache: vi.fn().mockResolvedValue({
-    cached: true,
+    cached: false,
     result: { time: [0], reactors: {} },
     meta: { created_at: Date.now() / 1000 },
   }),
@@ -82,16 +89,28 @@ vi.mock("@/stores/configStore", () => {
   return { useConfigStore };
 });
 
-vi.mock("@/stores/simulationStore", () => ({
-  useSimulationStore: () => ({
+vi.mock("@/stores/simulationStore", () => {
+  // Mirrors zustand's real call shape: `useSimulationStore()` (no selector,
+  // used by SimulateCard's own destructuring) and `useSimulationStore(sel)`
+  // (used by RunControl's useRunStatus hook, via useSimulationRunPhase) must
+  // both work — a mock that ignored the selector previously returned this
+  // whole (truthy) object for `progress?.is_stopping`, always reading as
+  // "stopping".
+  const state = {
     isRunning: false,
     simulationId: null,
+    progress: null,
     pythonCode: "",
     beginSimulationRun: vi.fn(),
     startSimulation: vi.fn(),
     setError: vi.fn(),
-  }),
-}));
+    setResults: vi.fn(),
+    stopped: vi.fn(),
+  };
+  const useSimulationStore = (selector?: (s: typeof state) => unknown) =>
+    selector ? selector(state) : state;
+  return { useSimulationStore };
+});
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -107,6 +126,7 @@ describe("SimulateCard", () => {
       simTime: "10",
       timeStep: "1",
     });
+    useSweepRunStore.setState({ sweeping: false });
   });
 
   it("Run button calls startSimulation without time/step in steady mode", async () => {
@@ -221,5 +241,17 @@ describe("SimulateCard", () => {
     });
 
     expect(toast.loading).not.toHaveBeenCalled();
+  });
+
+  it("regression: disables the Run button while a sweep is running", () => {
+    // A plain run and a sweep share the same backend solve path and must
+    // not overlap -- runDisabled previously only checked isRunning, so a
+    // sweep in progress didn't stop a second, conflicting solve from being
+    // launched on top of it.
+    mockConfig = { nodes: [{ id: "r1", type: "IdealGasReactor", properties: {} }], connections: [] };
+    useSweepRunStore.setState({ sweeping: true });
+    render(<SimulateCard />);
+
+    expect(screen.getByRole("button", { name: /run simulation/i })).toBeDisabled();
   });
 });

--- a/frontend/src/components/panels/SimulateCard.tsx
+++ b/frontend/src/components/panels/SimulateCard.tsx
@@ -4,8 +4,9 @@ import { useConfigStore } from "@/stores/configStore";
 import { useSimulationStore } from "@/stores/simulationStore";
 import { useSolverStore } from "@/stores/solverStore";
 import { useScenarioStore } from "@/stores/scenarioStore";
+import { useSweepRunStore } from "@/stores/sweepStore";
 import { fetchGuiActions, runGuiAction } from "@/api/guiActions";
-import { startSimulation } from "@/api/simulations";
+import { startSimulation, stopSimulation } from "@/api/simulations";
 import { checkSimulationCache } from "@/api/resultCache";
 import { getSweepInfo } from "@/api/sweep";
 import { Button } from "@/components/ui/Button";
@@ -49,6 +50,7 @@ export function SimulateCard() {
     setError,
     setResults,
   } = useSimulationStore();
+  const sweeping = useSweepRunStore((s) => s.sweeping);
 
   // Steady/Transient mode and its tolerances are edited from the Stage panel
   // (StageCard) — this card only needs to read them to run a simulation.
@@ -168,6 +170,14 @@ export function SimulateCard() {
     }
   }, [config, simTime, timeStep, sendTimeOverride, beginSimulationRun, setStarted, setError, setResults]);
 
+  const handleStop = useCallback(() => {
+    if (!simulationId) return;
+    stopSimulation(simulationId).catch((err) => {
+      const msg = err instanceof Error ? err.message : String(err);
+      toast.error(`Failed to stop: ${msg}`);
+    });
+  }, [simulationId]);
+
   const handleDownloadPy = useCallback(() => {
     if (!pythonCode) return;
     const blob = new Blob([pythonCode], { type: "text/x-python" });
@@ -235,7 +245,9 @@ export function SimulateCard() {
     [config, fileName, simulationId, syncYaml],
   );
 
-  const runDisabled = isRunning || config.nodes.length === 0;
+  // `sweeping` guards against launching a plain run on top of a running
+  // sweep — the two share the same backend solve path and must not overlap.
+  const runDisabled = isRunning || sweeping || config.nodes.length === 0;
 
   return (
     <div className="rounded-lg border border-border bg-card p-4 space-y-3">
@@ -243,6 +255,7 @@ export function SimulateCard() {
 
       <RunControl
         onRunSimulation={handleRun}
+        onStopSimulation={handleStop}
         isRunning={isRunning}
         runDisabled={runDisabled}
       />

--- a/frontend/src/components/results/CalculatingCardShell.tsx
+++ b/frontend/src/components/results/CalculatingCardShell.tsx
@@ -10,22 +10,31 @@ export function CalculatingCardShell({
   headline,
   detailLine,
   pct,
+  stopping,
 }: {
   headline: string;
   /** Latest console line or sub-step label shown under the headline. */
   detailLine?: string | null;
   /** Percent complete (0-100); omit to show a plain spinner with no bar. */
   pct?: number;
+  /** A stop was requested and this solve hasn't wound down yet — same amber
+   * used on the Stop button (RunControl.tsx) while it's disabled/"Stopping…". */
+  stopping?: boolean;
 }) {
+  const accent = stopping ? "border-amber-500" : "border-primary";
   return (
     <div className="rounded-lg border border-border bg-card p-6 text-center space-y-3">
-      <div className="animate-spin rounded-full h-8 w-8 border-4 border-primary border-t-transparent mx-auto" />
+      <div
+        className={`animate-spin rounded-full h-8 w-8 border-4 ${accent} border-t-transparent mx-auto`}
+      />
       <div className="space-y-1">
         <p className="text-foreground font-medium">{headline}</p>
         {pct != null && (
           <div className="w-full bg-muted rounded-full h-2">
             <div
-              className="bg-primary h-2 rounded-full transition-all duration-300"
+              className={`h-2 rounded-full transition-all duration-300 ${
+                stopping ? "bg-amber-500" : "bg-primary"
+              }`}
               style={{ width: `${pct}%` }}
             />
           </div>

--- a/frontend/src/components/results/ResultsTabs.tsx
+++ b/frontend/src/components/results/ResultsTabs.tsx
@@ -41,6 +41,7 @@ export function ResultsTabs() {
   const scenarioProgress = useSweepRunStore((s) => s.scenarioProgress);
   const sweepLastLine = useSweepRunStore((s) => s.lastLine);
   const sweepPinnedId = useSweepRunStore((s) => s.pinnedId);
+  const sweepStopping = useSweepRunStore((s) => s.stopping);
   const defaultResultsTab = results && hasSankeyData(results) ? "Sankey" : "Plots";
   /** Resolved tab for UI: explicit choice, else Sankey/Plots per available data. */
   const displayTab = activeTab ?? defaultResultsTab;
@@ -211,6 +212,7 @@ export function ResultsTabs() {
         scenarioId={followedId}
         stage={scenarioProgress[followedId]}
         lastLine={sweepLastLine}
+        stopping={sweepStopping}
       />
     );
   }

--- a/frontend/src/components/results/SimulationCalculatingCard.test.tsx
+++ b/frontend/src/components/results/SimulationCalculatingCard.test.tsx
@@ -53,4 +53,23 @@ describe("SimulationCalculatingCard", () => {
 
     expect(screen.getByText("Building")).toBeInTheDocument();
   });
+
+  it("shows a 'Stopping…' headline once is_stopping is set", () => {
+    mockIsRunning = true;
+    mockProgress = {
+      is_running: true,
+      is_complete: false,
+      is_stopping: true,
+      stages_done: 0,
+      n_stages: 1,
+      times: [],
+      total_time: 10,
+      reactors_series: {},
+    };
+
+    render(<SimulationCalculatingCard />);
+
+    expect(screen.getByText("Stopping simulation…")).toBeInTheDocument();
+    expect(screen.queryByText("Simulation running…")).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/results/SimulationCalculatingCard.tsx
+++ b/frontend/src/components/results/SimulationCalculatingCard.tsx
@@ -14,8 +14,14 @@ export function SimulationCalculatingCard() {
   if (!isRunning) return null;
 
   const { pct, label } = computeSimulationProgress(progress);
+  const stopping = progress?.is_stopping ?? false;
 
   return (
-    <CalculatingCardShell headline="Simulation running…" detailLine={label} pct={pct} />
+    <CalculatingCardShell
+      headline={stopping ? "Stopping simulation…" : "Simulation running…"}
+      detailLine={label}
+      pct={pct}
+      stopping={stopping}
+    />
   );
 }

--- a/frontend/src/components/results/SweepCalculatingCard.test.tsx
+++ b/frontend/src/components/results/SweepCalculatingCard.test.tsx
@@ -69,4 +69,17 @@ describe("SweepCalculatingCard", () => {
     // Only the headline paragraph — no empty second line taking up space.
     expect(container.querySelectorAll("p")).toHaveLength(1);
   });
+
+  it("shows a 'Stopping —' headline once stopping is set", () => {
+    render(
+      <SweepCalculatingCard
+        scenarioId="cold_feed"
+        stage={{ stage: 1, stageTotal: 3 }}
+        stopping
+      />,
+    );
+
+    expect(screen.getByText(/Stopping — "cold_feed"…/)).toBeInTheDocument();
+    expect(screen.queryByText(/Calculating "cold_feed"…/)).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/results/SweepCalculatingCard.tsx
+++ b/frontend/src/components/results/SweepCalculatingCard.tsx
@@ -9,6 +9,7 @@ export function SweepCalculatingCard({
   scenarioId,
   stage,
   lastLine,
+  stopping,
 }: {
   scenarioId: string;
   stage: { stage: number | null; stageTotal: number | null } | undefined;
@@ -18,6 +19,8 @@ export function SweepCalculatingCard({
    * line — the full stream is on the server console.
    */
   lastLine?: string | null;
+  /** A stop was requested and the sweep hasn't wound down yet (see sweepStore.ts). */
+  stopping?: boolean;
 }) {
   const stageLabel =
     stage?.stage != null && stage.stageTotal != null && stage.stageTotal > 1
@@ -26,8 +29,13 @@ export function SweepCalculatingCard({
 
   return (
     <CalculatingCardShell
-      headline={`Calculating "${scenarioId}"…${stageLabel}`}
+      headline={
+        stopping
+          ? `Stopping — "${scenarioId}"…${stageLabel}`
+          : `Calculating "${scenarioId}"…${stageLabel}`
+      }
       detailLine={lastLine}
+      stopping={stopping}
     />
   );
 }

--- a/frontend/src/components/ui/Button.tsx
+++ b/frontend/src/components/ui/Button.tsx
@@ -7,6 +7,7 @@ type ButtonVariant =
   | "secondary"
   | "destructive"
   | "success"
+  | "warning"
   | "muted"
   | "ghost"
   | "link"
@@ -27,6 +28,10 @@ const variantClasses: Record<ButtonVariant, string> = {
   secondary: "bg-secondary text-secondary-foreground hover:opacity-80",
   destructive: "bg-destructive text-destructive-foreground hover:opacity-90",
   success: "bg-green-600 text-white hover:bg-green-700 dark:bg-green-600 dark:hover:bg-green-700",
+  // "In progress and winding down" (e.g. Stopping…) — distinct from `muted`,
+  // which means "nothing to do right now"; collapsing the two would make an
+  // in-flight stop look identical to an inert button.
+  warning: "bg-amber-600 text-white hover:bg-amber-700 dark:bg-amber-600 dark:hover:bg-amber-700",
   muted:
     "border border-border bg-muted text-foreground hover:bg-accent hover:shadow-sm dark:hover:bg-white/10 dark:hover:border-white/20 dark:hover:shadow-md",
   ghost: "bg-transparent text-foreground hover:bg-accent",

--- a/frontend/src/hooks/useRunStatus.ts
+++ b/frontend/src/hooks/useRunStatus.ts
@@ -1,0 +1,27 @@
+import { useSimulationStore } from "@/stores/simulationStore";
+import { useSweepRunStore } from "@/stores/sweepStore";
+
+/**
+ * "stopping" is derived, not stored: both backends already carry it in the
+ * payload the client already polls/streams (`progress.is_stopping` for a
+ * single run, `SweepStatus.status === "stopping"` for a sweep — see
+ * sweepStore.ts's `stopping` field), so there is nothing here that could
+ * strand a stale flag on completion/error.
+ */
+export type RunPhase = "idle" | "running" | "stopping";
+
+/** Derive the run phase for a plain "Run Simulation". */
+export function useSimulationRunPhase(): RunPhase {
+  const isRunning = useSimulationStore((s) => s.isRunning);
+  const isStopping = useSimulationStore((s) => s.progress?.is_stopping ?? false);
+  if (!isRunning) return "idle";
+  return isStopping ? "stopping" : "running";
+}
+
+/** Derive the run phase for a sweep. */
+export function useSweepRunPhase(): RunPhase {
+  const sweeping = useSweepRunStore((s) => s.sweeping);
+  const stopping = useSweepRunStore((s) => s.stopping);
+  if (!sweeping) return "idle";
+  return stopping ? "stopping" : "running";
+}

--- a/frontend/src/hooks/useSimulationSSE.test.ts
+++ b/frontend/src/hooks/useSimulationSSE.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Asserts useSimulationSSE's stop-related terminal handling:
+ * - the "stopped" SSE event clears isRunning (via the store's `stopped()`
+ *   action) instead of leaving the run stuck forever.
+ * - a dropped connection (native EventSource `onerror`) now surfaces as a
+ *   run error instead of silently closing the stream with isRunning still
+ *   true and no feedback -- the bug that motivated this fix.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useSimulationSSE } from "./useSimulationSSE";
+
+class FakeEventSource {
+  static instances: FakeEventSource[] = [];
+  listeners: Record<string, Array<(e: { data: string }) => void>> = {};
+  onerror: (() => void) | null = null;
+  closed = false;
+  url: string;
+
+  constructor(url: string) {
+    this.url = url;
+    FakeEventSource.instances.push(this);
+  }
+
+  addEventListener(type: string, cb: (e: { data: string }) => void): void {
+    (this.listeners[type] ??= []).push(cb);
+  }
+
+  close(): void {
+    this.closed = true;
+  }
+
+  emit(type: string, data: unknown): void {
+    for (const cb of this.listeners[type] ?? []) cb({ data: JSON.stringify(data) });
+  }
+}
+
+const mockUpdateProgress = vi.fn();
+const mockSetResults = vi.fn();
+const mockSetError = vi.fn();
+const mockStopped = vi.fn();
+
+let mockSimulationId: string | null = "sim-123";
+const mockIsRunning = true;
+
+vi.mock("@/stores/simulationStore", () => ({
+  useSimulationStore: () => ({
+    simulationId: mockSimulationId,
+    isRunning: mockIsRunning,
+    updateProgress: mockUpdateProgress,
+    setResults: mockSetResults,
+    setError: mockSetError,
+    stopped: mockStopped,
+  }),
+}));
+
+describe("useSimulationSSE", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    FakeEventSource.instances = [];
+    mockSimulationId = "sim-123";
+    vi.stubGlobal("EventSource", FakeEventSource);
+  });
+
+  it("clears isRunning via stopped() on the SSE 'stopped' event, without an error", () => {
+    renderHook(() => useSimulationSSE());
+    const source = FakeEventSource.instances[0];
+
+    source.emit("stopped", { is_running: false, is_stopping: true });
+
+    expect(mockStopped).toHaveBeenCalledOnce();
+    expect(mockSetError).not.toHaveBeenCalled();
+    expect(source.closed).toBe(true);
+  });
+
+  it("surfaces a dropped connection as a run error instead of leaving isRunning stuck", () => {
+    renderHook(() => useSimulationSSE());
+    const source = FakeEventSource.instances[0];
+
+    source.onerror?.();
+
+    expect(mockSetError).toHaveBeenCalledWith(expect.stringContaining("Connection"));
+    expect(source.closed).toBe(true);
+  });
+});

--- a/frontend/src/hooks/useSimulationSSE.ts
+++ b/frontend/src/hooks/useSimulationSSE.ts
@@ -21,7 +21,7 @@ function conservationFailingNodes(data: SimulationResults): string[] {
  */
 export function useSimulationSSE() {
   const sourceRef = useRef<EventSource | null>(null);
-  const { simulationId, isRunning, updateProgress, setResults, setError } =
+  const { simulationId, isRunning, updateProgress, setResults, setError, stopped } =
     useSimulationStore();
 
   useEffect(() => {
@@ -136,8 +136,23 @@ export function useSimulationSSE() {
       source.close();
     });
 
+    // Terminal event for a cooperatively stopped run (see boulder/api/sse.py):
+    // is_running is now false with no is_complete and no error_message, so
+    // without this branch the run would just sit there with isRunning still
+    // true in the store — no overlay to visually hide that the way there
+    // almost accidentally used to be, so a genuinely stuck Stop button.
+    source.addEventListener("stopped", () => {
+      stopped();
+      toast.info("Simulation stopped");
+      source.close();
+    });
+
     source.onerror = () => {
-      // EventSource connection error – simulation may have ended
+      // EventSource connection error (dropped network, server restart, ...).
+      // Previously just closed the stream, leaving isRunning stuck true
+      // forever with no feedback -- now a permanently stuck Stop button
+      // rather than a permanently stuck spinner.
+      setError("Connection to simulation lost");
       source.close();
     };
 
@@ -145,5 +160,5 @@ export function useSimulationSSE() {
       source.close();
       sourceRef.current = null;
     };
-  }, [simulationId, isRunning, updateProgress, setResults, setError]);
+  }, [simulationId, isRunning, updateProgress, setResults, setError, stopped]);
 }

--- a/frontend/src/stores/simulationStore.ts
+++ b/frontend/src/stores/simulationStore.ts
@@ -16,6 +16,9 @@ interface SimulationState {
   updateProgress: (progress: SimulationProgress) => void;
   setResults: (results: SimulationResults) => void;
   setError: (error: string) => void;
+  /** The SSE stream's terminal "stopped" event: the solve thread has exited
+   * after a stop request, with no completion and no error. */
+  stopped: () => void;
   clearResults: () => void;
   setPythonCode: (code: string) => void;
 }
@@ -58,6 +61,8 @@ export const useSimulationStore = create<SimulationState>((set) => ({
     }),
 
   setError: (error) => set({ isRunning: false, error }),
+
+  stopped: () => set({ isRunning: false }),
 
   clearResults: () =>
     set({

--- a/frontend/src/stores/sweepStore.test.ts
+++ b/frontend/src/stores/sweepStore.test.ts
@@ -9,9 +9,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockStartSweep = vi.fn();
 const mockGetSweepStatus = vi.fn();
+const mockStopSweep = vi.fn();
 vi.mock("@/api/sweep", () => ({
   startSweep: (...args: unknown[]) => mockStartSweep(...args),
   getSweepStatus: (...args: unknown[]) => mockGetSweepStatus(...args),
+  stopSweep: (...args: unknown[]) => mockStopSweep(...args),
 }));
 
 const mockRefresh = vi.fn();
@@ -37,10 +39,12 @@ vi.mock("./scenarioStore", () => ({
 
 const mockToastSuccess = vi.fn();
 const mockToastError = vi.fn();
+const mockToastInfo = vi.fn();
 vi.mock("sonner", () => ({
   toast: {
     success: (...args: unknown[]) => mockToastSuccess(...args),
     error: (...args: unknown[]) => mockToastError(...args),
+    info: (...args: unknown[]) => mockToastInfo(...args),
   },
 }));
 
@@ -54,6 +58,7 @@ describe("sweepStore", () => {
     mockOverlays = {};
     useSweepRunStore.setState({
       sweeping: false,
+      stopping: false,
       progress: { current: 0, total: 0 },
       scenarioProgress: {},
       lastLine: null,
@@ -277,5 +282,70 @@ describe("sweepStore", () => {
     await vi.advanceTimersByTimeAsync(1000);
 
     expect(mockSetActive).not.toHaveBeenCalled();
+  });
+
+  describe("stop()", () => {
+    it("is a no-op when nothing is sweeping", () => {
+      useSweepRunStore.getState().stop();
+
+      expect(mockStopSweep).not.toHaveBeenCalled();
+      expect(useSweepRunStore.getState().stopping).toBe(false);
+    });
+
+    it("optimistically sets stopping, then the next poll tick confirms it", async () => {
+      vi.useFakeTimers();
+      mockStartSweep.mockResolvedValue({ status: "running", total: 2 });
+      mockStopSweep.mockResolvedValue({ stopping: true });
+      mockGetSweepStatus
+        .mockResolvedValueOnce({ status: "stopping", current: 1, total: 2 })
+        .mockResolvedValueOnce({ status: "cancelled" });
+
+      useSweepRunStore.getState().run({ total: 2 });
+      await vi.advanceTimersByTimeAsync(0);
+
+      useSweepRunStore.getState().stop();
+      expect(mockStopSweep).toHaveBeenCalledOnce();
+      expect(useSweepRunStore.getState().stopping).toBe(true);
+      expect(useSweepRunStore.getState().sweeping).toBe(true); // still "in progress" for the UI
+
+      await vi.advanceTimersByTimeAsync(1000); // poll tick -> status "stopping"
+      expect(useSweepRunStore.getState().sweeping).toBe(true);
+      expect(useSweepRunStore.getState().stopping).toBe(true);
+
+      await vi.advanceTimersByTimeAsync(1000); // poll tick -> status "cancelled"
+      expect(useSweepRunStore.getState().sweeping).toBe(false);
+      expect(useSweepRunStore.getState().stopping).toBe(false);
+    });
+
+    it("a cancelled sweep toasts info, not error, and still refreshes the Scenario Pane", async () => {
+      vi.useFakeTimers();
+      mockStartSweep.mockResolvedValue({ status: "running", total: 2 });
+      mockGetSweepStatus.mockResolvedValueOnce({ status: "cancelled" });
+
+      useSweepRunStore.getState().run({ total: 2 });
+      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(1000);
+
+      expect(useSweepRunStore.getState().sweeping).toBe(false);
+      expect(mockToastInfo).toHaveBeenCalledOnce();
+      expect(mockToastError).not.toHaveBeenCalled();
+      expect(mockRefresh).toHaveBeenCalledOnce();
+    });
+
+    it("reverts the optimistic stopping flag if the stop request itself fails", async () => {
+      vi.useFakeTimers();
+      mockStartSweep.mockResolvedValue({ status: "running", total: 1 });
+      mockStopSweep.mockRejectedValue(new Error("network error"));
+
+      useSweepRunStore.getState().run({ total: 1 });
+      await vi.advanceTimersByTimeAsync(0);
+
+      useSweepRunStore.getState().stop();
+      expect(useSweepRunStore.getState().stopping).toBe(true);
+
+      await vi.advanceTimersByTimeAsync(0); // flush the rejected stopSweep() promise
+      expect(useSweepRunStore.getState().stopping).toBe(false);
+      expect(mockToastError).toHaveBeenCalledWith(expect.stringContaining("network error"));
+    });
   });
 });

--- a/frontend/src/stores/sweepStore.ts
+++ b/frontend/src/stores/sweepStore.ts
@@ -1,10 +1,16 @@
 import { create } from "zustand";
 import { toast } from "sonner";
-import { getSweepStatus, startSweep, type SweepStatus } from "@/api/sweep";
+import { getSweepStatus, startSweep, stopSweep, type SweepStatus } from "@/api/sweep";
 import { useScenarioStore } from "./scenarioStore";
 
 interface SweepRunState {
   sweeping: boolean;
+  /**
+   * A stop was requested and the server has acknowledged it (status
+   * "stopping"), but the in-flight scenario hasn't wound down yet — still
+   * `sweeping`, just no longer making progress toward a "done" result.
+   */
+  stopping: boolean;
   progress: { current: number; total: number };
   /**
    * Scenarios currently being solved, keyed by id (mirrors
@@ -45,6 +51,12 @@ interface SweepRunState {
    * is already polling one via `run()`.
    */
   hydrate: () => void;
+  /**
+   * Request that the running sweep stop — cooperative, so this doesn't wait
+   * for the in-flight scenario to actually wind down; the next poll tick
+   * observes that via `stopping`/the eventual "cancelled" status.
+   */
+  stop: () => void;
 }
 
 // Module-level (not store state) — a plain interval handle, not observed by
@@ -81,6 +93,7 @@ export const useSweepRunStore = create<SweepRunState>((set, get) => {
       }
       set({
         sweeping: true,
+        stopping: false,
         progress: { current: st.current ?? 0, total: st.total ?? 0 },
         scenarioProgress,
         lastLine: st.last_line ?? null,
@@ -97,9 +110,26 @@ export const useSweepRunStore = create<SweepRunState>((set, get) => {
       lastSeenCurrent = cur;
       return;
     }
+    if (st.status === "stopping") {
+      // Keep polling — the in-flight scenario (or a host sweep.runner with
+      // no stop_event of its own) hasn't wound down yet. Leave
+      // scenarioProgress/lastLine as they were so the card doesn't blank
+      // out before there's anything new to show.
+      set({ sweeping: true, stopping: true });
+      return;
+    }
     stopPolling();
-    set({ sweeping: false, scenarioProgress: {}, lastLine: null, pinnedId: null });
-    if (st.status === "done") {
+    set({
+      sweeping: false,
+      stopping: false,
+      scenarioProgress: {},
+      lastLine: null,
+      pinnedId: null,
+    });
+    if (st.status === "cancelled") {
+      toast.info("Sweep stopped");
+      void useScenarioStore.getState().refresh();
+    } else if (st.status === "done") {
       toast.success("Sweep complete — scenarios updated");
       void (async () => {
         await useScenarioStore.getState().refresh();
@@ -130,13 +160,14 @@ export const useSweepRunStore = create<SweepRunState>((set, get) => {
         .then(applyStatus)
         .catch(() => {
           stopPolling();
-          set({ sweeping: false });
+          set({ sweeping: false, stopping: false });
         });
     }, 1000);
   }
 
   return {
     sweeping: false,
+    stopping: false,
     progress: { current: 0, total: 0 },
     scenarioProgress: {},
     lastLine: null,
@@ -152,6 +183,7 @@ export const useSweepRunStore = create<SweepRunState>((set, get) => {
       // had pinned during the last one.
       set({
         sweeping: true,
+        stopping: false,
         pinnedId: null,
         progress: { current: 0, total: options?.total ?? 0 },
       });
@@ -162,6 +194,17 @@ export const useSweepRunStore = create<SweepRunState>((set, get) => {
           set({ sweeping: false });
           toast.error(e instanceof Error ? e.message : String(e));
         });
+    },
+
+    stop: () => {
+      if (!get().sweeping) return;
+      // Optimistic: the next poll tick (up to 1s away) will confirm this
+      // once the server acknowledges, same pattern run() already uses.
+      set({ stopping: true });
+      stopSweep().catch((e) => {
+        set({ stopping: false });
+        toast.error(e instanceof Error ? e.message : String(e));
+      });
     },
 
     hydrate: () => {

--- a/frontend/src/types/simulation.ts
+++ b/frontend/src/types/simulation.ts
@@ -63,6 +63,13 @@ export interface ConnectionReport {
 export interface SimulationProgress {
   is_running: boolean;
   is_complete: boolean;
+  /**
+   * A stop was requested (DELETE /api/simulations/{id}) but the solve
+   * thread hasn't exited yet — cooperative, so it can lag the request by up
+   * to one stage. "Stopped" is derived, not a separate flag:
+   * `is_stopping && !is_running`.
+   */
+  is_stopping?: boolean;
   error_message?: string | null;
   /** Staged-solver build counters — updated after each stage completes. */
   stages_done?: number;

--- a/tests/test_simulation_cleanup.py
+++ b/tests/test_simulation_cleanup.py
@@ -48,13 +48,18 @@ class TestSimulationCleanup:
     """Test suite for simulation memory cleanup."""
 
     @pytest.mark.asyncio
-    async def test_simulation_deleted_after_stop(self, minimal_config):
-        """Verify that stopping a simulation removes it from memory."""
-        # Clear any existing simulations
+    async def test_cleanup_endpoint_removes_a_stopped_simulation(self, minimal_config):
+        """A stopped-and-exited simulation is cleanable, same as complete/errored.
+
+        DELETE /{sim_id} itself no longer removes the registry entry (see
+        tests/test_simulation_stop.py for that behavior change) -- it has to
+        stay reachable until :func:`cleanup_completed_simulations` reaps it.
+        """
+        import asyncio
+
         _simulations.clear()
 
         async with _make_client() as client:
-            # Start a simulation
             resp = await client.post(
                 "/api/simulations",
                 json={
@@ -65,20 +70,25 @@ class TestSimulationCleanup:
             )
             assert resp.status_code == 200
             sim_id = resp.json()["simulation_id"]
-
-            # Verify the simulation is in memory
             assert sim_id in _simulations
-            initial_count = len(_simulations)
-            assert initial_count == 1
 
-            # Stop the simulation
             resp = await client.delete(f"/api/simulations/{sim_id}")
             assert resp.status_code == 200
-            assert resp.json()["stopped"] is True
+            assert resp.json()["stopping"] is True
+            # Still present immediately after the (non-blocking) stop request.
+            assert sim_id in _simulations
 
-            # Verify the simulation was removed from memory
+            worker, _ = _simulations[sim_id]
+            for _ in range(20):
+                if not worker.get_progress().is_running:
+                    break
+                await asyncio.sleep(0.1)
+            assert not worker.get_progress().is_running
+
+            resp = await client.post("/api/simulations/cleanup")
+            assert resp.status_code == 200
+            assert resp.json()["removed"] == 1
             assert sim_id not in _simulations
-            assert len(_simulations) == initial_count - 1
 
     @pytest.mark.asyncio
     async def test_simulation_cleanup_with_query_param(self, minimal_config):

--- a/tests/test_simulation_stop.py
+++ b/tests/test_simulation_stop.py
@@ -1,0 +1,359 @@
+"""Tests for cooperative simulation cancellation ("Stop Simulation").
+
+Covers, end to end from the checkpoint up to the API:
+- SolveCancelled fires at a stage boundary when the cancel token is set.
+- SimulationWorker.stop_simulation() is non-blocking and, for the common
+  single-stage case (no reachable checkpoint before the solve finishes),
+  the finalize guard still skips the cache write and is_complete.
+- stop_simulation() is a no-op on a run that already finished.
+- DELETE /{sim_id} returns immediately and does not remove the registry
+  entry -- that's cleanup's job once the thread has actually exited (see
+  tests/test_simulation_cleanup.py for that behavior).
+- The SSE stream emits a terminal "stopped" event instead of polling forever.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+
+import pytest
+
+httpx = pytest.importorskip("httpx")
+pytest.importorskip("fastapi")
+
+from httpx import ASGITransport, AsyncClient  # noqa: E402
+
+from boulder.api.main import create_app  # noqa: E402
+from boulder.api.routes.simulations import _simulations  # noqa: E402
+from boulder.api.sse import simulation_event_stream  # noqa: E402
+from boulder.cantera_converter import DualCanteraConverter  # noqa: E402
+from boulder.config import synthesize_default_group  # noqa: E402
+from boulder.simulation_worker import SimulationProgress, SimulationWorker  # noqa: E402
+from boulder.staged_solver import SolveCancelled  # noqa: E402
+
+
+def _make_client():
+    """Return an AsyncClient bound to a fresh FastAPI app."""
+    app = create_app()
+    transport = ASGITransport(app=app)
+    return AsyncClient(transport=transport, base_url="http://test")
+
+
+@pytest.fixture
+def minimal_config():
+    """Return a single-stage config: no checkpoint fires before the solve completes."""
+    return {
+        "nodes": [
+            {
+                "id": "reactor1",
+                "type": "IdealGasReactor",
+                "properties": {
+                    "temperature": 1000,
+                    "pressure": 101325,
+                    "composition": "CH4:1,O2:2,N2:7.52",
+                },
+            }
+        ],
+        "connections": [],
+        "settings": {"end_time": 0.1, "dt": 0.05},
+    }
+
+
+# Minimal inert two-stage config (mirrors tests/test_staged_solver.py's
+# _INERT_TWO_STAGE): pure N2, so advance_to_steady_state converges in
+# milliseconds -- fast enough that setting the cancel token from stage_a's
+# own completion callback reliably lands before stage_b starts.
+_TWO_STAGE = {
+    "groups": {
+        "stage_a": {"mechanism": "gri30.yaml", "solve": "advance_to_steady_state"},
+        "stage_b": {"mechanism": "gri30.yaml", "solve": "advance_to_steady_state"},
+    },
+    "phases": {"gas": {"mechanism": "gri30.yaml"}},
+    "nodes": [
+        {
+            "id": "r_a",
+            "type": "IdealGasConstPressureMoleReactor",
+            "properties": {
+                "group": "stage_a",
+                "temperature": 1200.0,
+                "pressure": 101325.0,
+                "composition": "N2:1",
+                "volume": 1e-5,
+            },
+        },
+        {
+            "id": "r_b",
+            "type": "IdealGasConstPressureMoleReactor",
+            "properties": {
+                "group": "stage_b",
+                "temperature": 900.0,
+                "pressure": 101325.0,
+                "composition": "N2:1",
+                "volume": 5e-6,
+            },
+        },
+    ],
+    "connections": [
+        {
+            "id": "a_to_b",
+            "type": "MassFlowController",
+            "source": "r_a",
+            "target": "r_b",
+            "properties": {"mass_flow_rate": 1e-4},
+        },
+    ],
+}
+
+
+class TestSolveCancelledCheckpoint:
+    """The staged_solver.py:612 stage-boundary checkpoint."""
+
+    def test_cancel_token_set_before_stage_b_raises_before_it_solves(self):
+        """Setting the token from stage_a's own completion callback must stop stage_b.
+
+        Proof the checkpoint sits *before* each stage's build/solve, not just
+        somewhere in the loop.
+        """
+        conv = DualCanteraConverter(mechanism="gri30.yaml")
+        cancel_token = threading.Event()
+        conv.cancel_token = cancel_token
+
+        seen_stage_ids: list[str] = []
+
+        def _on_stage_done(stage_id: str, n_done: int, n_total: int) -> None:
+            seen_stage_ids.append(stage_id)
+            if stage_id == "stage_a":
+                cancel_token.set()
+
+        with pytest.raises(SolveCancelled):
+            conv.build_network(_TWO_STAGE, progress_callback=_on_stage_done)
+
+        assert seen_stage_ids == ["stage_a"]
+
+    def test_already_set_token_stops_before_the_first_stage(self):
+        conv = DualCanteraConverter(mechanism="gri30.yaml")
+        conv.cancel_token = threading.Event()
+        conv.cancel_token.set()
+
+        with pytest.raises(SolveCancelled):
+            conv.build_network(_TWO_STAGE)
+
+    def test_no_token_set_solves_normally(self):
+        """Absence of cancel_token (the default) must not affect a normal solve."""
+        conv = DualCanteraConverter(mechanism="gri30.yaml")
+        net = conv.build_network(_TWO_STAGE)
+        assert net is not None
+
+
+class TestSimulationWorkerStop:
+    """SimulationWorker.stop_simulation() and the finalize guard."""
+
+    def test_stop_simulation_is_non_blocking(self):
+        worker = SimulationWorker()
+        started = time.perf_counter()
+        worker.stop_simulation()  # No worker thread at all -- must not hang.
+        assert time.perf_counter() - started < 1.0
+
+    def test_stop_simulation_noop_on_already_finished_run(self):
+        """A stop request against an already-finished run must be a no-op.
+
+        It must not retroactively mark the run as stopping.
+        """
+        worker = SimulationWorker()
+        worker.progress = SimulationProgress(is_running=False, is_complete=True)
+        worker.stop_simulation()
+        assert worker.get_progress().is_stopping is False
+
+    def test_stopped_single_stage_solve_skips_cache_and_completion(
+        self, minimal_config, monkeypatch
+    ):
+        """Cover the common case the finalize-guard fix targets.
+
+        A single-stage steady solve has no reachable checkpoint before it
+        finishes, so SolveCancelled never fires -- only the explicit
+        `_stop_event.is_set()` check in the finalize block (and in the except
+        branch) makes Stop take effect here.
+        """
+        persist_calls = []
+        monkeypatch.setattr(
+            SimulationWorker,
+            "_persist_to_cache",
+            lambda self, *a, **k: persist_calls.append(1),
+        )
+
+        # start_simulation() expects a normalized config -- the POST route
+        # calls synthesize_default_group() before constructing the worker;
+        # do the same here so build_network doesn't fail for an unrelated
+        # reason ("no groups section") before the stop even matters.
+        config = {**minimal_config}
+        synthesize_default_group(config)
+
+        conv = DualCanteraConverter(mechanism="gri30.yaml")
+        worker = SimulationWorker()
+        worker.start_simulation(conv, config, 0.1, 0.05)
+        worker.stop_simulation()
+
+        for _ in range(50):
+            if not worker.get_progress().is_running:
+                break
+            time.sleep(0.05)
+        progress = worker.get_progress()
+
+        assert progress.is_running is False
+        assert progress.is_stopping is True
+        assert progress.is_complete is False
+        assert progress.error_message is None
+        assert persist_calls == []
+
+
+class TestSSEStoppedEvent:
+    """boulder.api.sse.simulation_event_stream's terminal "stopped" branch."""
+
+    class _StubWorker:
+        """Replays a canned sequence of SimulationProgress snapshots."""
+
+        def __init__(self, snapshots: list[SimulationProgress]) -> None:
+            self._snapshots = snapshots
+            self._i = 0
+
+        def get_progress(self) -> SimulationProgress:
+            snap = self._snapshots[min(self._i, len(self._snapshots) - 1)]
+            self._i += 1
+            return snap
+
+    @pytest.mark.asyncio
+    async def test_stream_emits_stopped_and_terminates(self):
+        worker = self._StubWorker(
+            [
+                SimulationProgress(is_running=True),
+                SimulationProgress(is_running=False, is_stopping=True),
+            ]
+        )
+        events = []
+        async for chunk in simulation_event_stream(worker, poll_interval=0.0):
+            events.append(chunk)
+
+        assert len(events) == 2
+        assert events[0].startswith("event: progress\n")
+        assert events[1].startswith("event: stopped\n")
+        assert '"is_stopping": true' in events[1]
+
+    @pytest.mark.asyncio
+    async def test_stopped_takes_priority_over_a_stray_error_message(self):
+        """A stopped run must never be reported as errored.
+
+        Even if error_message happens to still carry a stale value from
+        before the stop was requested.
+        """
+        worker = self._StubWorker(
+            [
+                SimulationProgress(
+                    is_running=False, is_stopping=True, error_message="stale"
+                ),
+            ]
+        )
+        events = []
+        async for chunk in simulation_event_stream(worker, poll_interval=0.0):
+            events.append(chunk)
+
+        assert len(events) == 1
+        assert events[0].startswith("event: stopped\n")
+
+
+class TestStopSimulationEndpoint:
+    """DELETE /api/simulations/{sim_id} — the API-level contract."""
+
+    @pytest.mark.asyncio
+    async def test_delete_returns_immediately_and_keeps_the_registry_entry(
+        self, minimal_config
+    ):
+        _simulations.clear()
+
+        async with _make_client() as client:
+            resp = await client.post(
+                "/api/simulations",
+                json={
+                    "config": minimal_config,
+                    "simulation_time": 0.1,
+                    "time_step": 0.05,
+                },
+            )
+            assert resp.status_code == 200
+            sim_id = resp.json()["simulation_id"]
+            assert sim_id in _simulations
+
+            started = time.perf_counter()
+            resp = await client.delete(f"/api/simulations/{sim_id}")
+            elapsed = time.perf_counter() - started
+
+            assert resp.status_code == 200
+            assert resp.json() == {"stopping": True, "simulation_id": sim_id}
+            # The old blocking behavior joined the worker thread for up to 5s;
+            # this must return right away regardless of solve state.
+            assert elapsed < 1.0
+            # Not removed -- the SSE stream still needs to reach it.
+            assert sim_id in _simulations
+
+        _simulations.clear()
+
+    @pytest.mark.asyncio
+    async def test_delete_unknown_simulation_404s(self):
+        _simulations.clear()
+        async with _make_client() as client:
+            resp = await client.delete("/api/simulations/does-not-exist")
+        assert resp.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_full_stop_flow_via_api_never_completes_or_caches(
+        self, minimal_config, monkeypatch
+    ):
+        """Start, stop, and wait for exit through the real DELETE handler, not the worker directly.
+
+        A trivial single-reactor solve can finish before this test's DELETE
+        request round-trips through the ASGI transport, which would make the
+        assertions below race real Cantera timing rather than test the
+        guard. build_network is slowed down deterministically so the DELETE
+        reliably lands first -- the point of Stop is long solves anyway.
+        """
+        persist_calls = []
+        monkeypatch.setattr(
+            SimulationWorker,
+            "_persist_to_cache",
+            lambda self, *a, **k: persist_calls.append(1),
+        )
+        original_build_network = DualCanteraConverter.build_network
+
+        def _slow_build_network(self, *args, **kwargs):
+            time.sleep(0.3)
+            return original_build_network(self, *args, **kwargs)
+
+        monkeypatch.setattr(DualCanteraConverter, "build_network", _slow_build_network)
+        _simulations.clear()
+
+        async with _make_client() as client:
+            resp = await client.post(
+                "/api/simulations",
+                json={
+                    "config": minimal_config,
+                    "simulation_time": 0.1,
+                    "time_step": 0.05,
+                },
+            )
+            sim_id = resp.json()["simulation_id"]
+
+            resp = await client.delete(f"/api/simulations/{sim_id}")
+            assert resp.json()["stopping"] is True
+
+            worker, _ = _simulations[sim_id]
+            for _ in range(50):
+                if not worker.get_progress().is_running:
+                    break
+                await asyncio.sleep(0.05)
+
+            progress = worker.get_progress()
+            assert progress.is_complete is False
+            assert persist_calls == []
+
+        _simulations.clear()

--- a/tests/test_sweep_stop.py
+++ b/tests/test_sweep_stop.py
@@ -1,0 +1,249 @@
+"""Tests for cooperative sweep cancellation (`POST /api/sweep/stop`).
+
+Run Sweep runs in-process, one scenario at a time through the same
+`SimulationWorker` a plain "Run Simulation" uses (see `boulder/api/routes/
+sweep.py`) -- no subprocess, so there is nothing to kill. Stop reuses
+exactly the mechanism tests/test_simulation_stop.py exercises for a single
+run: `solve_scenario` (boulder/sweep_runner.py) is handed a `stop_event` and
+checks it in its own poll loop, calling `worker.stop_simulation()` on the
+scenario currently in flight; the sweep's own scenario loop checks the same
+event before starting the next one.
+
+Like test_sweep_status_scenario_progress.py, these stand a fake in for
+SimulationWorker so scenario transitions can be driven deterministically
+without a real Cantera solve.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from pathlib import Path
+from typing import Any, Callable, List
+from unittest.mock import patch
+
+import pytest
+
+pytest.importorskip("fastapi")
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from boulder.api.main import create_app  # noqa: E402
+from boulder.api.routes.sweep import _run_host_sweep  # noqa: E402
+from boulder.simulation_worker import SimulationProgress  # noqa: E402
+
+_CONFIG_YAML = """\
+metadata:
+  description: "test config"
+phases:
+  gas:
+    mechanism: gri30.yaml
+network:
+  - id: feed
+    Reservoir:
+      temperature: 298.15
+      pressure: 101325
+      composition: "CH4:1"
+"""
+
+
+def _client_with_config(tmp_path: Path):
+    from boulder.runner import BoulderRunner
+
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(_CONFIG_YAML, encoding="utf-8")
+
+    app = create_app()
+    client = TestClient(app)
+    client.__enter__()
+    app.state.preloaded_config_path = str(cfg)
+    app.state.preloaded_raw = BoulderRunner.load(str(cfg))
+    return client, app
+
+
+def _wait_until(predicate: Callable[[], bool], timeout: float = 10.0) -> None:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if predicate():
+            return
+        time.sleep(0.02)
+    raise AssertionError("condition not met within timeout")
+
+
+class _FakeWorker:
+    """Stand-in for SimulationWorker.
+
+    Records whether stop_simulation() was called instead of actually
+    stopping anything (there's no real thread).
+    """
+
+    def __init__(self) -> None:
+        self.progress = SimulationProgress()
+        self.stop_calls = 0
+
+    def start_simulation(self, *args: Any, **kwargs: Any) -> None:
+        pass
+
+    def get_progress(self) -> SimulationProgress:
+        return self.progress
+
+    def stop_simulation(self) -> None:
+        self.stop_calls += 1
+        self.progress.is_stopping = True
+
+
+def _sweep_with_fake_workers(tmp_path: Path, scenarios: dict):
+    """Start a sweep with SimulationWorker faked out; return (client, app, workers)."""
+    client, app = _client_with_config(tmp_path)
+    workers: List[_FakeWorker] = []
+
+    def _factory() -> _FakeWorker:
+        w = _FakeWorker()
+        workers.append(w)
+        return w
+
+    patcher = patch("boulder.simulation_worker.SimulationWorker", side_effect=_factory)
+    patcher.start()
+    resp = client.post("/api/sweep/run", json={"scenarios": scenarios})
+    assert resp.status_code == 200, resp.text
+    return client, app, workers, patcher
+
+
+class TestSweepStopEndpoint:
+    def test_404_when_no_sweep_is_running(self, tmp_path: Path) -> None:
+        client, app = _client_with_config(tmp_path)
+        try:
+            resp = client.post("/api/sweep/stop")
+            assert resp.status_code == 404
+        finally:
+            client.__exit__(None, None, None)
+
+    def test_returns_immediately_and_marks_status_stopping(
+        self, tmp_path: Path
+    ) -> None:
+        client, app, workers, patcher = _sweep_with_fake_workers(tmp_path, {"a": {}})
+        try:
+            _wait_until(lambda: len(workers) >= 1)
+
+            started = time.perf_counter()
+            resp = client.post("/api/sweep/stop")
+            elapsed = time.perf_counter() - started
+
+            assert resp.status_code == 200
+            assert resp.json() == {"stopping": True}
+            assert elapsed < 1.0
+            assert app.state.sweep_job["status"] == "stopping"
+        finally:
+            patcher.stop()
+            client.__exit__(None, None, None)
+
+    def test_stop_calls_stop_simulation_on_the_in_flight_worker(
+        self, tmp_path: Path
+    ) -> None:
+        client, app, workers, patcher = _sweep_with_fake_workers(tmp_path, {"a": {}})
+        try:
+            _wait_until(lambda: len(workers) >= 1)
+            resp = client.post("/api/sweep/stop")
+            assert resp.status_code == 200
+
+            _wait_until(lambda: workers[0].stop_calls >= 1)
+        finally:
+            patcher.stop()
+            client.__exit__(None, None, None)
+
+    def test_stop_prevents_the_next_scenario_from_starting(
+        self, tmp_path: Path
+    ) -> None:
+        """BASELINE is in flight; stopping must not let scenario "a" start."""
+        client, app, workers, patcher = _sweep_with_fake_workers(tmp_path, {"a": {}})
+        try:
+            _wait_until(lambda: len(workers) >= 1)
+            resp = client.post("/api/sweep/stop")
+            assert resp.status_code == 200
+
+            _wait_until(lambda: app.state.sweep_job.get("status") == "cancelled")
+            assert len(workers) == 1  # scenario "a" never started
+            assert app.state.sweep_job["scenario_progress"] == {}
+        finally:
+            patcher.stop()
+            client.__exit__(None, None, None)
+
+    def test_cancelled_status_not_error(self, tmp_path: Path) -> None:
+        """A stopped sweep must be distinguishable from a genuinely failed one."""
+        client, app, workers, patcher = _sweep_with_fake_workers(tmp_path, {"a": {}})
+        try:
+            _wait_until(lambda: len(workers) >= 1)
+            resp = client.post("/api/sweep/stop")
+            assert resp.status_code == 200
+
+            _wait_until(lambda: app.state.sweep_job.get("status") == "cancelled")
+            assert app.state.sweep_job["status"] != "error"
+        finally:
+            patcher.stop()
+            client.__exit__(None, None, None)
+
+    def test_second_run_rejected_while_stopping(self, tmp_path: Path) -> None:
+        client, app, workers, patcher = _sweep_with_fake_workers(tmp_path, {"a": {}})
+        try:
+            _wait_until(lambda: len(workers) >= 1)
+            resp = client.post("/api/sweep/stop")
+            assert resp.status_code == 200
+            assert app.state.sweep_job["status"] == "stopping"
+
+            resp = client.post("/api/sweep/run", json={"scenarios": {"a": {}}})
+            assert resp.status_code == 409
+        finally:
+            patcher.stop()
+            client.__exit__(None, None, None)
+
+
+class TestHostRunnerStopEventKwarg:
+    """`_run_host_sweep` extends its existing signature-detection.
+
+    It now also detects `stop_event`, the same way it already does for
+    `progress`/`config_path`.
+    """
+
+    def test_stop_event_passed_when_the_runner_declares_it(
+        self, tmp_path: Path
+    ) -> None:
+        received = {}
+
+        def runner(store_dir, stop_event=None):
+            received["stop_event"] = stop_event
+
+        sentinel = threading.Event()
+
+        # _run_host_sweep resolves `dotted` via resolve_dotted_path -- patch
+        # that to hand back this in-test callable instead of a real import.
+        with patch(
+            "boulder.cantera_converter.resolve_dotted_path", return_value=runner
+        ):
+            _run_host_sweep(
+                "unused.dotted.path",
+                state={"current": 0, "total": 0, "message": "", "last_line": None},
+                store_dir=tmp_path,
+                stop_event=sentinel,
+            )
+
+        assert received["stop_event"] is sentinel
+
+    def test_stop_event_omitted_when_the_runner_does_not_declare_it(
+        self, tmp_path: Path
+    ) -> None:
+        received = {}
+
+        def runner(store_dir):
+            received["called"] = True
+
+        with patch(
+            "boulder.cantera_converter.resolve_dotted_path", return_value=runner
+        ):
+            _run_host_sweep(
+                "unused.dotted.path",
+                state={"current": 0, "total": 0, "message": "", "last_line": None},
+                store_dir=tmp_path,
+                stop_event=threading.Event(),
+            )
+
+        assert received == {"called": True}


### PR DESCRIPTION
## Summary

Adds the Stop/Stopping affordance the run button has been missing — until now there was no way to interrupt a running simulation or sweep. See the plan this PR implements (backend cooperative-cancellation design + frontend Stop/Stopping UI).

**Backend**
- New `SolveCancelled` exception checked at each staged-solver stage boundary (`staged_solver.py`) and inside the `advance_grid`/`micro_step` transient loops (`cantera_converter.py`), driven by a `cancel_token` attribute the worker sets on the converter before building — an attribute, not a `build_network` kwarg, so a host converter subclass that overrides `build_network` isn't affected.
- `SimulationWorker.stop_simulation()` is now non-blocking — it used to `join()` the worker thread for up to 5s *inside* the request handler, stalling the whole FastAPI event loop. It just sets the token and an `is_stopping` flag now.
- The finalize block explicitly checks the stop flag before writing the cache / setting `is_complete` — the common single-stage case has no reachable checkpoint before the solve finishes, so without this explicit check Stop would silently do nothing for that case.
- `DELETE /api/simulations/{id}` returns immediately and keeps the registry entry (the SSE stream needs it to report the wind-down); the cleanup predicate gained one clause (`is_stopping and not is_running`) to reap a stopped-and-exited entry.
- `sse.py` gets a terminal `stopped` event so the stream doesn't poll forever for a run that neither completed nor errored.
- Sweep reuses the exact same mechanism instead of a second cancellation design: `solve_scenario` (`sweep_runner.py`) takes a `stop_event` checked in its own poll loop, and `sweep.py`'s scenario loop checks the same event before starting the next scenario. There's no subprocess in the sweep path anymore (it moved in-process in an earlier PR), so there's nothing to kill — this is genuinely the same problem as the single-run case, not a separate one.
- New `POST /api/sweep/stop`, mirroring the DELETE endpoint; a stopped sweep reports `status: "cancelled"`, distinct from `"error"`. The host `sweep.runner` callable path picks up an optional `stop_event` kwarg via the same signature-detection it already uses for `progress`/`config_path`.

**Frontend**
- `RunControl`'s split button becomes **Stop** (red) while running and **Stopping…** (amber, disabled, with a "will stop at the next checkpoint" tooltip) while winding down — derived from `progress.is_stopping` / sweep status `"stopping"`, not a separately-tracked flag that could go stale.
- The existing non-blocking calculating cards (`SimulationCalculatingCard`/`SweepCalculatingCard`) pick up the same stopping/amber treatment.
- `useSimulationSSE`'s `onerror` now surfaces a real error instead of silently leaving `isRunning` stuck forever with no feedback.
- **Real bug fixed along the way**: `runDisabled` ignored a running sweep, so a plain "Run Simulation" click could start a second, conflicting solve on top of an in-flight sweep.

## Test plan

- [x] `pytest tests/test_simulation_stop.py tests/test_sweep_stop.py tests/test_simulation_cleanup.py` — 25 passed
- [x] Full backend suite: `pytest tests/` — 878 passed, 2 skipped, 7 xfailed (2 pre-existing Playwright/browser failures unrelated to this change, present on `main` too)
- [x] `mypy .` — clean, 165 files
- [x] `pre-commit run` (ruff, ruff-format, etc.) on all changed backend files — clean
- [x] Full frontend suite: `vitest run` — 252 passed (32 files)
- [x] `tsc -b` (the actual `npm run build` typecheck — `tsc --noEmit` alone checks 0 files here, solution-style root tsconfig) — clean
- [x] `eslint .` — no new errors/warnings from this change (a few pre-existing ones elsewhere, verified against `main`)

Not run: a live end-to-end GUI check (start a slow multi-stage solve, click Stop, watch the button/card go amber then idle) — no way to launch the actual GUI + browser in this environment. Worth doing manually before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)