### PR TITLE
fix: derive __version__ from setuptools_scm

### DIFF
--- a/boulder/__init__.py
+++ b/boulder/__init__.py
@@ -1,6 +1,9 @@
 """Boulder - A Cantera ReactorNet Visualization Tool."""
 
-__version__ = "0.5.0"
+try:
+    from .version import __version__
+except ImportError:
+    __version__ = "0.0.0+unknown"
 
 from .lagrangian import LagrangianTrajectory
 from .runner import BoulderRunner


### PR DESCRIPTION
## Summary
- `boulder/__init__.py` hardcoded a stale `__version__` string that never matched the actual git-tag-derived version already written by setuptools_scm to `boulder/version.py`.
- Now imports `__version__` from the generated `version.py`, with a fallback for source checkouts without a build.

## Test plan
- [x] `import boulder; boulder.__version__` resolves to the scm-derived version (e.g. `0.9.2.dev2+gc355451d4`)