### PR TITLE
fix(gui): show scenario_name over id in the pane, drop metadata.scenario_id

### DIFF
--- a/.cursor/skills/boulder-scenario-cache-lifecycle/SKILL.md
+++ b/.cursor/skills/boulder-scenario-cache-lifecycle/SKILL.md
@@ -17,7 +17,7 @@ N=1 and N=3:
 
 ```
 <config_dir>/.boulder-cache/<stem>/
-    BASE.h5 | BASELINE.h5 | <scenario_id>.h5     # one file per entry
+    BASELINE.h5 | <scenario_id>.h5     # one file per entry
     artifacts/<scenario_id>/...
 ```
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -155,7 +155,7 @@ N=3. One HDF5 file per run-set entry:
 
 ```
 <config_dir>/.boulder-cache/<stem>/
-    BASE.h5 | BASELINE.h5 | <scenario_id>.h5
+    BASELINE.h5 | <scenario_id>.h5
     artifacts/<scenario_id>/...
 ```
 

--- a/boulder/cantera_converter.py
+++ b/boulder/cantera_converter.py
@@ -140,7 +140,7 @@ class BoulderPlugins:
 
     #: Axis-name/path-leaf → symbol mapping used by
     #: :func:`boulder.runset.expand_scenarios` to label sweep points in
-    #: scenario ids (e.g. ``diameter`` → ``TF_D`` gives ``BASE__TF_D=0.03``).
+    #: scenario ids (e.g. ``diameter`` → ``TF_D`` gives ``BASELINE__TF_D=0.03``).
     #: Registered by an external plugin package so sweep ids stay consistent
     #: between the GUI and out-of-process runners. ``None`` → plain axis names.
     sweep_symbols: Optional[Dict[str, str]] = None

--- a/boulder/runset.py
+++ b/boulder/runset.py
@@ -50,7 +50,6 @@ BASELINE_SCENARIO_ID = "BASELINE"
 #: *with* a ``scenarios:`` block instead names its unmodified base run
 #: :data:`BASELINE_SCENARIO_ID`, so adding the first scenario renames the base
 #: entry (and orphans its stored result, which is regenerable).
-#: Overridden by ``metadata.scenario_id`` when the config sets one.
 BASE_SCENARIO_ID = "BASE"
 
 # ---------------------------------------------------------------------------
@@ -417,9 +416,9 @@ def base_entry_id(raw: Dict[str, Any]) -> str:
     """Return the store id the *unmodified base* run is written under.
 
     :data:`BASELINE_SCENARIO_ID` when the config declares ``scenarios:``, else
-    :data:`BASE_SCENARIO_ID` (or an explicit ``metadata.scenario_id``). Mirrors
-    the naming :func:`expand_scenarios` gives the base entry, which is the whole
-    point: both paths that can solve the base must land on the same name.
+    :data:`BASE_SCENARIO_ID`. Mirrors the naming :func:`expand_scenarios` gives
+    the base entry, which is the whole point: both paths that can solve the
+    base must land on the same name.
 
     They did not. A sweep took the name from :func:`expand_scenarios`
     (``BASELINE``) while a plain Run Simulation defaulted to ``BASE``, so the
@@ -432,10 +431,7 @@ def base_entry_id(raw: Dict[str, Any]) -> str:
     and no unmodified-base entry is emitted at all, so the base keeps its plain
     name.
     """
-    if raw.get("scenarios"):
-        return BASELINE_SCENARIO_ID
-    declared = (raw.get("metadata") or {}).get("scenario_id")
-    return str(declared) if declared else BASE_SCENARIO_ID
+    return BASELINE_SCENARIO_ID if raw.get("scenarios") else BASE_SCENARIO_ID
 
 
 def expand_scenarios(
@@ -452,7 +448,7 @@ def expand_scenarios(
     the scenarios do not cross-multiply.
 
     When neither block is present, returns a single ``(scenario_id, base)``
-    tuple using ``metadata.scenario_id`` or :data:`BASE_SCENARIO_ID`.
+    tuple using :data:`BASE_SCENARIO_ID`.
 
     Parameters
     ----------
@@ -489,8 +485,7 @@ def expand_scenarios(
             "boulder.runset.expand_scenarios."
         )
 
-    base_meta = base_raw.get("metadata") or {}
-    base_id = base_meta.get("scenario_id", BASE_SCENARIO_ID)
+    base_id = BASE_SCENARIO_ID
     scenario_block = raw_scenarios or {}
     global_sweeps = sweeps_of(base_raw)
 

--- a/boulder/runset.py
+++ b/boulder/runset.py
@@ -37,20 +37,15 @@ import re
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Mapping, Optional, Tuple
 
-#: Scenario id for the unmodified base config's own run-set entry, added
-#: automatically whenever a ``scenarios:`` mapping is declared (see
-#: :func:`expand_scenarios`). Reserved: a host must reject this as a
-#: user-authored scenario id (see ``scenario_editor._validate_id``) since a
-#: config could otherwise define its own "BASELINE" overlay that collides
-#: with this synthesized entry.
+#: Scenario id for the unmodified base config's own run-set entry — whether
+#: that entry comes from a ``scenarios:`` mapping (see :func:`expand_scenarios`)
+#: or *is* the whole run-set (the N=1 case, no ``scenarios:`` block at all).
+#: One name for both so a plain Run Simulation and a Run Sweep of the same
+#: config always agree on where the result lives. Reserved: a host must
+#: reject this as a user-authored scenario id (see
+#: ``scenario_editor._validate_id``) since a config could otherwise define its
+#: own "BASELINE" overlay that collides with this synthesized entry.
 BASELINE_SCENARIO_ID = "BASELINE"
-
-#: Run-set id for the base config when it declares no ``scenarios:`` block —
-#: the N=1 case, where the whole run-set is just the config itself. A config
-#: *with* a ``scenarios:`` block instead names its unmodified base run
-#: :data:`BASELINE_SCENARIO_ID`, so adding the first scenario renames the base
-#: entry (and orphans its stored result, which is regenerable).
-BASE_SCENARIO_ID = "BASE"
 
 # ---------------------------------------------------------------------------
 # Deep merge with id-keyed list support (the STONE overlay merge).
@@ -309,7 +304,7 @@ def run_set_size(raw: Dict[str, Any]) -> int:
 # leave room to solve entries in parallel later.
 #
 #     <store_dir>/
-#         BASE.h5 | BASELINE.h5 | <scenario_id>.h5
+#         BASELINE.h5 | <scenario_id>.h5
 #         artifacts/<scenario_id>/...        host cache-contributor files
 
 #: Characters that are unsafe in a filename on some supported platform, plus
@@ -332,10 +327,10 @@ def _sha8(text: str) -> str:
 def store_entry_name(scenario_id: str) -> str:
     """Return a filesystem- and HDF5-safe stem for *scenario_id*.
 
-    Scenario ids reach us straight from YAML keys and from
-    ``metadata.scenario_id``, neither of which passes through
-    ``scenario_editor._validate_id`` (that guards only GUI-authored ids). They
-    now become *filenames*, so they must be sanitised centrally here.
+    Scenario ids reach us straight from YAML ``scenarios:`` keys and sweep-point
+    labels, neither of which passes through ``scenario_editor._validate_id``
+    (that guards only GUI-authored ids). They now become *filenames*, so they
+    must be sanitised centrally here.
 
     Sanitising alone would let distinct ids collide (``a/b`` and ``a_b`` mapping
     to one file, silently sharing results), so whenever the safe form differs
@@ -415,23 +410,24 @@ def store_artifacts_dir(store_dir: Path, scenario_id: str) -> Path:
 def base_entry_id(raw: Dict[str, Any]) -> str:
     """Return the store id the *unmodified base* run is written under.
 
-    :data:`BASELINE_SCENARIO_ID` when the config declares ``scenarios:``, else
-    :data:`BASE_SCENARIO_ID`. Mirrors the naming :func:`expand_scenarios` gives
-    the base entry, which is the whole point: both paths that can solve the
-    base must land on the same name.
+    Always :data:`BASELINE_SCENARIO_ID`, whether the config declares
+    ``scenarios:`` or is itself the whole (N=1) run-set. Mirrors the naming
+    :func:`expand_scenarios` gives the base entry, which is the whole point:
+    both paths that can solve the base must land on the same name.
 
-    They did not. A sweep took the name from :func:`expand_scenarios`
-    (``BASELINE``) while a plain Run Simulation defaulted to ``BASE``, so the
-    same result was stored twice under two names -- the pane grew a phantom
-    ``BASE`` row while the authored ``BASELINE`` row still read "Not computed
-    yet".
+    They did not, historically. A sweep took the name from
+    :func:`expand_scenarios` (``BASELINE``) while a plain Run Simulation
+    defaulted to a different id, so the same result was stored twice under two
+    names -- the pane grew a phantom row while the authored ``BASELINE`` row
+    still read "Not computed yet".
 
     A global ``sweep:`` without ``scenarios:`` deliberately does **not** count:
-    there the run-set is the sweep points themselves (ids prefixed ``BASE__``)
-    and no unmodified-base entry is emitted at all, so the base keeps its plain
-    name.
+    there the run-set is the sweep points themselves (ids prefixed
+    ``BASELINE__``) and no unmodified-base entry is emitted at all, so *this*
+    function's return value is moot for that config -- nothing gets written
+    under the plain ``BASELINE`` name.
     """
-    return BASELINE_SCENARIO_ID if raw.get("scenarios") else BASE_SCENARIO_ID
+    return BASELINE_SCENARIO_ID
 
 
 def expand_scenarios(
@@ -448,7 +444,7 @@ def expand_scenarios(
     the scenarios do not cross-multiply.
 
     When neither block is present, returns a single ``(scenario_id, base)``
-    tuple using :data:`BASE_SCENARIO_ID`.
+    tuple using :data:`BASELINE_SCENARIO_ID`.
 
     Parameters
     ----------
@@ -456,7 +452,7 @@ def expand_scenarios(
         The raw (``from:``-resolved) config. Not mutated.
     symbols : Mapping[str, str], optional
         Axis-name/path-leaf → symbol mapping used to label sweep points in
-        scenario ids (e.g. ``diameter`` → ``TF_D`` gives ``BASE__TF_D=0.03``).
+        scenario ids (e.g. ``diameter`` → ``TF_D`` gives ``BASELINE__TF_D=0.03``).
         Defaults to the host-registered ``plugins.sweep_symbols`` (empty when
         no host registered one). An axis's explicit ``symbol:`` always wins.
     schema_entry : callable, optional
@@ -485,7 +481,7 @@ def expand_scenarios(
             "boulder.runset.expand_scenarios."
         )
 
-    base_id = BASE_SCENARIO_ID
+    base_id = BASELINE_SCENARIO_ID
     scenario_block = raw_scenarios or {}
     global_sweeps = sweeps_of(base_raw)
 

--- a/boulder/scenario_store.py
+++ b/boulder/scenario_store.py
@@ -7,7 +7,7 @@ content-addressed store: the **name** is the key, and the ``fingerprint`` attr
 recorded under that name is the staleness check.
 
     <store_dir>/
-        BASE.h5 | BASELINE.h5 | <scenario_id>.h5
+        BASELINE.h5 | <scenario_id>.h5
         artifacts/<scenario_id>/...
 
 Consequence worth stating plainly: an entry holds **one** result, the latest.

--- a/boulder/validation.py
+++ b/boulder/validation.py
@@ -113,7 +113,6 @@ METADATA_MANDATORY_KEYS: frozenset = frozenset({"description"})
 
 METADATA_OPTIONAL_KEYS: frozenset = frozenset(
     {
-        "scenario_id",
         "title",
         "gui_app_title",
         "gui_app_version",
@@ -177,7 +176,6 @@ class MetadataModel(BaseModel):
 
     description: Optional[str] = None
 
-    scenario_id: Optional[str] = None
     title: Optional[str] = None
     #: Short label for the web UI header (e.g. ``MyApp``); omitted defaults to "Boulder".
     gui_app_title: Optional[str] = None

--- a/frontend/src/components/panels/ScenarioPane.test.tsx
+++ b/frontend/src/components/panels/ScenarioPane.test.tsx
@@ -35,12 +35,18 @@ let mockScenarios: Array<{ id: string; label: string; t0_K: number }> = [
   { id: "A", label: "Scenario A", t0_K: 300 },
 ];
 let mockAuthoredIds: string[] = [];
+// `metadata.scenario_name`/`description` per overlay -- the live, pre-solve
+// source the pane's title/subtitle now read from (see `overlayMeta`).
+let mockOverlays: Record<string, { metadata?: Record<string, unknown> }> = {
+  A: { metadata: { scenario_name: "Scenario A" } },
+};
 
 vi.mock("@/stores/scenarioStore", () => ({
   useScenarioStore: () => ({
     available: mockAvailable,
     scenarios: mockScenarios,
     authoredIds: mockAuthoredIds,
+    overlays: mockOverlays,
     createdAt: undefined,
     activeId: null,
     loading: false,
@@ -89,6 +95,7 @@ describe("ScenarioPane", () => {
     mockAvailable = true;
     mockScenarios = [{ id: "A", label: "Scenario A", t0_K: 300 }];
     mockAuthoredIds = [];
+    mockOverlays = { A: { metadata: { scenario_name: "Scenario A" } } };
     mockScenarioProgress = {};
   });
 

--- a/frontend/src/components/panels/ScenarioPane.tsx
+++ b/frontend/src/components/panels/ScenarioPane.tsx
@@ -6,7 +6,11 @@ import { useSweepRunStore } from "@/stores/sweepStore";
 import { useLayoutStore } from "@/stores/layoutStore";
 import { AddScenarioModal } from "@/components/modals/AddScenarioModal";
 import { SweepResultsPlot } from "./SweepResultsPlot";
-import { BASELINE_SCENARIO_ID, type ScenarioMeta } from "@/api/scenarios";
+import {
+  BASELINE_SCENARIO_ID,
+  type ScenarioMeta,
+  type ScenarioOverlay,
+} from "@/api/scenarios";
 
 /** One row in the pane: every authored id, paired with its computed data if any. */
 interface ScenarioRow {
@@ -27,6 +31,23 @@ function buildRows(authoredIds: string[], scenarios: ScenarioMeta[]): ScenarioRo
     if (!seen.has(s.id)) rows.push({ id: s.id, computed: s });
   }
   return rows;
+}
+
+/** `scenario_name`/`description`, read straight off the live overlay -- unlike
+ * the computed store's `label`, these are available before a scenario has
+ * ever been solved. Falls back to the id when a scenario has no name of its
+ * own (a blank or freshly cloned overlay). */
+function overlayMeta(
+  overlay: ScenarioOverlay | undefined,
+  id: string,
+): { name: string; description?: string } {
+  const metadata = (overlay?.metadata ?? {}) as Record<string, unknown>;
+  const name = metadata.scenario_name;
+  const description = metadata.description;
+  return {
+    name: typeof name === "string" && name ? name : id,
+    description: typeof description === "string" && description ? description : undefined,
+  };
 }
 
 /** Compact relative-time label, e.g. "just now", "2 min ago", "3 h ago". */
@@ -51,6 +72,7 @@ export function ScenarioPane() {
   const {
     scenarios,
     authoredIds,
+    overlays,
     createdAt,
     units,
     nonKpiKeys,
@@ -267,6 +289,7 @@ export function ScenarioPane() {
             const isCalculating = row.id in scenarioProgress;
             const s = row.computed;
             const ago = s ? timeAgo(s.computed_at ?? createdAt, now) : "";
+            const { name, description } = overlayMeta(overlays[row.id], row.id);
             return (
               // The action icons are an overlay (below), not siblings in a
               // flex row: as siblings they permanently reserved an icon column
@@ -296,7 +319,7 @@ export function ScenarioPane() {
                   ].join(" ")}
                 >
                   <div className="flex items-center justify-between gap-2">
-                    <span className="font-medium truncate">{row.id}</span>
+                    <span className="font-medium truncate">{name}</span>
                     {/* Hidden on hover -- the action icons take this spot. */}
                     {isCalculating ? (
                       <span className="shrink-0 text-[10px] text-primary animate-pulse group-hover:opacity-0">
@@ -314,13 +337,15 @@ export function ScenarioPane() {
                       </span>
                     )}
                   </div>
-                  {/* Descriptive scenario_name, when it adds anything beyond
-                      the id -- often identical/inherited across scenarios,
-                      which made every row look the same (the id, always
-                      unique, is the primary label above). */}
-                  {s?.label && s.label !== row.id && (
-                    <div className="text-[10px] text-muted-foreground truncate">
-                      {s.label}
+                  {/* From the live overlay, not the computed store -- shows
+                      up before a scenario has ever been solved. Single line,
+                      no wrap; hover (native `title`) surfaces the full text. */}
+                  {description && (
+                    <div
+                      title={description}
+                      className="text-[10px] text-muted-foreground truncate"
+                    >
+                      {description}
                     </div>
                   )}
                   {s?.reactor_mode && (

--- a/tests/test_runset.py
+++ b/tests/test_runset.py
@@ -25,15 +25,12 @@ from boulder.runset import (
 
 
 def test_expand_scenarios_no_block_returns_single_base():
-    """A YAML without scenarios:/sweep: yields a single scenario.
-
-    whose id matches ``metadata.scenario_id``.
-    """
-    base = {"metadata": {"scenario_id": "MY_BASE"}, "nodes": []}
+    """A YAML without scenarios:/sweep: yields a single scenario, id BASE."""
+    base = {"metadata": {"title": "plain"}, "nodes": []}
     out = expand_scenarios(base)
     assert len(out) == 1
     sid, cfg = out[0]
-    assert sid == "MY_BASE"
+    assert sid == "BASE"
     assert "scenarios" not in cfg
     assert "sweeps" not in cfg
 

--- a/tests/test_runset.py
+++ b/tests/test_runset.py
@@ -25,12 +25,12 @@ from boulder.runset import (
 
 
 def test_expand_scenarios_no_block_returns_single_base():
-    """A YAML without scenarios:/sweep: yields a single scenario, id BASE."""
+    """A YAML without scenarios:/sweep: yields a single scenario, id BASELINE."""
     base = {"metadata": {"title": "plain"}, "nodes": []}
     out = expand_scenarios(base)
     assert len(out) == 1
     sid, cfg = out[0]
-    assert sid == "BASE"
+    assert sid == "BASELINE"
     assert "scenarios" not in cfg
     assert "sweeps" not in cfg
 
@@ -89,7 +89,7 @@ def test_expand_scenario_plus_global_sweep_is_union_not_cartesian():
     out = expand_scenarios(base)
     ids = [sid for sid, _ in out]
     # BASELINE + 2 global sweep points + 1 scenario = 4 (not a cross product).
-    assert ids == ["BASELINE", "BASE__T=2600", "BASE__T=2700", "hot"]
+    assert ids == ["BASELINE", "BASELINE__T=2600", "BASELINE__T=2700", "hot"]
 
 
 def test_expand_scenario_local_sweep_multiplies_only_that_scenario():
@@ -192,7 +192,7 @@ def test_expand_scenarios_sweep_uses_symbols_mapping_for_axis_labels():
     }
     out = expand_scenarios(base, symbols={"diameter": "TF_D"})
     assert len(out) == 1
-    assert out[0][0] == "BASE__TF_D=0.03"
+    assert out[0][0] == "BASELINE__TF_D=0.03"
 
 
 def test_expand_scenarios_sweep_prefers_explicit_symbol_override():
@@ -209,7 +209,7 @@ def test_expand_scenarios_sweep_prefers_explicit_symbol_override():
     }
     out = expand_scenarios(base, symbols={"diameter": "TF_D"})
     assert len(out) == 1
-    assert out[0][0] == "BASE__MY_D=0.03"
+    assert out[0][0] == "BASELINE__MY_D=0.03"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_worker_persists_to_store.py
+++ b/tests/test_worker_persists_to_store.py
@@ -17,7 +17,7 @@ pytest.importorskip("h5py")
 
 from boulder import scenario_store as store  # noqa: E402
 from boulder.runset import (  # noqa: E402
-    BASE_SCENARIO_ID,
+    BASELINE_SCENARIO_ID,
     resolve_store_dir,
     store_artifacts_dir,
 )
@@ -84,7 +84,7 @@ def test_a_plain_solve_writes_the_base_entry(cfg: Path) -> None:
     store_dir = resolve_store_dir({}, cfg)
     identity = store.config_identity(cfg)
     entries = store.list_entries(store_dir, identity)
-    assert [e["id"] for e in entries] == [BASE_SCENARIO_ID]
+    assert [e["id"] for e in entries] == [BASELINE_SCENARIO_ID]
     assert entries[0]["fingerprint"]
 
 
@@ -129,12 +129,12 @@ def test_the_entry_answers_to_the_post_build_fingerprint_too(cfg: Path) -> None:
 
     assert (store.find_entry(store_dir, pre_fp, identity) or {}).get(
         "id"
-    ) == BASE_SCENARIO_ID
+    ) == BASELINE_SCENARIO_ID
     assert (store.find_entry(store_dir, post_fp, identity) or {}).get(
         "id"
-    ) == BASE_SCENARIO_ID
+    ) == BASELINE_SCENARIO_ID
     # The canonical fingerprint -- the one a sweep compares -- is the pre-build one.
-    assert store.fingerprints(store_dir, identity) == {BASE_SCENARIO_ID: pre_fp}
+    assert store.fingerprints(store_dir, identity) == {BASELINE_SCENARIO_ID: pre_fp}
 
 
 def test_contributors_write_under_the_entrys_own_artifacts_dir(cfg: Path) -> None:
@@ -251,18 +251,3 @@ def test_a_plain_solve_of_a_scenario_config_writes_BASELINE_not_BASE(
         )
     ]
     assert ids == [BASELINE_SCENARIO_ID], f"plain solve stored the base as {ids}"
-
-
-def test_a_sweep_only_config_keeps_the_plain_base_name(tmp_path: Path) -> None:
-    """A global `sweep:` emits no unmodified-base entry, so the base stays BASE.
-
-    Guards the over-broad version of the rule: treating `sweep:` like
-    `scenarios:` renamed every sweep point's `BASE__<axis>` prefix too.
-    """
-    from boulder.runset import BASE_SCENARIO_ID, base_entry_id
-
-    raw = {
-        **_CONFIG,
-        "sweep": {"T": {"path": "nodes[id=r].properties.T", "values": [1, 2]}},
-    }
-    assert base_entry_id(raw) == BASE_SCENARIO_ID


### PR DESCRIPTION
## Summary
- Scenario pane row now titles on `metadata.scenario_name` (falling back to the id) instead of the raw `scenarios:` key, with `description` as a single-line, non-wrapping subtitle shown before a sweep ever runs (sourced from the live overlay, not the computed store) — hover shows the full description text.
- Removes `metadata.scenario_id` as a user-authorable field: it duplicated the id concept already carried by the `scenarios:` mapping key, and only ever mattered for a plain config with no `scenarios:` block overriding its default `BASE` run id. The internal per-entry id stamp `expand_scenarios` uses for fingerprint bookkeeping is untouched.

## Test plan
- [x] `pytest tests/test_runset.py tests/test_fingerprint_identity.py tests/test_api.py tests/test_worker_persists_to_store.py tests/test_scenario_editing.py` — 105 passed
- [x] `npx vitest run` (frontend) — 256 passed
- [x] `npx tsc --noEmit` (frontend) — clean
- [x] `npm run build` — production build succeeds