### PR TITLE
fix(gui): make the kind ⓘ tooltip a reachable Cantera docs link

### DIFF
--- a/frontend/src/components/modals/AddMFCModal.tsx
+++ b/frontend/src/components/modals/AddMFCModal.tsx
@@ -126,17 +126,14 @@ export function AddMFCModal({ open, onClose, defaultGroup, defaultSource }: Prop
             {selectedDoc?.doc_url && (
               <Tooltip
                 content={
-                  <span className="block space-y-1">
-                    <span className="block">{selectedDoc.description}</span>
-                    <a
-                      href={selectedDoc.doc_url}
-                      target="_blank"
-                      rel="noreferrer"
-                      className="underline text-primary"
-                    >
-                      Docs
-                    </a>
-                  </span>
+                  <a
+                    href={selectedDoc.doc_url}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="underline text-primary"
+                  >
+                    Docs
+                  </a>
                 }
               >
                 <span

--- a/frontend/src/components/modals/AddReactorModal.tsx
+++ b/frontend/src/components/modals/AddReactorModal.tsx
@@ -124,17 +124,14 @@ export function AddReactorModal({ open, onClose, defaultGroup }: Props) {
             {selectedDoc?.doc_url && (
               <Tooltip
                 content={
-                  <span className="block space-y-1">
-                    <span className="block">{selectedDoc.description}</span>
-                    <a
-                      href={selectedDoc.doc_url}
-                      target="_blank"
-                      rel="noreferrer"
-                      className="underline text-primary"
-                    >
-                      Docs
-                    </a>
-                  </span>
+                  <a
+                    href={selectedDoc.doc_url}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="underline text-primary"
+                  >
+                    Docs
+                  </a>
                 }
               >
                 <span

--- a/frontend/src/components/panels/PropertiesPanel.test.tsx
+++ b/frontend/src/components/panels/PropertiesPanel.test.tsx
@@ -466,7 +466,6 @@ describe("PropertiesPanel Cantera doc-link tooltip", () => {
       "href",
       "https://cantera.org/stable/python/zerodim.html#cantera.IdealGasReactor",
     );
-    expect(screen.getByText("Ideal-gas, constant-volume reactor.")).toBeInTheDocument();
   });
 
   it("shows a Cantera doc link for a selected connection kind on hover", () => {

--- a/frontend/src/components/panels/PropertiesPanel.tsx
+++ b/frontend/src/components/panels/PropertiesPanel.tsx
@@ -419,19 +419,14 @@ export function PropertiesPanel() {
             {kindDoc?.doc_url && (
               <Tooltip
                 content={
-                  <span className="block space-y-1">
-                    {kindDoc.description && (
-                      <span className="block">{kindDoc.description}</span>
-                    )}
-                    <a
-                      href={kindDoc.doc_url}
-                      target="_blank"
-                      rel="noreferrer"
-                      className="underline text-primary"
-                    >
-                      Docs
-                    </a>
-                  </span>
+                  <a
+                    href={kindDoc.doc_url}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="underline text-primary"
+                  >
+                    Docs
+                  </a>
                 }
               >
                 <span

--- a/frontend/src/components/ui/Tooltip.tsx
+++ b/frontend/src/components/ui/Tooltip.tsx
@@ -55,7 +55,7 @@ export function Tooltip({ content, children, className }: TooltipProps) {
         <span
           id={id}
           role="tooltip"
-          className="absolute bottom-full left-1/2 z-30 mb-1.5 w-max max-w-xs -translate-x-1/2 rounded-md border border-border bg-popover px-2 py-1 text-xs text-popover-foreground shadow-lg"
+          className="absolute bottom-full left-1/2 z-30 mb-1.5 w-max max-w-xs -translate-x-1/2 rounded-md border border-border bg-popover px-2 py-1 text-xs text-popover-foreground shadow-lg after:absolute after:left-0 after:top-full after:h-1.5 after:w-full after:content-['']"
         >
           {content}
         </span>


### PR DESCRIPTION
Hovering the ⓘ next to a node's or connection's kind showed the long kind
description, with the `Docs` link buried under it — and the 6px gap between the
trigger and the popup fired `mouseleave` before the pointer could get there, so
the link could never be clicked.

## Changes

- `Tooltip`: a transparent `after:` bridge spans the `mb-1.5` gap, so moving the
  pointer from the trigger into the popup keeps it open. This fixes every
  `Tooltip` caller, not just the kind tooltips.
- `PropertiesPanel`, `AddReactorModal`, `AddMFCModal`: the kind tooltip is now
  just the clickable `Docs` link.

## Verification

`npx vitest run` on the four touched test files: 45 passed. `npx tsc --noEmit`
clean.

---

*Extensive AI use — code & PR fully written by Claude Opus 5*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Example

<img width="505" height="96" alt="image" src="https://github.com/user-attachments/assets/5c938fe7-0cf5-401c-99b3-b0b2c0700ef6" />

Leads to  : https://cantera.org/stable/python/zerodim.html#cantera.Reservoir
