### PR TITLE
fix(gui): publish the post-solve config's nodes, not the pre-build ones

### DIFF
--- a/boulder/simulation_worker.py
+++ b/boulder/simulation_worker.py
@@ -419,12 +419,19 @@ class SimulationWorker:
 
             # Capture the full nodes + connections lists after post-build hooks
             # and the staged solver have run.  Both may grow during the build
-            # (e.g. interface-reservoir nodes, programmatic edges) so the client
+            # (e.g. stream-point reservoirs, programmatic edges) so the client
             # receives a single source of truth for the visual graph.
+            #
+            # Read them off the converter, not off the local ``config``:
+            # ``build_network`` deep-copies the config it is handed so a
+            # caller's dict is never corrupted, and it is that copy the staged
+            # solver enriches with stream-point nodes and their converged
+            # thermo (T, P, mdot, h_mass). This local dict never sees them.
+            post_config = getattr(converter, "_last_config", None) or config
             with self._lock:
-                self.progress.updated_nodes = list(config.get("nodes") or [])
+                self.progress.updated_nodes = list(post_config.get("nodes") or [])
                 self.progress.updated_connections = list(
-                    config.get("connections") or []
+                    post_config.get("connections") or []
                 )
 
             # Track last logged % for verbose throttle (log at 0, 25, 50, 75, 100)

--- a/tests/test_worker_publishes_stream_points.py
+++ b/tests/test_worker_publishes_stream_points.py
@@ -1,0 +1,67 @@
+"""What a solve synthesises, the client must receive.
+
+``SimulationWorker`` publishes ``updated_nodes``/``updated_connections`` as the
+single source of truth for the client's graph. A staged solve adds one
+stream-point reservoir per stage boundary and fills it with converged thermo,
+so those nodes must be in what the worker publishes -- otherwise every consumer
+of that list (graph, properties panel, output panes) sees a network whose stage
+boundaries do not exist.
+
+The trap: ``build_network`` deep-copies the config it is handed, so the dict the
+*caller* holds is never the one the staged solver enriches.
+"""
+
+from __future__ import annotations
+
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+from boulder.cantera_converter import DualCanteraConverter
+from boulder.config import normalize_config, validate_config
+from boulder.export import points_from_streams
+from boulder.simulation_worker import SimulationWorker
+
+sys.path.insert(0, str(Path(__file__).parent))
+from test_staged_viz_flow import _two_stage_linear_chain  # noqa: E402
+
+
+@pytest.mark.slow
+def test_updated_nodes_carry_the_stream_points_with_converged_thermo() -> None:
+    """A two-stage solve must publish its stream point, not just the declared nodes."""
+    cfg = validate_config(normalize_config(_two_stage_linear_chain()))
+    declared_ids = {n["id"] for n in cfg["nodes"]}
+
+    worker = SimulationWorker()
+    worker.start_simulation(
+        DualCanteraConverter(mechanism="gri30.yaml"),
+        cfg,
+        simulation_time=1e-4,
+        time_step=1e-4,
+    )
+    deadline = time.time() + 120
+    while time.time() < deadline:
+        if worker.get_progress().is_complete or worker.get_progress().error_message:
+            break
+        time.sleep(0.2)
+
+    progress = worker.get_progress()
+    assert not progress.error_message, progress.error_message
+    assert progress.updated_nodes is not None
+
+    published_ids = {n["id"] for n in progress.updated_nodes}
+    assert declared_ids <= published_ids
+    assert published_ids - declared_ids == {"r_a_outlet"}
+
+    # The published node must carry the converged stream state, not a
+    # build-time placeholder: this is what the client renders.
+    points = points_from_streams({"nodes": progress.updated_nodes})
+    assert [p["id"] for p in points] == ["r_a_outlet"]
+    point = points[0]
+    assert point["source_node"] == "r_a"
+    assert point["target_nodes"] == ["r_b"]
+    assert point["T_K"] > 0.0
+    assert point["mdot_kg_s"] > 0.0
+    assert point["h_mass_J_kg"] != 0.0


### PR DESCRIPTION
## The bug

`SimulationWorker` publishes `updated_nodes` / `updated_connections` as the client's single source of truth for the graph. It captured them from its own local config after `build_network` returned, on the assumption that the build enriches that dict in place:

```python
# comment: "after build_network mutates the config in-place"
self.progress.updated_nodes = list(config.get("nodes") or [])
```

It does not. `build_network` **deep-copies** the config it is handed (so a caller's dict is never corrupted) and the staged solver enriches *that copy* — adding one stream-point reservoir per stage boundary with its converged thermo (T, P, mdot, h_mass, density, top_Y) plus the inlet MFCs that draw from it.

Measured on a two-stage chain:

```
caller's config nodes   : ['feed', 'r_a', 'r_b']       -> 0 stream points
converter._last_config  : [..., 'r_a_outlet']          -> 1, with converged T/P/mdot/h_mass
```

So the client got a node list with no stream points in it at all. Consequences:

- the graph fell back to its **client-side placeholder** diamonds (`ReactorGraph.tsx`, "synthesise placeholder stream-point diamond nodes (pre-simulation)") — which is why stage boundaries still *looked* present
- the properties panel had no stream-point data to show when one was clicked
- anything asking the published config whether the network has stream points was told no

## The fix

Read the lists off `converter._last_config`, keeping the local config as the fallback so a converter subclass that overrides `build_network` without setting it behaves exactly as before. `SimulationWorker` is the single solve path for plain runs and for run-set scenarios, so one change covers both.

The frontend was already written expecting these nodes — `ReactorGraph` skips synthesizing a diamond when a real stream-point node exists, `PropertiesPanel` has a stream-point view, and `merge_config_into_yaml` filters exactly these solver-added nodes back out when saving YAML. The deepcopy silently starved all three.

## Verification

- `tests/test_worker_publishes_stream_points.py` — drives a real `SimulationWorker` solve of a two-stage chain and asserts the published node list contains the stream point with converged thermo. Reverting the fix fails it on the exact set difference (`Extra items in the right set: 'r_a_outlet'`).
- Full backend suite: 859 passed, 12 skipped, 7 xfailed. The 15 failures in the local run are all `pandas`/`matplotlib` missing from that venv (`ImportError: Method requires a working pandas installation.`), unrelated to this change.
- `pre-commit run --files boulder/simulation_worker.py tests/test_worker_publishes_stream_points.py` — all hooks pass, no files modified
- End-to-end in a browser against the built frontend: ran a two-stage config, confirmed the real `r_a_outlet` diamond now reaches the graph (one diamond, not a duplicate placeholder alongside it).

Rebased onto `main` and squashed to a single commit; the net diff is unchanged (`boulder/simulation_worker.py` +10/−3, plus the regression test).

*Extensive AI use — code & PR fully written by Claude Opus 5*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
