### PR TITLE
fix: BASE/BASELINE duplicate row + generic Add Scenario placeholders

### DIFF
--- a/boulder/api/routes/simulations.py
+++ b/boulder/api/routes/simulations.py
@@ -280,9 +280,16 @@ async def start_simulation(
         # worker left with no raw config wrote `BASE` into the default location
         # while a sweep of the same config wrote `BASELINE` into the declared
         # one -- the two paths disagreeing about a store they now share.
+        #
+        # `body.scenarios` (the caller's overlays) must be folded in the same
+        # way (`_merged_raw`) so a GUI-only-authored scenario resolves the
+        # base to BASELINE here too -- `preloaded_raw` alone never carries
+        # one, only a hand-edited YAML `scenarios:` block does.
         # A selected scenario names its own entry, so its result lands under
         # that scenario id instead of overwriting the base entry -- the same
         # naming a sweep gives it.
+        from .sweep import _merged_raw  # noqa: PLC0415 — avoid import cycle
+
         meta = config.get("metadata") or {}
         worker.set_run_identity(
             body.scenario_id if scenario_config is not None else None,
@@ -291,7 +298,7 @@ async def start_simulation(
                 if scenario_config is not None
                 else None
             ),
-            raw_config=getattr(request.app.state, "preloaded_raw", None),
+            raw_config=_merged_raw(request, body.scenarios),
         )
         worker.start_simulation(
             converter,

--- a/frontend/src/components/modals/AddScenarioModal.tsx
+++ b/frontend/src/components/modals/AddScenarioModal.tsx
@@ -76,7 +76,7 @@ export function AddScenarioModal({ open, onClose, onCreated }: Props) {
             id="scenario-id"
             value={id}
             onChange={(e) => setId(e.target.value)}
-            placeholder="e.g. C1T"
+            placeholder="e.g. High_P"
             className="block w-full mt-1 px-2 py-1.5 text-sm rounded-md bg-input border border-border text-foreground"
             autoFocus
             onKeyDown={(e) => {
@@ -91,7 +91,7 @@ export function AddScenarioModal({ open, onClose, onCreated }: Props) {
             id="scenario-description"
             value={description}
             onChange={(e) => setDescription(e.target.value)}
-            placeholder="e.g. Case 1 max: H2-NG (25 %vol H2)"
+            placeholder="e.g. High Pressure Version"
             className="block w-full mt-1 px-2 py-1.5 text-sm rounded-md bg-input border border-border text-foreground"
             onKeyDown={(e) => {
               if (e.key === "Enter") void handleSubmit();

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -379,6 +379,57 @@ class TestSimulationRoutes:
         simulation_routes._simulations.clear()
 
     @pytest.mark.asyncio
+    async def test_start_simulation_names_the_base_BASELINE_for_gui_authored_scenarios(
+        self, monkeypatch
+    ):
+        """Assert a plain run resolves the base entry to BASELINE for GUI scenarios.
+
+        A scenario authored only in the GUI (never written into the YAML's
+        `scenarios:` block) must still make the plain run's base entry resolve
+        to BASELINE, matching what Run Sweep of the same overlays would name it.
+
+        Regression for the phantom-`BASE`-row bug re-appearing via
+        `body.scenarios` (the in-memory overlay map) instead of a hand-edited
+        YAML `scenarios:` block — see boulder.runset.base_entry_id.
+        """
+        from boulder.runset import BASELINE_SCENARIO_ID, base_entry_id
+
+        simulation_routes._simulations.clear()
+        captured: dict = {}
+
+        class DummyConverter:
+            def __init__(self, mechanism: str):
+                self.mechanism = mechanism
+
+        class DummyWorker:
+            def set_run_identity(self, scenario_id, **kwargs):
+                captured["scenario_id"] = scenario_id
+                captured["raw_config"] = kwargs.get("raw_config")
+
+            def start_simulation(self, *args, **kwargs):
+                pass
+
+        monkeypatch.setattr(simulation_routes, "DualCanteraConverter", DummyConverter)
+        monkeypatch.setattr(simulation_routes, "SimulationWorker", DummyWorker)
+
+        config = {"nodes": [], "connections": [], "settings": {}}
+        payload = {
+            "config": config,
+            # No scenario_id: this is the base ("Run Simulation" / BASELINE
+            # row), the same request shape the frontend sends when the pane's
+            # active selection is BASELINE.
+            "scenarios": {"hot": {}},
+        }
+        async with _make_client() as client:
+            resp = await client.post("/api/simulations", json=payload)
+
+        assert resp.status_code == 200
+        assert captured["scenario_id"] is None
+        assert base_entry_id(captured["raw_config"]) == BASELINE_SCENARIO_ID
+
+        simulation_routes._simulations.clear()
+
+    @pytest.mark.asyncio
     @pytest.mark.parametrize("invalid_time_step", [0.0, -1.0])
     async def test_start_simulation_rejects_non_positive_time_step(
         self, monkeypatch, invalid_time_step: float


### PR DESCRIPTION
## Summary
- Fixes a real "one result, two names" bug: creating a scenario through the **+ Add Scenario** pane (no YAML `scenarios:` block) and running the base ("Run Simulation" / BASELINE row) stored the result as `BASE` instead of `BASELINE`, leaving the pane showing a phantom `BASE` row and an authored `BASELINE` row stuck on "Not computed yet" — the exact symptom in the issue screenshot (BASELINE / C1T / BASE all present).
  - Root cause: `POST /api/simulations` named the base entry from `app.state.preloaded_raw` (the pristine startup snapshot, never mutated by GUI-only scenario authoring), while `POST /api/sweep/run` names it from `preloaded_raw` merged with the caller's in-memory scenario overlays (`_merged_raw`). Same overlays, two different base names.
  - This is the same bug class already described in `runset.base_entry_id`'s docstring and guarded by `test_worker_persists_to_store.py`, just reached via GUI-only authoring instead of a hand-edited YAML — the existing fix/test didn't cover this path.
  - Fix: `boulder/api/routes/simulations.py` now merges `body.scenarios` into the raw config via the same `_merged_raw` helper before naming the base entry.
  - Added a regression test (`tests/test_api.py::test_start_simulation_names_the_base_BASELINE_for_gui_authored_scenarios`) that fails on `main` and passes with the fix.
- `AddScenarioModal`'s default placeholders (`"C1T"`, `"Case 1 max: H2-NG (25 %vol H2)"`) were example values from a specific downstream config, not generic to Boulder. Swapped for `"High_P"` / `"High Pressure Version"`.

## Test plan
- [x] `pytest tests/test_api.py tests/test_worker_persists_to_store.py tests/test_sweep_scenario_hooks.py` — all pass
- [x] New regression test confirmed to fail on `main` (pre-fix) and pass with the fix
- [x] `npx vitest run` (full frontend suite) — 255 passed
- [x] Full backend suite run; the 15 pre-existing failures (pandas import error, sim2stone example scripts, network diagram) reproduce identically on `main` without this change — unrelated to this fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)