### PR TITLE
fix(gui): reset scenario pane on config replace

### DIFF
--- a/frontend/src/components/panels/NetworkCard.test.tsx
+++ b/frontend/src/components/panels/NetworkCard.test.tsx
@@ -21,12 +21,12 @@ vi.mock("@/stores/configStore", () => ({
     selector({ setConfig: mockSetConfig, fileName: mockFileName }),
 }));
 
-const mockScenarioRefresh = vi.fn();
+const mockResetForNewConfig = vi.fn();
 vi.mock("@/stores/scenarioStore", () => {
   const useScenarioStore = (selector: (s: { activeId: string | null }) => unknown) =>
     selector({ activeId: mockActiveId });
   (useScenarioStore as unknown as { getState: () => unknown }).getState = () => ({
-    refresh: mockScenarioRefresh,
+    resetForNewConfig: mockResetForNewConfig,
   });
   return { useScenarioStore };
 });
@@ -92,7 +92,7 @@ describe("NetworkCard", () => {
     expect(onEditYaml).not.toHaveBeenCalled();
   });
 
-  it("nudges RunControl to re-check Run Sweep availability after an upload", async () => {
+  it("resets the scenario store to the new config's own scenarios after an upload", async () => {
     mockUploadConfigFile.mockResolvedValue({
       config: { nodes: [], connections: [] },
       filename: "uploaded.yaml",
@@ -105,6 +105,6 @@ describe("NetworkCard", () => {
     fireEvent.change(input, { target: { files: [file] } });
 
     await waitFor(() => expect(mockSetConfig).toHaveBeenCalledOnce());
-    expect(mockScenarioRefresh).toHaveBeenCalledOnce();
+    expect(mockResetForNewConfig).toHaveBeenCalledOnce();
   });
 });

--- a/frontend/src/components/panels/NetworkCard.tsx
+++ b/frontend/src/components/panels/NetworkCard.tsx
@@ -43,10 +43,10 @@ export function NetworkCard({ onEditYaml }: Props) {
       try {
         const resp = await uploadConfigFile(file);
         setConfig(resp.config, resp.filename, resp.yaml);
-        // The backend may have just adopted this upload as its preloaded
-        // config (if none was set yet) — bump scenarioRevision so RunControl
-        // re-checks Run Sweep availability instead of showing stale info.
-        void useScenarioStore.getState().refresh();
+        // A whole new network was just adopted server-side — drop this
+        // session's scenario overlays (they belonged to the previous file)
+        // and re-seed from the new config's own `scenarios:` block.
+        void useScenarioStore.getState().resetForNewConfig();
         toast.success(`Config uploaded: ${resp.filename}`);
       } catch (err) {
         toast.error(`Upload failed: ${err instanceof Error ? err.message : String(err)}`);

--- a/frontend/src/components/panels/YamlPane.test.tsx
+++ b/frontend/src/components/panels/YamlPane.test.tsx
@@ -53,9 +53,9 @@ vi.mock("@/stores/layoutStore", () => ({
     selector({ closeYamlPane: mockCloseYamlPane }),
 }));
 
-const mockScenarioRefresh = vi.fn();
+const mockResetForNewConfig = vi.fn();
 vi.mock("@/stores/scenarioStore", () => ({
-  useScenarioStore: { getState: () => ({ refresh: mockScenarioRefresh }) },
+  useScenarioStore: { getState: () => ({ resetForNewConfig: mockResetForNewConfig }) },
 }));
 
 vi.mock("@/stores/themeStore", () => ({
@@ -149,9 +149,9 @@ describe("YamlPane", () => {
     expect(mockParseYaml).toHaveBeenCalledWith("merged: yaml\nextra: 1\n");
     // A save that round-trips exactly what's on screen needs no re-sync.
     expect(saveButton()).toBeDisabled();
-    // Nudges RunControl to re-check Run Sweep availability: the backend may
-    // have just adopted this Save as its preloaded config.
-    expect(mockScenarioRefresh).toHaveBeenCalledOnce();
+    // The base config was just replaced -- drops stale scenario overlays and
+    // re-seeds from the new config's own `scenarios:` block.
+    expect(mockResetForNewConfig).toHaveBeenCalledOnce();
   });
 
   it("Cancel reverts unsaved edits back to the last synced value", async () => {

--- a/frontend/src/components/panels/YamlPane.tsx
+++ b/frontend/src/components/panels/YamlPane.tsx
@@ -106,10 +106,10 @@ export function YamlPane() {
       setConfig(resp.config, undefined, value);
       justSavedRef.current = true;
       setBaseline(value);
-      // The backend may have just adopted this Save as its preloaded config
-      // (if none was set yet) — bump scenarioRevision so RunControl re-checks
-      // Run Sweep availability instead of showing stale info.
-      void useScenarioStore.getState().refresh();
+      // The full base config was just replaced — drop this session's
+      // scenario overlays (they belonged to the previous YAML) and re-seed
+      // from the new config's own `scenarios:` block.
+      void useScenarioStore.getState().resetForNewConfig();
       toast.success("YAML config updated");
     } catch (err) {
       toast.error(`Invalid YAML: ${err instanceof Error ? err.message : String(err)}`);

--- a/frontend/src/stores/scenarioStore.test.ts
+++ b/frontend/src/stores/scenarioStore.test.ts
@@ -119,6 +119,32 @@ describe("scenarioStore", () => {
     expect(state.available).toBe(true); // unrelated fields still refresh normally
   });
 
+  it("resetForNewConfig() drops the old overlays and re-seeds from the new config", async () => {
+    mockListScenarios.mockResolvedValue({
+      available: false,
+      scenarios: [],
+      authored_ids: ["BASELINE", "A"],
+      authored_overlays: { A: {} },
+    });
+    await useScenarioStore.getState().refresh();
+    useScenarioStore.getState().applyOverlays({ A: {}, B: { metadata: {} } });
+    useScenarioStore.setState({ activeId: "A" });
+
+    // A brand new config was just uploaded -- it only defines "C".
+    mockListScenarios.mockResolvedValue({
+      available: true,
+      scenarios: [],
+      authored_ids: ["BASELINE", "C"],
+      authored_overlays: { C: {} },
+    });
+    await useScenarioStore.getState().resetForNewConfig();
+
+    const state = useScenarioStore.getState();
+    expect(state.overlays).toEqual({ C: {} });
+    expect(state.authoredIds).toEqual(["BASELINE", "C"]);
+    expect(state.activeId).toBeNull();
+  });
+
   it("createScenario sends the current overlays and applies the response locally", async () => {
     useScenarioStore.getState().applyOverlays({ A: {} });
     mockCreateScenario.mockResolvedValue({

--- a/frontend/src/stores/scenarioStore.ts
+++ b/frontend/src/stores/scenarioStore.ts
@@ -81,6 +81,13 @@ interface ScenarioState {
 
   /** Fetch the scenario list for the active store (no-op-safe if none). */
   refresh: () => Promise<void>;
+  /**
+   * Drop this session's authored overlays and re-seed from the server's
+   * `authored_overlays` on the next `refresh()` -- for when the base config
+   * itself was just replaced wholesale (upload / preloaded-config swap), so
+   * the previous config's scenarios stop lingering in the pane.
+   */
+  resetForNewConfig: () => Promise<void>;
   /** Load a scenario's trajectory and push it into the simulation results. */
   setActive: (id: string) => Promise<void>;
   /**
@@ -166,6 +173,20 @@ export const useScenarioStore = create<ScenarioState>((set, get) => ({
         revision: s.revision + 1,
       }));
     }
+  },
+
+  resetForNewConfig: async () => {
+    set({
+      overlays: {},
+      overlaysSeeded: false,
+      authoredIds: [],
+      activeId: null,
+      previewId: null,
+      previewNodes: null,
+      previewConnections: null,
+      previewError: null,
+    });
+    await get().refresh();
   },
 
   applyOverlays: (overlays) => {


### PR DESCRIPTION
## Summary
- Uploading a new YAML config (or saving in the full YAML editor) left the Scenario Pane showing the previous file's scenarios/count — `scenarioStore.refresh()` deliberately only seeds `overlays`/`authoredIds` from the server on the *first* call, to protect locally-authored scenarios from being clobbered by a mid-sweep refresh. That same guard also blocked a genuine config replacement from ever updating the list.
- Added `resetForNewConfig()` to the scenario store, which drops the stale overlays and lets the next `refresh()` re-seed from the newly adopted config's own `scenarios:` block. Wired it into both wholesale-replace paths: Upload Config (`NetworkCard.tsx`) and Save in the full YAML editor (`YamlPane.tsx`).
- Left the sweep-completion/mid-sweep `refresh()` calls untouched — those are legitimate cases where not clobbering local edits is correct.

## Test plan
- [x] `frontend`: added a store-level test for `resetForNewConfig()`, updated `NetworkCard.test.tsx` and `YamlPane.test.tsx` for the new call
- [x] Full frontend suite: `npx vitest run` → 256/256 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)