### PR TITLE
fix(gui): Run Simulation solves the selected scenario, not the baseline

### DIFF
--- a/boulder/api/routes/simulations.py
+++ b/boulder/api/routes/simulations.py
@@ -14,7 +14,7 @@ from typing import Any, Dict, Optional
 
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import StreamingResponse
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from ...cantera_converter import DualCanteraConverter
 from ...config import TRANSIENT_SOLVER_KINDS, synthesize_default_group
@@ -67,6 +67,41 @@ class StartSimulationRequest(BaseModel):
     mechanism: Optional[str] = None
     simulation_time: Optional[float] = None
     time_step: Optional[float] = None
+    #: Run-set entry to solve *instead of* ``config``: the scenario selected in
+    #: the GUI. ``None`` (or ``BASELINE``) keeps solving the submitted config,
+    #: which is the only config carrying this session's base-network edits.
+    scenario_id: Optional[str] = None
+    #: The caller's in-memory scenario overlays map, as ``POST /api/sweep/run``
+    #: takes it -- ``scenario_id`` is resolved against these.
+    scenarios: Dict[str, Any] = Field(default_factory=dict)
+
+
+def _scenario_config(
+    request: Request, body: StartSimulationRequest
+) -> Optional[Dict[str, Any]]:
+    """Return the normalized config for ``body.scenario_id`` (``None`` if unset).
+
+    Resolved through the same expansion Run Sweep uses (base snapshot ⊕ the
+    caller's overlays → :func:`boulder.runset.expand_scenarios`), so running
+    one selected scenario on its own and running it inside a sweep solve the
+    same config. BASELINE is deliberately *not* diverted: it is the submitted
+    config, the only one carrying this session's base-network edits.
+    """
+    from ...runset import BASELINE_SCENARIO_ID, expand_scenarios
+
+    if not body.scenario_id or body.scenario_id == BASELINE_SCENARIO_ID:
+        return None
+
+    from ...cantera_converter import get_plugins
+    from ...config import normalize_config
+    from .sweep import _merged_raw
+
+    for sid, cfg in expand_scenarios(_merged_raw(request, body.scenarios)):
+        if sid == body.scenario_id:
+            return normalize_config(copy.deepcopy(cfg), plugins=get_plugins())
+    raise HTTPException(
+        status_code=404, detail=f"Unknown scenario {body.scenario_id!r}"
+    )
 
 
 def _require_positive(value: float, name: str) -> None:
@@ -198,7 +233,8 @@ async def start_simulation(
     #
     # synthesize_default_group IS idempotent: it only adds a "default" group
     # when none exists, which build_network requires.
-    config: Dict[str, Any] = dict(body.config)
+    scenario_config = _scenario_config(request, body)
+    config: Dict[str, Any] = scenario_config or dict(body.config)
     synthesize_default_group(config)
 
     # Determine mechanism
@@ -244,8 +280,18 @@ async def start_simulation(
         # worker left with no raw config wrote `BASE` into the default location
         # while a sweep of the same config wrote `BASELINE` into the declared
         # one -- the two paths disagreeing about a store they now share.
+        # A selected scenario names its own entry, so its result lands under
+        # that scenario id instead of overwriting the base entry -- the same
+        # naming a sweep gives it.
+        meta = config.get("metadata") or {}
         worker.set_run_identity(
-            None, raw_config=getattr(request.app.state, "preloaded_raw", None)
+            body.scenario_id if scenario_config is not None else None,
+            label=(
+                str(meta.get("scenario_name") or body.scenario_id)
+                if scenario_config is not None
+                else None
+            ),
+            raw_config=getattr(request.app.state, "preloaded_raw", None),
         )
         worker.start_simulation(
             converter,
@@ -387,7 +433,9 @@ async def check_simulation_cache(
 
     # Normalize exactly like a run would (transient re-runs included).
     config = normalize_config_for_fingerprint(
-        body.config, body.simulation_time, body.time_step
+        _scenario_config(request, body) or body.config,
+        body.simulation_time,
+        body.time_step,
     )
     converter_cls = getattr(request.app.state, "converter_class", None)
     mechanism = resolve_mechanism_for_fingerprint(

--- a/frontend/src/api/resultCache.ts
+++ b/frontend/src/api/resultCache.ts
@@ -40,6 +40,7 @@ export function checkSimulationCache(
   mechanism?: string | null,
   simulationTime?: number,
   timeStep?: number,
+  scenario?: { id: string; overlays: Record<string, unknown> },
 ): Promise<CacheCheckResponse> {
   return apiFetch<CacheCheckResponse>("/simulations/check-cache", {
     method: "POST",
@@ -52,6 +53,11 @@ export function checkSimulationCache(
       // matches what the worker saved.
       simulation_time: simulationTime ?? null,
       time_step: timeStep ?? null,
+      // Same scenario selection the run itself sends (see startSimulation) —
+      // otherwise this looks up the base config's fingerprint and hands back
+      // the baseline result for a selected scenario.
+      scenario_id: scenario?.id ?? null,
+      scenarios: scenario?.overlays ?? {},
     }),
   });
 }

--- a/frontend/src/api/simulations.ts
+++ b/frontend/src/api/simulations.ts
@@ -6,14 +6,25 @@ interface StartResponse {
   simulation_id: string;
 }
 
+/**
+ * Start a run. When *scenario* is given, the server solves that run-set entry
+ * (base config ⊕ *scenario.overlays*) instead of *config* — the same
+ * expansion Run Sweep uses — and stores the result under that scenario id.
+ * BASELINE is passed as-is and keeps solving *config*.
+ */
 export function startSimulation(
   config: NormalizedConfig,
   simulationTime?: number,
   timeStep?: number,
+  scenario?: { id: string; overlays: Record<string, unknown> },
 ) {
   const body: Record<string, unknown> = { config };
   if (simulationTime !== undefined) body.simulation_time = simulationTime;
   if (timeStep !== undefined) body.time_step = timeStep;
+  if (scenario) {
+    body.scenario_id = scenario.id;
+    body.scenarios = scenario.overlays;
+  }
   return apiFetch<StartResponse>("/simulations", {
     method: "POST",
     body: JSON.stringify(body),

--- a/frontend/src/components/panels/SimulateCard.tsx
+++ b/frontend/src/components/panels/SimulateCard.tsx
@@ -4,6 +4,7 @@ import { useConfigStore } from "@/stores/configStore";
 import { useSimulationStore } from "@/stores/simulationStore";
 import { useSolverStore } from "@/stores/solverStore";
 import { useScenarioStore } from "@/stores/scenarioStore";
+import { BASELINE_SCENARIO_ID } from "@/api/scenarios";
 import { useSweepRunStore } from "@/stores/sweepStore";
 import { fetchGuiActions, runGuiAction } from "@/api/guiActions";
 import { startSimulation, stopSimulation } from "@/api/simulations";
@@ -124,6 +125,16 @@ export function SimulateCard() {
       return;
     }
 
+    // Run what the Scenario pane has selected, not the baseline. The server
+    // resolves the id against these overlays exactly as Run Sweep does; a
+    // null/BASELINE selection keeps solving the config held here (the only
+    // one carrying this session's base-network edits).
+    const { activeId, overlays } = useScenarioStore.getState();
+    const scenario =
+      activeId && activeId !== BASELINE_SCENARIO_ID
+        ? { id: activeId, overlays: overlays as Record<string, unknown> }
+        : undefined;
+
     // Check whether a cached result already exists for the current config.
     // This avoids re-running the full simulation when nothing has changed.
     // Transient runs pass their time/step overrides so the server-side
@@ -141,6 +152,7 @@ export function SimulateCard() {
           mechStr,
           sendTimeOverride ? parseFloat(simTime) : undefined,
           sendTimeOverride ? parseFloat(timeStep) : undefined,
+          scenario,
         );
         if (cacheResp.cached) {
           setResults(cacheResp.result);
@@ -161,6 +173,7 @@ export function SimulateCard() {
         config,
         sendTimeOverride ? parseFloat(simTime) : undefined,
         sendTimeOverride ? parseFloat(timeStep) : undefined,
+        scenario,
       );
       setStarted(resp.simulation_id);
     } catch (err) {

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -830,3 +830,142 @@ class TestStaticFrontend:
             resp = await client.get("/assets/SankeyTab-stalehash.js")
         assert resp.status_code == 404
         assert "text/html" not in resp.headers.get("content-type", "")
+
+
+# ---------------------------------------------------------------------------
+# Run Simulation on the selected scenario
+# ---------------------------------------------------------------------------
+
+
+class TestRunSelectedScenario:
+    """``POST /api/simulations`` solves ``scenario_id``, not the baseline."""
+
+    _RAW = {
+        "metadata": {},
+        "phases": {"gas": {"mechanism": "gri30.yaml"}},
+        "settings": {"end_time": 1.0, "dt": 0.1},
+        "nodes": [
+            {
+                "id": "r",
+                "type": "IdealGasReactor",
+                "properties": {"temperature": 300.0},
+            }
+        ],
+        "connections": [],
+    }
+
+    @staticmethod
+    def _stub(monkeypatch, captured):
+        class DummyConverter:
+            def __init__(self, mechanism: str):
+                self.mechanism = mechanism
+
+        class DummyWorker:
+            def set_run_identity(self, scenario_id, **kwargs):
+                captured["scenario_id"] = scenario_id
+                captured["label"] = kwargs.get("label")
+
+            def start_simulation(self, converter, config, *_args, **_kwargs):
+                captured["config"] = config
+
+        monkeypatch.setattr(simulation_routes, "DualCanteraConverter", DummyConverter)
+        monkeypatch.setattr(simulation_routes, "SimulationWorker", DummyWorker)
+
+    @staticmethod
+    def _temperature(config):
+        return config["nodes"][0]["properties"]["temperature"]
+
+    @pytest.mark.asyncio
+    async def test_selected_scenario_overrides_the_base_config(self, monkeypatch):
+        simulation_routes._simulations.clear()
+        captured: dict = {}
+        self._stub(monkeypatch, captured)
+
+        app = create_app()
+        app.state.preloaded_raw = dict(self._RAW)
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            resp = await client.post(
+                "/api/simulations",
+                json={
+                    # The config the GUI holds is the *baseline* one -- if the
+                    # route used it, the override below would be ignored.
+                    "config": {"nodes": [], "connections": []},
+                    "scenario_id": "hot",
+                    "scenarios": {
+                        "hot": {
+                            "metadata": {"scenario_name": "Hot feed"},
+                            "nodes": [
+                                {"id": "r", "properties": {"temperature": 900.0}}
+                            ],
+                        }
+                    },
+                },
+            )
+
+        assert resp.status_code == 200
+        assert self._temperature(captured["config"]) == 900.0
+        # Named after the scenario, so the result lands in that entry rather
+        # than overwriting the baseline's.
+        assert captured["scenario_id"] == "hot"
+        assert captured["label"] == "Hot feed"
+        simulation_routes._simulations.clear()
+
+    @pytest.mark.asyncio
+    async def test_baseline_and_no_selection_keep_the_submitted_config(
+        self, monkeypatch
+    ):
+        """Only the submitted config carries this session's base-network edits."""
+        simulation_routes._simulations.clear()
+        captured: dict = {}
+        self._stub(monkeypatch, captured)
+
+        edited = {
+            "nodes": [
+                {
+                    "id": "r",
+                    "type": "IdealGasReactor",
+                    "properties": {"temperature": 500.0},
+                }
+            ],
+            "connections": [],
+            "settings": {"end_time": 1.0, "dt": 0.1},
+        }
+        app = create_app()
+        app.state.preloaded_raw = dict(self._RAW)
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            for scenario_id in ("BASELINE", None):
+                resp = await client.post(
+                    "/api/simulations",
+                    json={"config": edited, "scenario_id": scenario_id},
+                )
+                assert resp.status_code == 200
+                assert self._temperature(captured["config"]) == 500.0
+                assert captured["scenario_id"] is None
+
+        simulation_routes._simulations.clear()
+
+    @pytest.mark.asyncio
+    async def test_unknown_scenario_is_a_404(self, monkeypatch):
+        simulation_routes._simulations.clear()
+        self._stub(monkeypatch, {})
+
+        app = create_app()
+        app.state.preloaded_raw = dict(self._RAW)
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            resp = await client.post(
+                "/api/simulations",
+                json={
+                    "config": {"nodes": [], "connections": []},
+                    "scenario_id": "nope",
+                    "scenarios": {"hot": {}},
+                },
+            )
+
+        assert resp.status_code == 404
+        simulation_routes._simulations.clear()


### PR DESCRIPTION
## Problem

Selecting a scenario in the Scenario pane changed what the results area showed, but not what **Run Simulation** solved — the run always sent the base config. Consequences:

- a scenario with no cached trajectory could only ever be solved by a full **Run Sweep**;
- re-running with a scenario selected silently overwrote the *baseline* store entry.

## Change

`POST /api/simulations` — and `/check-cache`, which has to fingerprint whatever the run would save — now accept `scenario_id` plus the caller's in-memory overlays map, the same body shape `POST /api/sweep/run` already takes.

The id is resolved through the **existing** `expand_scenarios(base snapshot ⊕ overlays)` path the sweep uses, then normalized, so running one scenario on its own and running it inside a sweep solve the same config. The worker is given that scenario's run identity (id + label), so the result lands in its own store entry instead of the baseline's.

`BASELINE` and "nothing selected" are deliberately *not* diverted: the config the GUI submits is the only one carrying this session's base-network edits, and resolving from the startup snapshot would silently drop them. An unknown `scenario_id` is a 404.

Frontend: `handleRun` in `SimulateCard.tsx` passes `scenarioStore.activeId` + overlays to both the cache check and the run.

## Verification

- 3 new tests in `tests/test_api.py` — scenario overrides the base config (and names its own entry), `BASELINE`/none keep the submitted config, unknown id → 404
- `pytest tests/test_api.py tests/test_worker_persists_to_store.py tests/test_sweep_stop.py` — 50 passed
- `pre-commit run --files <changed>` — clean
- `frontend`: `npm run type-check`, `npm run test:unit` (255 passed), `npm run build`

`mypy` was not run: it is not installed in the local venv.

## Not included

The primary button still reads "Run Simulation" with no scenario name on it. Worth adding if it reads ambiguous now that the action follows the selection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
