### PR TITLE
fix(api): report the stage a sweep is solving, not the one it finished

### DIFF
--- a/boulder/api/routes/sweep.py
+++ b/boulder/api/routes/sweep.py
@@ -377,8 +377,15 @@ async def sweep_run(
                     continue
 
                 line = f"scenario {i + 1}/{total} ({sid})"
+                # Stage counts are unknown until the solver reports them (see
+                # `_publish` below), but the stage now running is already known:
+                # nothing has completed, so it is the first one.
                 state["scenario_progress"] = {
-                    sid: {"stage": None, "stage_total": None, "stage_id": None}
+                    sid: {
+                        "stage": None,
+                        "stage_total": None,
+                        "stage_id": next(iter(config.get("groups") or {}), None),
+                    }
                 }
                 state["message"] = line
                 state["last_line"] = line
@@ -390,16 +397,31 @@ async def sweep_run(
                 # depend on which button produced it. `progress_cb` is how this
                 # route stays able to publish per-stage progress while the
                 # solve runs.
-                def _publish(progress: Any, _sid: str = sid) -> None:
+                # Both fields describe the stage *currently solving*, not the
+                # last one that finished: `SimulationProgress` counts completed
+                # stages, so the running stage is `stages_done + 1` -- matching
+                # the solver's own "stage 'x' (3/3)" log line shown underneath,
+                # which is 1-based over stages *started*. Its id is the first
+                # stage not yet completed; `config["groups"]` is already in
+                # topological (== solve) order, see `config.py`.
+                def _publish(
+                    progress: Any, _sid: str = sid, _cfg: Any = config
+                ) -> None:
                     if progress.n_stages:
+                        done = set(progress.completed_stage_ids)
                         state["scenario_progress"] = {
                             _sid: {
-                                "stage": progress.stages_done,
+                                "stage": min(
+                                    progress.stages_done + 1, progress.n_stages
+                                ),
                                 "stage_total": progress.n_stages,
-                                "stage_id": (
-                                    progress.completed_stage_ids[-1]
-                                    if progress.completed_stage_ids
-                                    else None
+                                "stage_id": next(
+                                    (
+                                        g
+                                        for g in (_cfg.get("groups") or {})
+                                        if g not in done
+                                    ),
+                                    None,
                                 ),
                             }
                         }

--- a/tests/test_sweep_status_scenario_progress.py
+++ b/tests/test_sweep_status_scenario_progress.py
@@ -46,11 +46,44 @@ network:
 """
 
 
-def _client_with_config(tmp_path: Path):
+# Two stages, so `scenario_progress` has something to count: `groups` comes out
+# of validation in topological (== solve) order, which is what tells the route
+# which stage is running -- the first one not yet completed.
+_TWO_STAGE_YAML = """
+metadata:
+  description: "two-stage test config"
+phases:
+  gas:
+    mechanism: gri30.yaml
+stages:
+  first:
+    mechanism: gri30.yaml
+    solver: advance_to_steady_state
+  second:
+    mechanism: gri30.yaml
+    solver: advance_to_steady_state
+
+first:
+  - id: feed
+    Reservoir:
+      temperature: 298.15
+      pressure: 101325
+      composition: "CH4:1"
+
+second:
+  - id: feed2
+    Reservoir:
+      temperature: 298.15
+      pressure: 101325
+      composition: "CH4:1"
+"""
+
+
+def _client_with_config(tmp_path: Path, yaml_text: str = _CONFIG_YAML):
     from boulder.runner import BoulderRunner
 
     cfg = tmp_path / "config.yaml"
-    cfg.write_text(_CONFIG_YAML, encoding="utf-8")
+    cfg.write_text(yaml_text, encoding="utf-8")
 
     app = create_app()
     client = TestClient(app)
@@ -97,7 +130,7 @@ def test_scenario_progress_tracks_stage_then_moves_to_the_next_scenario(
     A fresh scenario starts with no stage info of its own -- BASELINE (the
     unmodified base config) always solves first, then each named scenario.
     """
-    client, app = _client_with_config(tmp_path)
+    client, app = _client_with_config(tmp_path, _TWO_STAGE_YAML)
     workers: List[_FakeWorker] = []
 
     def _factory() -> _FakeWorker:
@@ -111,26 +144,32 @@ def test_scenario_progress_tracks_stage_then_moves_to_the_next_scenario(
             assert resp.status_code == 200, resp.text
 
             _wait_until(lambda: len(workers) >= 1)
+            # Stage "first" is done, so stage 2 of 2 ("second") is the one now
+            # solving -- what both the spinner headline and the tinted stage box
+            # mean by "stage". Reporting the *finished* stage here made the
+            # headline read "Stage 1/2" while the solver log line right
+            # underneath already announced stage 2/2.
             workers[0].progress = SimulationProgress(
-                stages_done=1, n_stages=2, completed_stage_ids=["default"]
+                stages_done=1, n_stages=2, completed_stage_ids=["first"]
             )
             _wait_until(
                 lambda: app.state.sweep_job.get("scenario_progress", {})
                 .get("BASELINE", {})
                 .get("stage")
-                == 1
+                == 2
             )
             assert app.state.sweep_job["scenario_progress"] == {
-                "BASELINE": {"stage": 1, "stage_total": 2, "stage_id": "default"}
+                "BASELINE": {"stage": 2, "stage_total": 2, "stage_id": "second"}
             }
 
             # BASELINE finishes -- the sweep moves on to "a".
             workers[0].progress = SimulationProgress(is_complete=True)
             _wait_until(lambda: len(workers) >= 2)
             _wait_until(lambda: app.state.sweep_job.get("current") == 2)
-            # "a"'s freshly constructed worker hasn't reported a stage yet.
+            # "a"'s freshly constructed worker hasn't reported stage counts
+            # yet -- but its first stage is already the one solving.
             assert app.state.sweep_job["scenario_progress"] == {
-                "a": {"stage": None, "stage_total": None, "stage_id": None}
+                "a": {"stage": None, "stage_total": None, "stage_id": "first"}
             }
 
             workers[1].progress = SimulationProgress(is_complete=True)
@@ -219,8 +258,10 @@ def test_scenario_progress_clears_if_a_scenario_errors_mid_solve(
                 .get("stage")
                 == 1
             )
+            # The only stage has finished, so no stage id is reported -- there
+            # is nothing left solving for the graph to tint.
             assert app.state.sweep_job["scenario_progress"] == {
-                "BASELINE": {"stage": 1, "stage_total": 1, "stage_id": "default"}
+                "BASELINE": {"stage": 1, "stage_total": 1, "stage_id": None}
             }
 
             workers[0].progress = SimulationProgress(error_message="boom")


### PR DESCRIPTION
The sweep spinner showed `Calculating "backpulse_max"… — Stage 2/3` with
`Staged solve: stage 'pfr_stage' (3/3, 3 reactors)` on the line right below it.

## Root cause

`GET /api/sweep/status`'s `scenario_progress` published
`SimulationProgress.stages_done` — stages *completed* — as `stage`, and
`completed_stage_ids[-1]` as `stage_id`. Both consumers mean the stage
*currently solving*:

- `SweepCalculatingCard` renders `Stage {stage}/{stageTotal}` in the headline,
  while the detail line under it is the solver's own log record, which is 1-based
  over stages *started* — hence 2/3 vs 3/3 for the same moment.
- `ReactorGraph` tints `stageId`'s box "calculating" — so it was highlighting the
  stage that had just finished.

The single-run path never had this: `frontend/src/lib/simulationProgress.ts`
already displays `min(stagesDone + 1, nStages)`.

## Fix

`boulder/api/routes/sweep.py` publishes the running stage:

- `stage` → `min(stages_done + 1, n_stages)`
- `stage_id` → first stage in `config["groups"]` (already topological, see
  `config.py`) not yet in `completed_stage_ids`, which is the same rule
  `ReactorGraph` already uses to find the stage a failed solve died in.
- A scenario's first stage is known to be running the moment it starts, so its id
  is published at scenario start too (counts still wait for the solver to report
  them). Side benefit: a single-stage scenario now gets tinted while it solves
  instead of never.

## Verification

- `pytest tests/test_sweep_status_scenario_progress.py` — 3 passed; the stage test
  now runs on a two-stage config so the "which stage is running" derivation is
  actually exercised.
- `pytest tests -k "sweep or scenario"` — 155 passed, 1 xfailed.
- `pre-commit` on the touched files, and `mypy boulder/api/routes/sweep.py`: clean.

---

*Extensive AI use — code & PR fully written by Claude Opus 5*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
